### PR TITLE
fix: update codeql for dependabot compat

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,7 +1,7 @@
 name: CodeQL
 
 on:
-  - push
+  - pull_request
 
 jobs:
   codeql:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,10 +1,7 @@
 name: CodeQL
 
 on:
-  pull_request:
-  push:
-  schedule:
-    - cron: 0 0 * * 0
+  - push
 
 jobs:
   codeql:


### PR DESCRIPTION
Error from CodeQL Workflows on Dependabot updates:

>Error: Workflows triggered by Dependabot on the "push" event run with read-only access. Uploading Code Scanning results requires write access. To use Code Scanning with Dependabot, please ensure you are using the "pull_request" event for this workflow and avoid triggering on the "push" event for Dependabot branches. See docs.github.com/en/code-security/secure-coding/configuring-code-scanning#scanning-on-push for more information on how to configure these events.

This change should enable all green checks on Dependabot updates (I wasn't approving the PRs as failures were reported and was waiting for Dependabot to not break PRs)

I removed the scheduled workflow as well for the same reason, though it can also lead GitHub to disable entire workflows after 30 days of no changes to the code being tested.