### PR TITLE
support asdf install in subdirectories

### DIFF
--- a/install/action.yml
+++ b/install/action.yml
@@ -5,6 +5,10 @@ runs:
   using: node12
   main: main.js
 inputs:
+  directory:
+    description:
+      If present, the action will execute from this directory
+    required: false
   tool_versions:
     description:
       If present, this value will be written to the .tool-versions file.

--- a/install/action.yml
+++ b/install/action.yml
@@ -6,15 +6,15 @@ runs:
   main: main.js
 inputs:
   directory:
-    description:
+    description: |-
       If present, the action will execute from this directory
     required: false
   tool_versions:
-    description:
+    description: |-
       If present, this value will be written to the .tool-versions file.
     required: false
   before_install:
-    description:
+    description: |-
       Bash script to run after plugins are installed but before `asdf install`.
       eg, to install npm keyring
     required: false

--- a/install/main.js
+++ b/install/main.js
@@ -1,427 +1,403 @@
 var __create = Object.create;
 var __defProp = Object.defineProperty;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __getOwnPropNames = Object.getOwnPropertyNames;
 var __getProtoOf = Object.getPrototypeOf;
 var __hasOwnProp = Object.prototype.hasOwnProperty;
-var __getOwnPropNames = Object.getOwnPropertyNames;
-var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
-var __markAsModule = (target) => __defProp(target, "__esModule", {value: true});
-var __commonJS = (callback, module2) => () => {
-  if (!module2) {
-    module2 = {exports: {}};
-    callback(module2.exports, module2);
-  }
-  return module2.exports;
+var __markAsModule = (target) => __defProp(target, "__esModule", { value: true });
+var __commonJS = (cb, mod) => function __require() {
+  return mod || (0, cb[Object.keys(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports;
 };
-var __exportStar = (target, module2, desc) => {
-  __markAsModule(target);
+var __reExport = (target, module2, desc) => {
   if (module2 && typeof module2 === "object" || typeof module2 === "function") {
     for (let key of __getOwnPropNames(module2))
       if (!__hasOwnProp.call(target, key) && key !== "default")
-        __defProp(target, key, {get: () => module2[key], enumerable: !(desc = __getOwnPropDesc(module2, key)) || desc.enumerable});
+        __defProp(target, key, { get: () => module2[key], enumerable: !(desc = __getOwnPropDesc(module2, key)) || desc.enumerable });
   }
   return target;
 };
 var __toModule = (module2) => {
-  if (module2 && module2.__esModule)
-    return module2;
-  return __exportStar(__defProp(module2 != null ? __create(__getProtoOf(module2)) : {}, "default", {value: module2, enumerable: true}), module2);
+  return __reExport(__markAsModule(__defProp(module2 != null ? __create(__getProtoOf(module2)) : {}, "default", module2 && module2.__esModule && "default" in module2 ? { get: () => module2.default, enumerable: true } : { value: module2, enumerable: true })), module2);
 };
 
 // node_modules/@actions/core/lib/utils.js
-var require_utils = __commonJS((exports2) => {
-  "use strict";
-  Object.defineProperty(exports2, "__esModule", {value: true});
-  function toCommandValue(input) {
-    if (input === null || input === void 0) {
-      return "";
-    } else if (typeof input === "string" || input instanceof String) {
-      return input;
+var require_utils = __commonJS({
+  "node_modules/@actions/core/lib/utils.js"(exports2) {
+    "use strict";
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    function toCommandValue(input) {
+      if (input === null || input === void 0) {
+        return "";
+      } else if (typeof input === "string" || input instanceof String) {
+        return input;
+      }
+      return JSON.stringify(input);
     }
-    return JSON.stringify(input);
+    exports2.toCommandValue = toCommandValue;
   }
-  exports2.toCommandValue = toCommandValue;
 });
 
 // node_modules/@actions/core/lib/command.js
-var require_command = __commonJS((exports2) => {
-  "use strict";
-  var __importStar = exports2 && exports2.__importStar || function(mod) {
-    if (mod && mod.__esModule)
-      return mod;
-    var result = {};
-    if (mod != null) {
-      for (var k in mod)
-        if (Object.hasOwnProperty.call(mod, k))
-          result[k] = mod[k];
-    }
-    result["default"] = mod;
-    return result;
-  };
-  Object.defineProperty(exports2, "__esModule", {value: true});
-  var os2 = __importStar(require("os"));
-  var utils_1 = require_utils();
-  function issueCommand(command, properties, message) {
-    const cmd = new Command(command, properties, message);
-    process.stdout.write(cmd.toString() + os2.EOL);
-  }
-  exports2.issueCommand = issueCommand;
-  function issue(name, message = "") {
-    issueCommand(name, {}, message);
-  }
-  exports2.issue = issue;
-  var CMD_STRING = "::";
-  var Command = class {
-    constructor(command, properties, message) {
-      if (!command) {
-        command = "missing.command";
+var require_command = __commonJS({
+  "node_modules/@actions/core/lib/command.js"(exports2) {
+    "use strict";
+    var __importStar = exports2 && exports2.__importStar || function(mod) {
+      if (mod && mod.__esModule)
+        return mod;
+      var result = {};
+      if (mod != null) {
+        for (var k in mod)
+          if (Object.hasOwnProperty.call(mod, k))
+            result[k] = mod[k];
       }
-      this.command = command;
-      this.properties = properties;
-      this.message = message;
+      result["default"] = mod;
+      return result;
+    };
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    var os2 = __importStar(require("os"));
+    var utils_1 = require_utils();
+    function issueCommand(command, properties, message) {
+      const cmd = new Command(command, properties, message);
+      process.stdout.write(cmd.toString() + os2.EOL);
     }
-    toString() {
-      let cmdStr = CMD_STRING + this.command;
-      if (this.properties && Object.keys(this.properties).length > 0) {
-        cmdStr += " ";
-        let first = true;
-        for (const key in this.properties) {
-          if (this.properties.hasOwnProperty(key)) {
-            const val = this.properties[key];
-            if (val) {
-              if (first) {
-                first = false;
-              } else {
-                cmdStr += ",";
+    exports2.issueCommand = issueCommand;
+    function issue(name, message = "") {
+      issueCommand(name, {}, message);
+    }
+    exports2.issue = issue;
+    var CMD_STRING = "::";
+    var Command = class {
+      constructor(command, properties, message) {
+        if (!command) {
+          command = "missing.command";
+        }
+        this.command = command;
+        this.properties = properties;
+        this.message = message;
+      }
+      toString() {
+        let cmdStr = CMD_STRING + this.command;
+        if (this.properties && Object.keys(this.properties).length > 0) {
+          cmdStr += " ";
+          let first = true;
+          for (const key in this.properties) {
+            if (this.properties.hasOwnProperty(key)) {
+              const val = this.properties[key];
+              if (val) {
+                if (first) {
+                  first = false;
+                } else {
+                  cmdStr += ",";
+                }
+                cmdStr += `${key}=${escapeProperty(val)}`;
               }
-              cmdStr += `${key}=${escapeProperty(val)}`;
             }
           }
         }
+        cmdStr += `${CMD_STRING}${escapeData(this.message)}`;
+        return cmdStr;
       }
-      cmdStr += `${CMD_STRING}${escapeData(this.message)}`;
-      return cmdStr;
+    };
+    function escapeData(s) {
+      return utils_1.toCommandValue(s).replace(/%/g, "%25").replace(/\r/g, "%0D").replace(/\n/g, "%0A");
     }
-  };
-  function escapeData(s) {
-    return utils_1.toCommandValue(s).replace(/%/g, "%25").replace(/\r/g, "%0D").replace(/\n/g, "%0A");
-  }
-  function escapeProperty(s) {
-    return utils_1.toCommandValue(s).replace(/%/g, "%25").replace(/\r/g, "%0D").replace(/\n/g, "%0A").replace(/:/g, "%3A").replace(/,/g, "%2C");
+    function escapeProperty(s) {
+      return utils_1.toCommandValue(s).replace(/%/g, "%25").replace(/\r/g, "%0D").replace(/\n/g, "%0A").replace(/:/g, "%3A").replace(/,/g, "%2C");
+    }
   }
 });
 
 // node_modules/@actions/core/lib/file-command.js
-var require_file_command = __commonJS((exports2) => {
-  "use strict";
-  var __importStar = exports2 && exports2.__importStar || function(mod) {
-    if (mod && mod.__esModule)
-      return mod;
-    var result = {};
-    if (mod != null) {
-      for (var k in mod)
-        if (Object.hasOwnProperty.call(mod, k))
-          result[k] = mod[k];
+var require_file_command = __commonJS({
+  "node_modules/@actions/core/lib/file-command.js"(exports2) {
+    "use strict";
+    var __importStar = exports2 && exports2.__importStar || function(mod) {
+      if (mod && mod.__esModule)
+        return mod;
+      var result = {};
+      if (mod != null) {
+        for (var k in mod)
+          if (Object.hasOwnProperty.call(mod, k))
+            result[k] = mod[k];
+      }
+      result["default"] = mod;
+      return result;
+    };
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    var fs2 = __importStar(require("fs"));
+    var os2 = __importStar(require("os"));
+    var utils_1 = require_utils();
+    function issueCommand(command, message) {
+      const filePath = process.env[`GITHUB_${command}`];
+      if (!filePath) {
+        throw new Error(`Unable to find environment variable for file command ${command}`);
+      }
+      if (!fs2.existsSync(filePath)) {
+        throw new Error(`Missing file at path: ${filePath}`);
+      }
+      fs2.appendFileSync(filePath, `${utils_1.toCommandValue(message)}${os2.EOL}`, {
+        encoding: "utf8"
+      });
     }
-    result["default"] = mod;
-    return result;
-  };
-  Object.defineProperty(exports2, "__esModule", {value: true});
-  var fs2 = __importStar(require("fs"));
-  var os2 = __importStar(require("os"));
-  var utils_1 = require_utils();
-  function issueCommand(command, message) {
-    const filePath = process.env[`GITHUB_${command}`];
-    if (!filePath) {
-      throw new Error(`Unable to find environment variable for file command ${command}`);
-    }
-    if (!fs2.existsSync(filePath)) {
-      throw new Error(`Missing file at path: ${filePath}`);
-    }
-    fs2.appendFileSync(filePath, `${utils_1.toCommandValue(message)}${os2.EOL}`, {
-      encoding: "utf8"
-    });
+    exports2.issueCommand = issueCommand;
   }
-  exports2.issueCommand = issueCommand;
 });
 
 // node_modules/@actions/core/lib/core.js
-var require_core = __commonJS((exports2) => {
-  "use strict";
-  var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
-    function adopt(value) {
-      return value instanceof P ? value : new P(function(resolve) {
-        resolve(value);
+var require_core = __commonJS({
+  "node_modules/@actions/core/lib/core.js"(exports2) {
+    "use strict";
+    var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve) {
+          resolve(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+      });
+    };
+    var __importStar = exports2 && exports2.__importStar || function(mod) {
+      if (mod && mod.__esModule)
+        return mod;
+      var result = {};
+      if (mod != null) {
+        for (var k in mod)
+          if (Object.hasOwnProperty.call(mod, k))
+            result[k] = mod[k];
+      }
+      result["default"] = mod;
+      return result;
+    };
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    var command_1 = require_command();
+    var file_command_1 = require_file_command();
+    var utils_1 = require_utils();
+    var os2 = __importStar(require("os"));
+    var path2 = __importStar(require("path"));
+    var ExitCode;
+    (function(ExitCode2) {
+      ExitCode2[ExitCode2["Success"] = 0] = "Success";
+      ExitCode2[ExitCode2["Failure"] = 1] = "Failure";
+    })(ExitCode = exports2.ExitCode || (exports2.ExitCode = {}));
+    function exportVariable2(name, val) {
+      const convertedVal = utils_1.toCommandValue(val);
+      process.env[name] = convertedVal;
+      const filePath = process.env["GITHUB_ENV"] || "";
+      if (filePath) {
+        const delimiter = "_GitHubActionsFileCommandDelimeter_";
+        const commandValue = `${name}<<${delimiter}${os2.EOL}${convertedVal}${os2.EOL}${delimiter}`;
+        file_command_1.issueCommand("ENV", commandValue);
+      } else {
+        command_1.issueCommand("set-env", { name }, convertedVal);
+      }
+    }
+    exports2.exportVariable = exportVariable2;
+    function setSecret(secret) {
+      command_1.issueCommand("add-mask", {}, secret);
+    }
+    exports2.setSecret = setSecret;
+    function addPath2(inputPath) {
+      const filePath = process.env["GITHUB_PATH"] || "";
+      if (filePath) {
+        file_command_1.issueCommand("PATH", inputPath);
+      } else {
+        command_1.issueCommand("add-path", {}, inputPath);
+      }
+      process.env["PATH"] = `${inputPath}${path2.delimiter}${process.env["PATH"]}`;
+    }
+    exports2.addPath = addPath2;
+    function getInput4(name, options) {
+      const val = process.env[`INPUT_${name.replace(/ /g, "_").toUpperCase()}`] || "";
+      if (options && options.required && !val) {
+        throw new Error(`Input required and not supplied: ${name}`);
+      }
+      return val.trim();
+    }
+    exports2.getInput = getInput4;
+    function setOutput(name, value) {
+      command_1.issueCommand("set-output", { name }, value);
+    }
+    exports2.setOutput = setOutput;
+    function setCommandEcho(enabled) {
+      command_1.issue("echo", enabled ? "on" : "off");
+    }
+    exports2.setCommandEcho = setCommandEcho;
+    function setFailed2(message) {
+      process.exitCode = ExitCode.Failure;
+      error(message);
+    }
+    exports2.setFailed = setFailed2;
+    function isDebug() {
+      return process.env["RUNNER_DEBUG"] === "1";
+    }
+    exports2.isDebug = isDebug;
+    function debug(message) {
+      command_1.issueCommand("debug", {}, message);
+    }
+    exports2.debug = debug;
+    function error(message) {
+      command_1.issue("error", message instanceof Error ? message.toString() : message);
+    }
+    exports2.error = error;
+    function warning(message) {
+      command_1.issue("warning", message instanceof Error ? message.toString() : message);
+    }
+    exports2.warning = warning;
+    function info3(message) {
+      process.stdout.write(message + os2.EOL);
+    }
+    exports2.info = info3;
+    function startGroup(name) {
+      command_1.issue("group", name);
+    }
+    exports2.startGroup = startGroup;
+    function endGroup() {
+      command_1.issue("endgroup");
+    }
+    exports2.endGroup = endGroup;
+    function group(name, fn) {
+      return __awaiter(this, void 0, void 0, function* () {
+        startGroup(name);
+        let result;
+        try {
+          result = yield fn();
+        } finally {
+          endGroup();
+        }
+        return result;
       });
     }
-    return new (P || (P = Promise))(function(resolve, reject) {
-      function fulfilled(value) {
-        try {
-          step(generator.next(value));
-        } catch (e) {
-          reject(e);
-        }
-      }
-      function rejected(value) {
-        try {
-          step(generator["throw"](value));
-        } catch (e) {
-          reject(e);
-        }
-      }
-      function step(result) {
-        result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
-      }
-      step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-  };
-  var __importStar = exports2 && exports2.__importStar || function(mod) {
-    if (mod && mod.__esModule)
-      return mod;
-    var result = {};
-    if (mod != null) {
-      for (var k in mod)
-        if (Object.hasOwnProperty.call(mod, k))
-          result[k] = mod[k];
+    exports2.group = group;
+    function saveState(name, value) {
+      command_1.issueCommand("save-state", { name }, value);
     }
-    result["default"] = mod;
-    return result;
-  };
-  Object.defineProperty(exports2, "__esModule", {value: true});
-  var command_1 = require_command();
-  var file_command_1 = require_file_command();
-  var utils_1 = require_utils();
-  var os2 = __importStar(require("os"));
-  var path2 = __importStar(require("path"));
-  var ExitCode;
-  (function(ExitCode2) {
-    ExitCode2[ExitCode2["Success"] = 0] = "Success";
-    ExitCode2[ExitCode2["Failure"] = 1] = "Failure";
-  })(ExitCode = exports2.ExitCode || (exports2.ExitCode = {}));
-  function exportVariable2(name, val) {
-    const convertedVal = utils_1.toCommandValue(val);
-    process.env[name] = convertedVal;
-    const filePath = process.env["GITHUB_ENV"] || "";
-    if (filePath) {
-      const delimiter = "_GitHubActionsFileCommandDelimeter_";
-      const commandValue = `${name}<<${delimiter}${os2.EOL}${convertedVal}${os2.EOL}${delimiter}`;
-      file_command_1.issueCommand("ENV", commandValue);
-    } else {
-      command_1.issueCommand("set-env", {name}, convertedVal);
+    exports2.saveState = saveState;
+    function getState(name) {
+      return process.env[`STATE_${name}`] || "";
     }
+    exports2.getState = getState;
   }
-  exports2.exportVariable = exportVariable2;
-  function setSecret(secret) {
-    command_1.issueCommand("add-mask", {}, secret);
-  }
-  exports2.setSecret = setSecret;
-  function addPath2(inputPath) {
-    const filePath = process.env["GITHUB_PATH"] || "";
-    if (filePath) {
-      file_command_1.issueCommand("PATH", inputPath);
-    } else {
-      command_1.issueCommand("add-path", {}, inputPath);
-    }
-    process.env["PATH"] = `${inputPath}${path2.delimiter}${process.env["PATH"]}`;
-  }
-  exports2.addPath = addPath2;
-  function getInput4(name, options) {
-    const val = process.env[`INPUT_${name.replace(/ /g, "_").toUpperCase()}`] || "";
-    if (options && options.required && !val) {
-      throw new Error(`Input required and not supplied: ${name}`);
-    }
-    return val.trim();
-  }
-  exports2.getInput = getInput4;
-  function setOutput(name, value) {
-    command_1.issueCommand("set-output", {name}, value);
-  }
-  exports2.setOutput = setOutput;
-  function setCommandEcho(enabled) {
-    command_1.issue("echo", enabled ? "on" : "off");
-  }
-  exports2.setCommandEcho = setCommandEcho;
-  function setFailed2(message) {
-    process.exitCode = ExitCode.Failure;
-    error(message);
-  }
-  exports2.setFailed = setFailed2;
-  function isDebug() {
-    return process.env["RUNNER_DEBUG"] === "1";
-  }
-  exports2.isDebug = isDebug;
-  function debug(message) {
-    command_1.issueCommand("debug", {}, message);
-  }
-  exports2.debug = debug;
-  function error(message) {
-    command_1.issue("error", message instanceof Error ? message.toString() : message);
-  }
-  exports2.error = error;
-  function warning(message) {
-    command_1.issue("warning", message instanceof Error ? message.toString() : message);
-  }
-  exports2.warning = warning;
-  function info3(message) {
-    process.stdout.write(message + os2.EOL);
-  }
-  exports2.info = info3;
-  function startGroup(name) {
-    command_1.issue("group", name);
-  }
-  exports2.startGroup = startGroup;
-  function endGroup() {
-    command_1.issue("endgroup");
-  }
-  exports2.endGroup = endGroup;
-  function group(name, fn) {
-    return __awaiter(this, void 0, void 0, function* () {
-      startGroup(name);
-      let result;
-      try {
-        result = yield fn();
-      } finally {
-        endGroup();
-      }
-      return result;
-    });
-  }
-  exports2.group = group;
-  function saveState(name, value) {
-    command_1.issueCommand("save-state", {name}, value);
-  }
-  exports2.saveState = saveState;
-  function getState(name) {
-    return process.env[`STATE_${name}`] || "";
-  }
-  exports2.getState = getState;
 });
 
-// node_modules/@actions/io/lib/io-util.js
-var require_io_util = __commonJS((exports2) => {
-  "use strict";
-  var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
-    function adopt(value) {
-      return value instanceof P ? value : new P(function(resolve) {
-        resolve(value);
+// node_modules/@actions/exec/node_modules/@actions/io/lib/io-util.js
+var require_io_util = __commonJS({
+  "node_modules/@actions/exec/node_modules/@actions/io/lib/io-util.js"(exports2) {
+    "use strict";
+    var __createBinding = exports2 && exports2.__createBinding || (Object.create ? function(o, m, k, k2) {
+      if (k2 === void 0)
+        k2 = k;
+      Object.defineProperty(o, k2, { enumerable: true, get: function() {
+        return m[k];
+      } });
+    } : function(o, m, k, k2) {
+      if (k2 === void 0)
+        k2 = k;
+      o[k2] = m[k];
+    });
+    var __setModuleDefault = exports2 && exports2.__setModuleDefault || (Object.create ? function(o, v) {
+      Object.defineProperty(o, "default", { enumerable: true, value: v });
+    } : function(o, v) {
+      o["default"] = v;
+    });
+    var __importStar = exports2 && exports2.__importStar || function(mod) {
+      if (mod && mod.__esModule)
+        return mod;
+      var result = {};
+      if (mod != null) {
+        for (var k in mod)
+          if (k !== "default" && Object.hasOwnProperty.call(mod, k))
+            __createBinding(result, mod, k);
+      }
+      __setModuleDefault(result, mod);
+      return result;
+    };
+    var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve) {
+          resolve(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+      });
+    };
+    var _a;
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    exports2.getCmdPath = exports2.tryGetExecutablePath = exports2.isRooted = exports2.isDirectory = exports2.exists = exports2.IS_WINDOWS = exports2.unlink = exports2.symlink = exports2.stat = exports2.rmdir = exports2.rename = exports2.readlink = exports2.readdir = exports2.mkdir = exports2.lstat = exports2.copyFile = exports2.chmod = void 0;
+    var fs2 = __importStar(require("fs"));
+    var path2 = __importStar(require("path"));
+    _a = fs2.promises, exports2.chmod = _a.chmod, exports2.copyFile = _a.copyFile, exports2.lstat = _a.lstat, exports2.mkdir = _a.mkdir, exports2.readdir = _a.readdir, exports2.readlink = _a.readlink, exports2.rename = _a.rename, exports2.rmdir = _a.rmdir, exports2.stat = _a.stat, exports2.symlink = _a.symlink, exports2.unlink = _a.unlink;
+    exports2.IS_WINDOWS = process.platform === "win32";
+    function exists(fsPath) {
+      return __awaiter(this, void 0, void 0, function* () {
+        try {
+          yield exports2.stat(fsPath);
+        } catch (err) {
+          if (err.code === "ENOENT") {
+            return false;
+          }
+          throw err;
+        }
+        return true;
       });
     }
-    return new (P || (P = Promise))(function(resolve, reject) {
-      function fulfilled(value) {
-        try {
-          step(generator.next(value));
-        } catch (e) {
-          reject(e);
-        }
-      }
-      function rejected(value) {
-        try {
-          step(generator["throw"](value));
-        } catch (e) {
-          reject(e);
-        }
-      }
-      function step(result) {
-        result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
-      }
-      step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-  };
-  var _a;
-  Object.defineProperty(exports2, "__esModule", {value: true});
-  var assert_1 = require("assert");
-  var fs2 = require("fs");
-  var path2 = require("path");
-  _a = fs2.promises, exports2.chmod = _a.chmod, exports2.copyFile = _a.copyFile, exports2.lstat = _a.lstat, exports2.mkdir = _a.mkdir, exports2.readdir = _a.readdir, exports2.readlink = _a.readlink, exports2.rename = _a.rename, exports2.rmdir = _a.rmdir, exports2.stat = _a.stat, exports2.symlink = _a.symlink, exports2.unlink = _a.unlink;
-  exports2.IS_WINDOWS = process.platform === "win32";
-  function exists(fsPath) {
-    return __awaiter(this, void 0, void 0, function* () {
-      try {
-        yield exports2.stat(fsPath);
-      } catch (err) {
-        if (err.code === "ENOENT") {
-          return false;
-        }
-        throw err;
-      }
-      return true;
-    });
-  }
-  exports2.exists = exists;
-  function isDirectory(fsPath, useStat = false) {
-    return __awaiter(this, void 0, void 0, function* () {
-      const stats = useStat ? yield exports2.stat(fsPath) : yield exports2.lstat(fsPath);
-      return stats.isDirectory();
-    });
-  }
-  exports2.isDirectory = isDirectory;
-  function isRooted(p) {
-    p = normalizeSeparators(p);
-    if (!p) {
-      throw new Error('isRooted() parameter "p" cannot be empty');
+    exports2.exists = exists;
+    function isDirectory(fsPath, useStat = false) {
+      return __awaiter(this, void 0, void 0, function* () {
+        const stats = useStat ? yield exports2.stat(fsPath) : yield exports2.lstat(fsPath);
+        return stats.isDirectory();
+      });
     }
-    if (exports2.IS_WINDOWS) {
-      return p.startsWith("\\") || /^[A-Z]:/i.test(p);
+    exports2.isDirectory = isDirectory;
+    function isRooted(p) {
+      p = normalizeSeparators(p);
+      if (!p) {
+        throw new Error('isRooted() parameter "p" cannot be empty');
+      }
+      if (exports2.IS_WINDOWS) {
+        return p.startsWith("\\") || /^[A-Z]:/i.test(p);
+      }
+      return p.startsWith("/");
     }
-    return p.startsWith("/");
-  }
-  exports2.isRooted = isRooted;
-  function mkdirP(fsPath, maxDepth = 1e3, depth = 1) {
-    return __awaiter(this, void 0, void 0, function* () {
-      assert_1.ok(fsPath, "a path argument must be provided");
-      fsPath = path2.resolve(fsPath);
-      if (depth >= maxDepth)
-        return exports2.mkdir(fsPath);
-      try {
-        yield exports2.mkdir(fsPath);
-        return;
-      } catch (err) {
-        switch (err.code) {
-          case "ENOENT": {
-            yield mkdirP(path2.dirname(fsPath), maxDepth, depth + 1);
-            yield exports2.mkdir(fsPath);
-            return;
-          }
-          default: {
-            let stats;
-            try {
-              stats = yield exports2.stat(fsPath);
-            } catch (err2) {
-              throw err;
-            }
-            if (!stats.isDirectory())
-              throw err;
-          }
-        }
-      }
-    });
-  }
-  exports2.mkdirP = mkdirP;
-  function tryGetExecutablePath(filePath, extensions) {
-    return __awaiter(this, void 0, void 0, function* () {
-      let stats = void 0;
-      try {
-        stats = yield exports2.stat(filePath);
-      } catch (err) {
-        if (err.code !== "ENOENT") {
-          console.log(`Unexpected error attempting to determine if executable file exists '${filePath}': ${err}`);
-        }
-      }
-      if (stats && stats.isFile()) {
-        if (exports2.IS_WINDOWS) {
-          const upperExt = path2.extname(filePath).toUpperCase();
-          if (extensions.some((validExt) => validExt.toUpperCase() === upperExt)) {
-            return filePath;
-          }
-        } else {
-          if (isUnixExecutable(stats)) {
-            return filePath;
-          }
-        }
-      }
-      const originalFilePath = filePath;
-      for (const extension of extensions) {
-        filePath = originalFilePath + extension;
-        stats = void 0;
+    exports2.isRooted = isRooted;
+    function tryGetExecutablePath(filePath, extensions) {
+      return __awaiter(this, void 0, void 0, function* () {
+        let stats = void 0;
         try {
           stats = yield exports2.stat(filePath);
         } catch (err) {
@@ -431,189 +407,272 @@ var require_io_util = __commonJS((exports2) => {
         }
         if (stats && stats.isFile()) {
           if (exports2.IS_WINDOWS) {
-            try {
-              const directory = path2.dirname(filePath);
-              const upperName = path2.basename(filePath).toUpperCase();
-              for (const actualName of yield exports2.readdir(directory)) {
-                if (upperName === actualName.toUpperCase()) {
-                  filePath = path2.join(directory, actualName);
-                  break;
-                }
-              }
-            } catch (err) {
-              console.log(`Unexpected error attempting to determine the actual case of the file '${filePath}': ${err}`);
+            const upperExt = path2.extname(filePath).toUpperCase();
+            if (extensions.some((validExt) => validExt.toUpperCase() === upperExt)) {
+              return filePath;
             }
-            return filePath;
           } else {
             if (isUnixExecutable(stats)) {
               return filePath;
             }
           }
         }
-      }
-      return "";
-    });
-  }
-  exports2.tryGetExecutablePath = tryGetExecutablePath;
-  function normalizeSeparators(p) {
-    p = p || "";
-    if (exports2.IS_WINDOWS) {
-      p = p.replace(/\//g, "\\");
-      return p.replace(/\\\\+/g, "\\");
+        const originalFilePath = filePath;
+        for (const extension of extensions) {
+          filePath = originalFilePath + extension;
+          stats = void 0;
+          try {
+            stats = yield exports2.stat(filePath);
+          } catch (err) {
+            if (err.code !== "ENOENT") {
+              console.log(`Unexpected error attempting to determine if executable file exists '${filePath}': ${err}`);
+            }
+          }
+          if (stats && stats.isFile()) {
+            if (exports2.IS_WINDOWS) {
+              try {
+                const directory = path2.dirname(filePath);
+                const upperName = path2.basename(filePath).toUpperCase();
+                for (const actualName of yield exports2.readdir(directory)) {
+                  if (upperName === actualName.toUpperCase()) {
+                    filePath = path2.join(directory, actualName);
+                    break;
+                  }
+                }
+              } catch (err) {
+                console.log(`Unexpected error attempting to determine the actual case of the file '${filePath}': ${err}`);
+              }
+              return filePath;
+            } else {
+              if (isUnixExecutable(stats)) {
+                return filePath;
+              }
+            }
+          }
+        }
+        return "";
+      });
     }
-    return p.replace(/\/\/+/g, "/");
-  }
-  function isUnixExecutable(stats) {
-    return (stats.mode & 1) > 0 || (stats.mode & 8) > 0 && stats.gid === process.getgid() || (stats.mode & 64) > 0 && stats.uid === process.getuid();
+    exports2.tryGetExecutablePath = tryGetExecutablePath;
+    function normalizeSeparators(p) {
+      p = p || "";
+      if (exports2.IS_WINDOWS) {
+        p = p.replace(/\//g, "\\");
+        return p.replace(/\\\\+/g, "\\");
+      }
+      return p.replace(/\/\/+/g, "/");
+    }
+    function isUnixExecutable(stats) {
+      return (stats.mode & 1) > 0 || (stats.mode & 8) > 0 && stats.gid === process.getgid() || (stats.mode & 64) > 0 && stats.uid === process.getuid();
+    }
+    function getCmdPath() {
+      var _a2;
+      return (_a2 = process.env["COMSPEC"]) !== null && _a2 !== void 0 ? _a2 : `cmd.exe`;
+    }
+    exports2.getCmdPath = getCmdPath;
   }
 });
 
-// node_modules/@actions/io/lib/io.js
-var require_io = __commonJS((exports2) => {
-  "use strict";
-  var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
-    function adopt(value) {
-      return value instanceof P ? value : new P(function(resolve) {
-        resolve(value);
+// node_modules/@actions/exec/node_modules/@actions/io/lib/io.js
+var require_io = __commonJS({
+  "node_modules/@actions/exec/node_modules/@actions/io/lib/io.js"(exports2) {
+    "use strict";
+    var __createBinding = exports2 && exports2.__createBinding || (Object.create ? function(o, m, k, k2) {
+      if (k2 === void 0)
+        k2 = k;
+      Object.defineProperty(o, k2, { enumerable: true, get: function() {
+        return m[k];
+      } });
+    } : function(o, m, k, k2) {
+      if (k2 === void 0)
+        k2 = k;
+      o[k2] = m[k];
+    });
+    var __setModuleDefault = exports2 && exports2.__setModuleDefault || (Object.create ? function(o, v) {
+      Object.defineProperty(o, "default", { enumerable: true, value: v });
+    } : function(o, v) {
+      o["default"] = v;
+    });
+    var __importStar = exports2 && exports2.__importStar || function(mod) {
+      if (mod && mod.__esModule)
+        return mod;
+      var result = {};
+      if (mod != null) {
+        for (var k in mod)
+          if (k !== "default" && Object.hasOwnProperty.call(mod, k))
+            __createBinding(result, mod, k);
+      }
+      __setModuleDefault(result, mod);
+      return result;
+    };
+    var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve) {
+          resolve(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
-    }
-    return new (P || (P = Promise))(function(resolve, reject) {
-      function fulfilled(value) {
-        try {
-          step(generator.next(value));
-        } catch (e) {
-          reject(e);
-        }
-      }
-      function rejected(value) {
-        try {
-          step(generator["throw"](value));
-        } catch (e) {
-          reject(e);
-        }
-      }
-      function step(result) {
-        result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
-      }
-      step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-  };
-  Object.defineProperty(exports2, "__esModule", {value: true});
-  var childProcess = require("child_process");
-  var path2 = require("path");
-  var util_1 = require("util");
-  var ioUtil = require_io_util();
-  var exec7 = util_1.promisify(childProcess.exec);
-  function cp(source, dest, options = {}) {
-    return __awaiter(this, void 0, void 0, function* () {
-      const {force, recursive} = readCopyOptions(options);
-      const destStat = (yield ioUtil.exists(dest)) ? yield ioUtil.stat(dest) : null;
-      if (destStat && destStat.isFile() && !force) {
-        return;
-      }
-      const newDest = destStat && destStat.isDirectory() ? path2.join(dest, path2.basename(source)) : dest;
-      if (!(yield ioUtil.exists(source))) {
-        throw new Error(`no such file or directory: ${source}`);
-      }
-      const sourceStat = yield ioUtil.stat(source);
-      if (sourceStat.isDirectory()) {
-        if (!recursive) {
-          throw new Error(`Failed to copy. ${source} is a directory, but tried to copy without recursive flag.`);
-        } else {
-          yield cpDirRecursive(source, newDest, 0, force);
-        }
-      } else {
-        if (path2.relative(source, newDest) === "") {
-          throw new Error(`'${newDest}' and '${source}' are the same file`);
-        }
-        yield copyFile(source, newDest, force);
-      }
-    });
-  }
-  exports2.cp = cp;
-  function mv(source, dest, options = {}) {
-    return __awaiter(this, void 0, void 0, function* () {
-      if (yield ioUtil.exists(dest)) {
-        let destExists = true;
-        if (yield ioUtil.isDirectory(dest)) {
-          dest = path2.join(dest, path2.basename(source));
-          destExists = yield ioUtil.exists(dest);
-        }
-        if (destExists) {
-          if (options.force == null || options.force) {
-            yield rmRF(dest);
-          } else {
-            throw new Error("Destination already exists");
-          }
-        }
-      }
-      yield mkdirP(path2.dirname(dest));
-      yield ioUtil.rename(source, dest);
-    });
-  }
-  exports2.mv = mv;
-  function rmRF(inputPath) {
-    return __awaiter(this, void 0, void 0, function* () {
-      if (ioUtil.IS_WINDOWS) {
-        try {
-          if (yield ioUtil.isDirectory(inputPath, true)) {
-            yield exec7(`rd /s /q "${inputPath}"`);
-          } else {
-            yield exec7(`del /f /a "${inputPath}"`);
-          }
-        } catch (err) {
-          if (err.code !== "ENOENT")
-            throw err;
-        }
-        try {
-          yield ioUtil.unlink(inputPath);
-        } catch (err) {
-          if (err.code !== "ENOENT")
-            throw err;
-        }
-      } else {
-        let isDir = false;
-        try {
-          isDir = yield ioUtil.isDirectory(inputPath);
-        } catch (err) {
-          if (err.code !== "ENOENT")
-            throw err;
+    };
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    exports2.findInPath = exports2.which = exports2.mkdirP = exports2.rmRF = exports2.mv = exports2.cp = void 0;
+    var assert_1 = require("assert");
+    var childProcess = __importStar(require("child_process"));
+    var path2 = __importStar(require("path"));
+    var util_1 = require("util");
+    var ioUtil = __importStar(require_io_util());
+    var exec7 = util_1.promisify(childProcess.exec);
+    var execFile = util_1.promisify(childProcess.execFile);
+    function cp(source, dest, options = {}) {
+      return __awaiter(this, void 0, void 0, function* () {
+        const { force, recursive, copySourceDirectory } = readCopyOptions(options);
+        const destStat = (yield ioUtil.exists(dest)) ? yield ioUtil.stat(dest) : null;
+        if (destStat && destStat.isFile() && !force) {
           return;
         }
-        if (isDir) {
-          yield exec7(`rm -rf "${inputPath}"`);
-        } else {
-          yield ioUtil.unlink(inputPath);
+        const newDest = destStat && destStat.isDirectory() && copySourceDirectory ? path2.join(dest, path2.basename(source)) : dest;
+        if (!(yield ioUtil.exists(source))) {
+          throw new Error(`no such file or directory: ${source}`);
         }
-      }
-    });
-  }
-  exports2.rmRF = rmRF;
-  function mkdirP(fsPath) {
-    return __awaiter(this, void 0, void 0, function* () {
-      yield ioUtil.mkdirP(fsPath);
-    });
-  }
-  exports2.mkdirP = mkdirP;
-  function which2(tool, check) {
-    return __awaiter(this, void 0, void 0, function* () {
-      if (!tool) {
-        throw new Error("parameter 'tool' is required");
-      }
-      if (check) {
-        const result = yield which2(tool, false);
-        if (!result) {
-          if (ioUtil.IS_WINDOWS) {
-            throw new Error(`Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also verify the file has a valid extension for an executable file.`);
+        const sourceStat = yield ioUtil.stat(source);
+        if (sourceStat.isDirectory()) {
+          if (!recursive) {
+            throw new Error(`Failed to copy. ${source} is a directory, but tried to copy without recursive flag.`);
           } else {
-            throw new Error(`Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also check the file mode to verify the file is executable.`);
+            yield cpDirRecursive(source, newDest, 0, force);
+          }
+        } else {
+          if (path2.relative(source, newDest) === "") {
+            throw new Error(`'${newDest}' and '${source}' are the same file`);
+          }
+          yield copyFile(source, newDest, force);
+        }
+      });
+    }
+    exports2.cp = cp;
+    function mv(source, dest, options = {}) {
+      return __awaiter(this, void 0, void 0, function* () {
+        if (yield ioUtil.exists(dest)) {
+          let destExists = true;
+          if (yield ioUtil.isDirectory(dest)) {
+            dest = path2.join(dest, path2.basename(source));
+            destExists = yield ioUtil.exists(dest);
+          }
+          if (destExists) {
+            if (options.force == null || options.force) {
+              yield rmRF(dest);
+            } else {
+              throw new Error("Destination already exists");
+            }
           }
         }
-      }
-      try {
+        yield mkdirP(path2.dirname(dest));
+        yield ioUtil.rename(source, dest);
+      });
+    }
+    exports2.mv = mv;
+    function rmRF(inputPath) {
+      return __awaiter(this, void 0, void 0, function* () {
+        if (ioUtil.IS_WINDOWS) {
+          if (/[*"<>|]/.test(inputPath)) {
+            throw new Error('File path must not contain `*`, `"`, `<`, `>` or `|` on Windows');
+          }
+          try {
+            const cmdPath = ioUtil.getCmdPath();
+            if (yield ioUtil.isDirectory(inputPath, true)) {
+              yield exec7(`${cmdPath} /s /c "rd /s /q "%inputPath%""`, {
+                env: { inputPath }
+              });
+            } else {
+              yield exec7(`${cmdPath} /s /c "del /f /a "%inputPath%""`, {
+                env: { inputPath }
+              });
+            }
+          } catch (err) {
+            if (err.code !== "ENOENT")
+              throw err;
+          }
+          try {
+            yield ioUtil.unlink(inputPath);
+          } catch (err) {
+            if (err.code !== "ENOENT")
+              throw err;
+          }
+        } else {
+          let isDir = false;
+          try {
+            isDir = yield ioUtil.isDirectory(inputPath);
+          } catch (err) {
+            if (err.code !== "ENOENT")
+              throw err;
+            return;
+          }
+          if (isDir) {
+            yield execFile(`rm`, [`-rf`, `${inputPath}`]);
+          } else {
+            yield ioUtil.unlink(inputPath);
+          }
+        }
+      });
+    }
+    exports2.rmRF = rmRF;
+    function mkdirP(fsPath) {
+      return __awaiter(this, void 0, void 0, function* () {
+        assert_1.ok(fsPath, "a path argument must be provided");
+        yield ioUtil.mkdir(fsPath, { recursive: true });
+      });
+    }
+    exports2.mkdirP = mkdirP;
+    function which2(tool, check) {
+      return __awaiter(this, void 0, void 0, function* () {
+        if (!tool) {
+          throw new Error("parameter 'tool' is required");
+        }
+        if (check) {
+          const result = yield which2(tool, false);
+          if (!result) {
+            if (ioUtil.IS_WINDOWS) {
+              throw new Error(`Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also verify the file has a valid extension for an executable file.`);
+            } else {
+              throw new Error(`Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also check the file mode to verify the file is executable.`);
+            }
+          }
+          return result;
+        }
+        const matches = yield findInPath(tool);
+        if (matches && matches.length > 0) {
+          return matches[0];
+        }
+        return "";
+      });
+    }
+    exports2.which = which2;
+    function findInPath(tool) {
+      return __awaiter(this, void 0, void 0, function* () {
+        if (!tool) {
+          throw new Error("parameter 'tool' is required");
+        }
         const extensions = [];
-        if (ioUtil.IS_WINDOWS && process.env.PATHEXT) {
-          for (const extension of process.env.PATHEXT.split(path2.delimiter)) {
+        if (ioUtil.IS_WINDOWS && process.env["PATHEXT"]) {
+          for (const extension of process.env["PATHEXT"].split(path2.delimiter)) {
             if (extension) {
               extensions.push(extension);
             }
@@ -622,12 +681,12 @@ var require_io = __commonJS((exports2) => {
         if (ioUtil.isRooted(tool)) {
           const filePath = yield ioUtil.tryGetExecutablePath(tool, extensions);
           if (filePath) {
-            return filePath;
+            return [filePath];
           }
-          return "";
+          return [];
         }
-        if (tool.includes("/") || ioUtil.IS_WINDOWS && tool.includes("\\")) {
-          return "";
+        if (tool.includes(path2.sep)) {
+          return [];
         }
         const directories = [];
         if (process.env.PATH) {
@@ -637,578 +696,986 @@ var require_io = __commonJS((exports2) => {
             }
           }
         }
+        const matches = [];
         for (const directory of directories) {
-          const filePath = yield ioUtil.tryGetExecutablePath(directory + path2.sep + tool, extensions);
+          const filePath = yield ioUtil.tryGetExecutablePath(path2.join(directory, tool), extensions);
           if (filePath) {
-            return filePath;
+            matches.push(filePath);
           }
         }
-        return "";
-      } catch (err) {
-        throw new Error(`which failed with message ${err.message}`);
-      }
-    });
-  }
-  exports2.which = which2;
-  function readCopyOptions(options) {
-    const force = options.force == null ? true : options.force;
-    const recursive = Boolean(options.recursive);
-    return {force, recursive};
-  }
-  function cpDirRecursive(sourceDir, destDir, currentDepth, force) {
-    return __awaiter(this, void 0, void 0, function* () {
-      if (currentDepth >= 255)
-        return;
-      currentDepth++;
-      yield mkdirP(destDir);
-      const files = yield ioUtil.readdir(sourceDir);
-      for (const fileName of files) {
-        const srcFile = `${sourceDir}/${fileName}`;
-        const destFile = `${destDir}/${fileName}`;
-        const srcFileStat = yield ioUtil.lstat(srcFile);
-        if (srcFileStat.isDirectory()) {
-          yield cpDirRecursive(srcFile, destFile, currentDepth, force);
-        } else {
-          yield copyFile(srcFile, destFile, force);
+        return matches;
+      });
+    }
+    exports2.findInPath = findInPath;
+    function readCopyOptions(options) {
+      const force = options.force == null ? true : options.force;
+      const recursive = Boolean(options.recursive);
+      const copySourceDirectory = options.copySourceDirectory == null ? true : Boolean(options.copySourceDirectory);
+      return { force, recursive, copySourceDirectory };
+    }
+    function cpDirRecursive(sourceDir, destDir, currentDepth, force) {
+      return __awaiter(this, void 0, void 0, function* () {
+        if (currentDepth >= 255)
+          return;
+        currentDepth++;
+        yield mkdirP(destDir);
+        const files = yield ioUtil.readdir(sourceDir);
+        for (const fileName of files) {
+          const srcFile = `${sourceDir}/${fileName}`;
+          const destFile = `${destDir}/${fileName}`;
+          const srcFileStat = yield ioUtil.lstat(srcFile);
+          if (srcFileStat.isDirectory()) {
+            yield cpDirRecursive(srcFile, destFile, currentDepth, force);
+          } else {
+            yield copyFile(srcFile, destFile, force);
+          }
         }
-      }
-      yield ioUtil.chmod(destDir, (yield ioUtil.stat(sourceDir)).mode);
-    });
-  }
-  function copyFile(srcFile, destFile, force) {
-    return __awaiter(this, void 0, void 0, function* () {
-      if ((yield ioUtil.lstat(srcFile)).isSymbolicLink()) {
-        try {
-          yield ioUtil.lstat(destFile);
-          yield ioUtil.unlink(destFile);
-        } catch (e) {
-          if (e.code === "EPERM") {
-            yield ioUtil.chmod(destFile, "0666");
+        yield ioUtil.chmod(destDir, (yield ioUtil.stat(sourceDir)).mode);
+      });
+    }
+    function copyFile(srcFile, destFile, force) {
+      return __awaiter(this, void 0, void 0, function* () {
+        if ((yield ioUtil.lstat(srcFile)).isSymbolicLink()) {
+          try {
+            yield ioUtil.lstat(destFile);
             yield ioUtil.unlink(destFile);
+          } catch (e) {
+            if (e.code === "EPERM") {
+              yield ioUtil.chmod(destFile, "0666");
+              yield ioUtil.unlink(destFile);
+            }
           }
+          const symlinkFull = yield ioUtil.readlink(srcFile);
+          yield ioUtil.symlink(symlinkFull, destFile, ioUtil.IS_WINDOWS ? "junction" : null);
+        } else if (!(yield ioUtil.exists(destFile)) || force) {
+          yield ioUtil.copyFile(srcFile, destFile);
         }
-        const symlinkFull = yield ioUtil.readlink(srcFile);
-        yield ioUtil.symlink(symlinkFull, destFile, ioUtil.IS_WINDOWS ? "junction" : null);
-      } else if (!(yield ioUtil.exists(destFile)) || force) {
-        yield ioUtil.copyFile(srcFile, destFile);
-      }
-    });
+      });
+    }
   }
 });
 
 // node_modules/@actions/exec/lib/toolrunner.js
-var require_toolrunner = __commonJS((exports2) => {
-  "use strict";
-  var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
-    function adopt(value) {
-      return value instanceof P ? value : new P(function(resolve) {
-        resolve(value);
+var require_toolrunner = __commonJS({
+  "node_modules/@actions/exec/lib/toolrunner.js"(exports2) {
+    "use strict";
+    var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve) {
+          resolve(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
-    }
-    return new (P || (P = Promise))(function(resolve, reject) {
-      function fulfilled(value) {
-        try {
-          step(generator.next(value));
-        } catch (e) {
-          reject(e);
+    };
+    var __importStar = exports2 && exports2.__importStar || function(mod) {
+      if (mod && mod.__esModule)
+        return mod;
+      var result = {};
+      if (mod != null) {
+        for (var k in mod)
+          if (Object.hasOwnProperty.call(mod, k))
+            result[k] = mod[k];
+      }
+      result["default"] = mod;
+      return result;
+    };
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    var os2 = __importStar(require("os"));
+    var events = __importStar(require("events"));
+    var child = __importStar(require("child_process"));
+    var path2 = __importStar(require("path"));
+    var io2 = __importStar(require_io());
+    var ioUtil = __importStar(require_io_util());
+    var IS_WINDOWS = process.platform === "win32";
+    var ToolRunner = class extends events.EventEmitter {
+      constructor(toolPath, args, options) {
+        super();
+        if (!toolPath) {
+          throw new Error("Parameter 'toolPath' cannot be null or empty.");
+        }
+        this.toolPath = toolPath;
+        this.args = args || [];
+        this.options = options || {};
+      }
+      _debug(message) {
+        if (this.options.listeners && this.options.listeners.debug) {
+          this.options.listeners.debug(message);
         }
       }
-      function rejected(value) {
-        try {
-          step(generator["throw"](value));
-        } catch (e) {
-          reject(e);
-        }
-      }
-      function step(result) {
-        result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
-      }
-      step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-  };
-  var __importStar = exports2 && exports2.__importStar || function(mod) {
-    if (mod && mod.__esModule)
-      return mod;
-    var result = {};
-    if (mod != null) {
-      for (var k in mod)
-        if (Object.hasOwnProperty.call(mod, k))
-          result[k] = mod[k];
-    }
-    result["default"] = mod;
-    return result;
-  };
-  Object.defineProperty(exports2, "__esModule", {value: true});
-  var os2 = __importStar(require("os"));
-  var events = __importStar(require("events"));
-  var child = __importStar(require("child_process"));
-  var path2 = __importStar(require("path"));
-  var io2 = __importStar(require_io());
-  var ioUtil = __importStar(require_io_util());
-  var IS_WINDOWS = process.platform === "win32";
-  var ToolRunner = class extends events.EventEmitter {
-    constructor(toolPath, args, options) {
-      super();
-      if (!toolPath) {
-        throw new Error("Parameter 'toolPath' cannot be null or empty.");
-      }
-      this.toolPath = toolPath;
-      this.args = args || [];
-      this.options = options || {};
-    }
-    _debug(message) {
-      if (this.options.listeners && this.options.listeners.debug) {
-        this.options.listeners.debug(message);
-      }
-    }
-    _getCommandString(options, noPrefix) {
-      const toolPath = this._getSpawnFileName();
-      const args = this._getSpawnArgs(options);
-      let cmd = noPrefix ? "" : "[command]";
-      if (IS_WINDOWS) {
-        if (this._isCmdFile()) {
+      _getCommandString(options, noPrefix) {
+        const toolPath = this._getSpawnFileName();
+        const args = this._getSpawnArgs(options);
+        let cmd = noPrefix ? "" : "[command]";
+        if (IS_WINDOWS) {
+          if (this._isCmdFile()) {
+            cmd += toolPath;
+            for (const a of args) {
+              cmd += ` ${a}`;
+            }
+          } else if (options.windowsVerbatimArguments) {
+            cmd += `"${toolPath}"`;
+            for (const a of args) {
+              cmd += ` ${a}`;
+            }
+          } else {
+            cmd += this._windowsQuoteCmdArg(toolPath);
+            for (const a of args) {
+              cmd += ` ${this._windowsQuoteCmdArg(a)}`;
+            }
+          }
+        } else {
           cmd += toolPath;
           for (const a of args) {
             cmd += ` ${a}`;
           }
-        } else if (options.windowsVerbatimArguments) {
-          cmd += `"${toolPath}"`;
-          for (const a of args) {
-            cmd += ` ${a}`;
+        }
+        return cmd;
+      }
+      _processLineBuffer(data, strBuffer, onLine) {
+        try {
+          let s = strBuffer + data.toString();
+          let n = s.indexOf(os2.EOL);
+          while (n > -1) {
+            const line = s.substring(0, n);
+            onLine(line);
+            s = s.substring(n + os2.EOL.length);
+            n = s.indexOf(os2.EOL);
           }
-        } else {
-          cmd += this._windowsQuoteCmdArg(toolPath);
-          for (const a of args) {
-            cmd += ` ${this._windowsQuoteCmdArg(a)}`;
+          strBuffer = s;
+        } catch (err) {
+          this._debug(`error processing line. Failed with error ${err}`);
+        }
+      }
+      _getSpawnFileName() {
+        if (IS_WINDOWS) {
+          if (this._isCmdFile()) {
+            return process.env["COMSPEC"] || "cmd.exe";
           }
         }
-      } else {
-        cmd += toolPath;
-        for (const a of args) {
-          cmd += ` ${a}`;
-        }
+        return this.toolPath;
       }
-      return cmd;
-    }
-    _processLineBuffer(data, strBuffer, onLine) {
-      try {
-        let s = strBuffer + data.toString();
-        let n = s.indexOf(os2.EOL);
-        while (n > -1) {
-          const line = s.substring(0, n);
-          onLine(line);
-          s = s.substring(n + os2.EOL.length);
-          n = s.indexOf(os2.EOL);
-        }
-        strBuffer = s;
-      } catch (err) {
-        this._debug(`error processing line. Failed with error ${err}`);
-      }
-    }
-    _getSpawnFileName() {
-      if (IS_WINDOWS) {
-        if (this._isCmdFile()) {
-          return process.env["COMSPEC"] || "cmd.exe";
-        }
-      }
-      return this.toolPath;
-    }
-    _getSpawnArgs(options) {
-      if (IS_WINDOWS) {
-        if (this._isCmdFile()) {
-          let argline = `/D /S /C "${this._windowsQuoteCmdArg(this.toolPath)}`;
-          for (const a of this.args) {
-            argline += " ";
-            argline += options.windowsVerbatimArguments ? a : this._windowsQuoteCmdArg(a);
+      _getSpawnArgs(options) {
+        if (IS_WINDOWS) {
+          if (this._isCmdFile()) {
+            let argline = `/D /S /C "${this._windowsQuoteCmdArg(this.toolPath)}`;
+            for (const a of this.args) {
+              argline += " ";
+              argline += options.windowsVerbatimArguments ? a : this._windowsQuoteCmdArg(a);
+            }
+            argline += '"';
+            return [argline];
           }
-          argline += '"';
-          return [argline];
         }
+        return this.args;
       }
-      return this.args;
-    }
-    _endsWith(str, end) {
-      return str.endsWith(end);
-    }
-    _isCmdFile() {
-      const upperToolPath = this.toolPath.toUpperCase();
-      return this._endsWith(upperToolPath, ".CMD") || this._endsWith(upperToolPath, ".BAT");
-    }
-    _windowsQuoteCmdArg(arg) {
-      if (!this._isCmdFile()) {
-        return this._uvQuoteCmdArg(arg);
+      _endsWith(str, end) {
+        return str.endsWith(end);
       }
-      if (!arg) {
-        return '""';
+      _isCmdFile() {
+        const upperToolPath = this.toolPath.toUpperCase();
+        return this._endsWith(upperToolPath, ".CMD") || this._endsWith(upperToolPath, ".BAT");
       }
-      const cmdSpecialChars = [
-        " ",
-        "	",
-        "&",
-        "(",
-        ")",
-        "[",
-        "]",
-        "{",
-        "}",
-        "^",
-        "=",
-        ";",
-        "!",
-        "'",
-        "+",
-        ",",
-        "`",
-        "~",
-        "|",
-        "<",
-        ">",
-        '"'
-      ];
-      let needsQuotes = false;
-      for (const char of arg) {
-        if (cmdSpecialChars.some((x) => x === char)) {
-          needsQuotes = true;
-          break;
+      _windowsQuoteCmdArg(arg) {
+        if (!this._isCmdFile()) {
+          return this._uvQuoteCmdArg(arg);
         }
-      }
-      if (!needsQuotes) {
-        return arg;
-      }
-      let reverse = '"';
-      let quoteHit = true;
-      for (let i = arg.length; i > 0; i--) {
-        reverse += arg[i - 1];
-        if (quoteHit && arg[i - 1] === "\\") {
-          reverse += "\\";
-        } else if (arg[i - 1] === '"') {
-          quoteHit = true;
-          reverse += '"';
-        } else {
-          quoteHit = false;
+        if (!arg) {
+          return '""';
         }
-      }
-      reverse += '"';
-      return reverse.split("").reverse().join("");
-    }
-    _uvQuoteCmdArg(arg) {
-      if (!arg) {
-        return '""';
-      }
-      if (!arg.includes(" ") && !arg.includes("	") && !arg.includes('"')) {
-        return arg;
-      }
-      if (!arg.includes('"') && !arg.includes("\\")) {
-        return `"${arg}"`;
-      }
-      let reverse = '"';
-      let quoteHit = true;
-      for (let i = arg.length; i > 0; i--) {
-        reverse += arg[i - 1];
-        if (quoteHit && arg[i - 1] === "\\") {
-          reverse += "\\";
-        } else if (arg[i - 1] === '"') {
-          quoteHit = true;
-          reverse += "\\";
-        } else {
-          quoteHit = false;
-        }
-      }
-      reverse += '"';
-      return reverse.split("").reverse().join("");
-    }
-    _cloneExecOptions(options) {
-      options = options || {};
-      const result = {
-        cwd: options.cwd || process.cwd(),
-        env: options.env || process.env,
-        silent: options.silent || false,
-        windowsVerbatimArguments: options.windowsVerbatimArguments || false,
-        failOnStdErr: options.failOnStdErr || false,
-        ignoreReturnCode: options.ignoreReturnCode || false,
-        delay: options.delay || 1e4
-      };
-      result.outStream = options.outStream || process.stdout;
-      result.errStream = options.errStream || process.stderr;
-      return result;
-    }
-    _getSpawnOptions(options, toolPath) {
-      options = options || {};
-      const result = {};
-      result.cwd = options.cwd;
-      result.env = options.env;
-      result["windowsVerbatimArguments"] = options.windowsVerbatimArguments || this._isCmdFile();
-      if (options.windowsVerbatimArguments) {
-        result.argv0 = `"${toolPath}"`;
-      }
-      return result;
-    }
-    exec() {
-      return __awaiter(this, void 0, void 0, function* () {
-        if (!ioUtil.isRooted(this.toolPath) && (this.toolPath.includes("/") || IS_WINDOWS && this.toolPath.includes("\\"))) {
-          this.toolPath = path2.resolve(process.cwd(), this.options.cwd || process.cwd(), this.toolPath);
-        }
-        this.toolPath = yield io2.which(this.toolPath, true);
-        return new Promise((resolve, reject) => {
-          this._debug(`exec tool: ${this.toolPath}`);
-          this._debug("arguments:");
-          for (const arg of this.args) {
-            this._debug(`   ${arg}`);
+        const cmdSpecialChars = [
+          " ",
+          "	",
+          "&",
+          "(",
+          ")",
+          "[",
+          "]",
+          "{",
+          "}",
+          "^",
+          "=",
+          ";",
+          "!",
+          "'",
+          "+",
+          ",",
+          "`",
+          "~",
+          "|",
+          "<",
+          ">",
+          '"'
+        ];
+        let needsQuotes = false;
+        for (const char of arg) {
+          if (cmdSpecialChars.some((x) => x === char)) {
+            needsQuotes = true;
+            break;
           }
-          const optionsNonNull = this._cloneExecOptions(this.options);
-          if (!optionsNonNull.silent && optionsNonNull.outStream) {
-            optionsNonNull.outStream.write(this._getCommandString(optionsNonNull) + os2.EOL);
+        }
+        if (!needsQuotes) {
+          return arg;
+        }
+        let reverse = '"';
+        let quoteHit = true;
+        for (let i = arg.length; i > 0; i--) {
+          reverse += arg[i - 1];
+          if (quoteHit && arg[i - 1] === "\\") {
+            reverse += "\\";
+          } else if (arg[i - 1] === '"') {
+            quoteHit = true;
+            reverse += '"';
+          } else {
+            quoteHit = false;
           }
-          const state = new ExecState(optionsNonNull, this.toolPath);
-          state.on("debug", (message) => {
-            this._debug(message);
-          });
-          const fileName = this._getSpawnFileName();
-          const cp = child.spawn(fileName, this._getSpawnArgs(optionsNonNull), this._getSpawnOptions(this.options, fileName));
-          const stdbuffer = "";
-          if (cp.stdout) {
-            cp.stdout.on("data", (data) => {
-              if (this.options.listeners && this.options.listeners.stdout) {
-                this.options.listeners.stdout(data);
-              }
-              if (!optionsNonNull.silent && optionsNonNull.outStream) {
-                optionsNonNull.outStream.write(data);
-              }
-              this._processLineBuffer(data, stdbuffer, (line) => {
-                if (this.options.listeners && this.options.listeners.stdline) {
-                  this.options.listeners.stdline(line);
-                }
-              });
+        }
+        reverse += '"';
+        return reverse.split("").reverse().join("");
+      }
+      _uvQuoteCmdArg(arg) {
+        if (!arg) {
+          return '""';
+        }
+        if (!arg.includes(" ") && !arg.includes("	") && !arg.includes('"')) {
+          return arg;
+        }
+        if (!arg.includes('"') && !arg.includes("\\")) {
+          return `"${arg}"`;
+        }
+        let reverse = '"';
+        let quoteHit = true;
+        for (let i = arg.length; i > 0; i--) {
+          reverse += arg[i - 1];
+          if (quoteHit && arg[i - 1] === "\\") {
+            reverse += "\\";
+          } else if (arg[i - 1] === '"') {
+            quoteHit = true;
+            reverse += "\\";
+          } else {
+            quoteHit = false;
+          }
+        }
+        reverse += '"';
+        return reverse.split("").reverse().join("");
+      }
+      _cloneExecOptions(options) {
+        options = options || {};
+        const result = {
+          cwd: options.cwd || process.cwd(),
+          env: options.env || process.env,
+          silent: options.silent || false,
+          windowsVerbatimArguments: options.windowsVerbatimArguments || false,
+          failOnStdErr: options.failOnStdErr || false,
+          ignoreReturnCode: options.ignoreReturnCode || false,
+          delay: options.delay || 1e4
+        };
+        result.outStream = options.outStream || process.stdout;
+        result.errStream = options.errStream || process.stderr;
+        return result;
+      }
+      _getSpawnOptions(options, toolPath) {
+        options = options || {};
+        const result = {};
+        result.cwd = options.cwd;
+        result.env = options.env;
+        result["windowsVerbatimArguments"] = options.windowsVerbatimArguments || this._isCmdFile();
+        if (options.windowsVerbatimArguments) {
+          result.argv0 = `"${toolPath}"`;
+        }
+        return result;
+      }
+      exec() {
+        return __awaiter(this, void 0, void 0, function* () {
+          if (!ioUtil.isRooted(this.toolPath) && (this.toolPath.includes("/") || IS_WINDOWS && this.toolPath.includes("\\"))) {
+            this.toolPath = path2.resolve(process.cwd(), this.options.cwd || process.cwd(), this.toolPath);
+          }
+          this.toolPath = yield io2.which(this.toolPath, true);
+          return new Promise((resolve, reject) => {
+            this._debug(`exec tool: ${this.toolPath}`);
+            this._debug("arguments:");
+            for (const arg of this.args) {
+              this._debug(`   ${arg}`);
+            }
+            const optionsNonNull = this._cloneExecOptions(this.options);
+            if (!optionsNonNull.silent && optionsNonNull.outStream) {
+              optionsNonNull.outStream.write(this._getCommandString(optionsNonNull) + os2.EOL);
+            }
+            const state = new ExecState(optionsNonNull, this.toolPath);
+            state.on("debug", (message) => {
+              this._debug(message);
             });
-          }
-          const errbuffer = "";
-          if (cp.stderr) {
-            cp.stderr.on("data", (data) => {
-              state.processStderr = true;
-              if (this.options.listeners && this.options.listeners.stderr) {
-                this.options.listeners.stderr(data);
-              }
-              if (!optionsNonNull.silent && optionsNonNull.errStream && optionsNonNull.outStream) {
-                const s = optionsNonNull.failOnStdErr ? optionsNonNull.errStream : optionsNonNull.outStream;
-                s.write(data);
-              }
-              this._processLineBuffer(data, errbuffer, (line) => {
-                if (this.options.listeners && this.options.listeners.errline) {
-                  this.options.listeners.errline(line);
+            const fileName = this._getSpawnFileName();
+            const cp = child.spawn(fileName, this._getSpawnArgs(optionsNonNull), this._getSpawnOptions(this.options, fileName));
+            const stdbuffer = "";
+            if (cp.stdout) {
+              cp.stdout.on("data", (data) => {
+                if (this.options.listeners && this.options.listeners.stdout) {
+                  this.options.listeners.stdout(data);
                 }
+                if (!optionsNonNull.silent && optionsNonNull.outStream) {
+                  optionsNonNull.outStream.write(data);
+                }
+                this._processLineBuffer(data, stdbuffer, (line) => {
+                  if (this.options.listeners && this.options.listeners.stdline) {
+                    this.options.listeners.stdline(line);
+                  }
+                });
               });
+            }
+            const errbuffer = "";
+            if (cp.stderr) {
+              cp.stderr.on("data", (data) => {
+                state.processStderr = true;
+                if (this.options.listeners && this.options.listeners.stderr) {
+                  this.options.listeners.stderr(data);
+                }
+                if (!optionsNonNull.silent && optionsNonNull.errStream && optionsNonNull.outStream) {
+                  const s = optionsNonNull.failOnStdErr ? optionsNonNull.errStream : optionsNonNull.outStream;
+                  s.write(data);
+                }
+                this._processLineBuffer(data, errbuffer, (line) => {
+                  if (this.options.listeners && this.options.listeners.errline) {
+                    this.options.listeners.errline(line);
+                  }
+                });
+              });
+            }
+            cp.on("error", (err) => {
+              state.processError = err.message;
+              state.processExited = true;
+              state.processClosed = true;
+              state.CheckComplete();
             });
-          }
-          cp.on("error", (err) => {
-            state.processError = err.message;
-            state.processExited = true;
-            state.processClosed = true;
-            state.CheckComplete();
-          });
-          cp.on("exit", (code) => {
-            state.processExitCode = code;
-            state.processExited = true;
-            this._debug(`Exit code ${code} received from tool '${this.toolPath}'`);
-            state.CheckComplete();
-          });
-          cp.on("close", (code) => {
-            state.processExitCode = code;
-            state.processExited = true;
-            state.processClosed = true;
-            this._debug(`STDIO streams have closed for tool '${this.toolPath}'`);
-            state.CheckComplete();
-          });
-          state.on("done", (error, exitCode) => {
-            if (stdbuffer.length > 0) {
-              this.emit("stdline", stdbuffer);
+            cp.on("exit", (code) => {
+              state.processExitCode = code;
+              state.processExited = true;
+              this._debug(`Exit code ${code} received from tool '${this.toolPath}'`);
+              state.CheckComplete();
+            });
+            cp.on("close", (code) => {
+              state.processExitCode = code;
+              state.processExited = true;
+              state.processClosed = true;
+              this._debug(`STDIO streams have closed for tool '${this.toolPath}'`);
+              state.CheckComplete();
+            });
+            state.on("done", (error, exitCode) => {
+              if (stdbuffer.length > 0) {
+                this.emit("stdline", stdbuffer);
+              }
+              if (errbuffer.length > 0) {
+                this.emit("errline", errbuffer);
+              }
+              cp.removeAllListeners();
+              if (error) {
+                reject(error);
+              } else {
+                resolve(exitCode);
+              }
+            });
+            if (this.options.input) {
+              if (!cp.stdin) {
+                throw new Error("child process missing stdin");
+              }
+              cp.stdin.end(this.options.input);
             }
-            if (errbuffer.length > 0) {
-              this.emit("errline", errbuffer);
-            }
-            cp.removeAllListeners();
-            if (error) {
-              reject(error);
-            } else {
-              resolve(exitCode);
-            }
           });
-          if (this.options.input) {
-            if (!cp.stdin) {
-              throw new Error("child process missing stdin");
-            }
-            cp.stdin.end(this.options.input);
-          }
         });
-      });
-    }
-  };
-  exports2.ToolRunner = ToolRunner;
-  function argStringToArray(argString) {
-    const args = [];
-    let inQuotes = false;
-    let escaped = false;
-    let arg = "";
-    function append(c) {
-      if (escaped && c !== '"') {
-        arg += "\\";
       }
-      arg += c;
-      escaped = false;
-    }
-    for (let i = 0; i < argString.length; i++) {
-      const c = argString.charAt(i);
-      if (c === '"') {
-        if (!escaped) {
-          inQuotes = !inQuotes;
-        } else {
+    };
+    exports2.ToolRunner = ToolRunner;
+    function argStringToArray(argString) {
+      const args = [];
+      let inQuotes = false;
+      let escaped = false;
+      let arg = "";
+      function append(c) {
+        if (escaped && c !== '"') {
+          arg += "\\";
+        }
+        arg += c;
+        escaped = false;
+      }
+      for (let i = 0; i < argString.length; i++) {
+        const c = argString.charAt(i);
+        if (c === '"') {
+          if (!escaped) {
+            inQuotes = !inQuotes;
+          } else {
+            append(c);
+          }
+          continue;
+        }
+        if (c === "\\" && escaped) {
           append(c);
+          continue;
         }
-        continue;
-      }
-      if (c === "\\" && escaped) {
+        if (c === "\\" && inQuotes) {
+          escaped = true;
+          continue;
+        }
+        if (c === " " && !inQuotes) {
+          if (arg.length > 0) {
+            args.push(arg);
+            arg = "";
+          }
+          continue;
+        }
         append(c);
-        continue;
       }
-      if (c === "\\" && inQuotes) {
-        escaped = true;
-        continue;
+      if (arg.length > 0) {
+        args.push(arg.trim());
       }
-      if (c === " " && !inQuotes) {
-        if (arg.length > 0) {
-          args.push(arg);
-          arg = "";
-        }
-        continue;
-      }
-      append(c);
+      return args;
     }
-    if (arg.length > 0) {
-      args.push(arg.trim());
-    }
-    return args;
-  }
-  exports2.argStringToArray = argStringToArray;
-  var ExecState = class extends events.EventEmitter {
-    constructor(options, toolPath) {
-      super();
-      this.processClosed = false;
-      this.processError = "";
-      this.processExitCode = 0;
-      this.processExited = false;
-      this.processStderr = false;
-      this.delay = 1e4;
-      this.done = false;
-      this.timeout = null;
-      if (!toolPath) {
-        throw new Error("toolPath must not be empty");
-      }
-      this.options = options;
-      this.toolPath = toolPath;
-      if (options.delay) {
-        this.delay = options.delay;
-      }
-    }
-    CheckComplete() {
-      if (this.done) {
-        return;
-      }
-      if (this.processClosed) {
-        this._setResult();
-      } else if (this.processExited) {
-        this.timeout = setTimeout(ExecState.HandleTimeout, this.delay, this);
-      }
-    }
-    _debug(message) {
-      this.emit("debug", message);
-    }
-    _setResult() {
-      let error;
-      if (this.processExited) {
-        if (this.processError) {
-          error = new Error(`There was an error when attempting to execute the process '${this.toolPath}'. This may indicate the process failed to start. Error: ${this.processError}`);
-        } else if (this.processExitCode !== 0 && !this.options.ignoreReturnCode) {
-          error = new Error(`The process '${this.toolPath}' failed with exit code ${this.processExitCode}`);
-        } else if (this.processStderr && this.options.failOnStdErr) {
-          error = new Error(`The process '${this.toolPath}' failed because one or more lines were written to the STDERR stream`);
-        }
-      }
-      if (this.timeout) {
-        clearTimeout(this.timeout);
+    exports2.argStringToArray = argStringToArray;
+    var ExecState = class extends events.EventEmitter {
+      constructor(options, toolPath) {
+        super();
+        this.processClosed = false;
+        this.processError = "";
+        this.processExitCode = 0;
+        this.processExited = false;
+        this.processStderr = false;
+        this.delay = 1e4;
+        this.done = false;
         this.timeout = null;
+        if (!toolPath) {
+          throw new Error("toolPath must not be empty");
+        }
+        this.options = options;
+        this.toolPath = toolPath;
+        if (options.delay) {
+          this.delay = options.delay;
+        }
       }
-      this.done = true;
-      this.emit("done", error, this.processExitCode);
-    }
-    static HandleTimeout(state) {
-      if (state.done) {
-        return;
+      CheckComplete() {
+        if (this.done) {
+          return;
+        }
+        if (this.processClosed) {
+          this._setResult();
+        } else if (this.processExited) {
+          this.timeout = setTimeout(ExecState.HandleTimeout, this.delay, this);
+        }
       }
-      if (!state.processClosed && state.processExited) {
-        const message = `The STDIO streams did not close within ${state.delay / 1e3} seconds of the exit event from process '${state.toolPath}'. This may indicate a child process inherited the STDIO streams and has not yet exited.`;
-        state._debug(message);
+      _debug(message) {
+        this.emit("debug", message);
       }
-      state._setResult();
-    }
-  };
+      _setResult() {
+        let error;
+        if (this.processExited) {
+          if (this.processError) {
+            error = new Error(`There was an error when attempting to execute the process '${this.toolPath}'. This may indicate the process failed to start. Error: ${this.processError}`);
+          } else if (this.processExitCode !== 0 && !this.options.ignoreReturnCode) {
+            error = new Error(`The process '${this.toolPath}' failed with exit code ${this.processExitCode}`);
+          } else if (this.processStderr && this.options.failOnStdErr) {
+            error = new Error(`The process '${this.toolPath}' failed because one or more lines were written to the STDERR stream`);
+          }
+        }
+        if (this.timeout) {
+          clearTimeout(this.timeout);
+          this.timeout = null;
+        }
+        this.done = true;
+        this.emit("done", error, this.processExitCode);
+      }
+      static HandleTimeout(state) {
+        if (state.done) {
+          return;
+        }
+        if (!state.processClosed && state.processExited) {
+          const message = `The STDIO streams did not close within ${state.delay / 1e3} seconds of the exit event from process '${state.toolPath}'. This may indicate a child process inherited the STDIO streams and has not yet exited.`;
+          state._debug(message);
+        }
+        state._setResult();
+      }
+    };
+  }
 });
 
 // node_modules/@actions/exec/lib/exec.js
-var require_exec = __commonJS((exports2) => {
-  "use strict";
-  var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
-    function adopt(value) {
-      return value instanceof P ? value : new P(function(resolve) {
-        resolve(value);
+var require_exec = __commonJS({
+  "node_modules/@actions/exec/lib/exec.js"(exports2) {
+    "use strict";
+    var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve) {
+          resolve(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+      });
+    };
+    var __importStar = exports2 && exports2.__importStar || function(mod) {
+      if (mod && mod.__esModule)
+        return mod;
+      var result = {};
+      if (mod != null) {
+        for (var k in mod)
+          if (Object.hasOwnProperty.call(mod, k))
+            result[k] = mod[k];
+      }
+      result["default"] = mod;
+      return result;
+    };
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    var tr = __importStar(require_toolrunner());
+    function exec7(commandLine, args, options) {
+      return __awaiter(this, void 0, void 0, function* () {
+        const commandArgs = tr.argStringToArray(commandLine);
+        if (commandArgs.length === 0) {
+          throw new Error(`Parameter 'commandLine' cannot be null or empty.`);
+        }
+        const toolPath = commandArgs[0];
+        args = commandArgs.slice(1).concat(args || []);
+        const runner = new tr.ToolRunner(toolPath, args, options);
+        return runner.exec();
       });
     }
-    return new (P || (P = Promise))(function(resolve, reject) {
-      function fulfilled(value) {
-        try {
-          step(generator.next(value));
-        } catch (e) {
-          reject(e);
-        }
-      }
-      function rejected(value) {
-        try {
-          step(generator["throw"](value));
-        } catch (e) {
-          reject(e);
-        }
-      }
-      function step(result) {
-        result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
-      }
-      step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-  };
-  var __importStar = exports2 && exports2.__importStar || function(mod) {
-    if (mod && mod.__esModule)
-      return mod;
-    var result = {};
-    if (mod != null) {
-      for (var k in mod)
-        if (Object.hasOwnProperty.call(mod, k))
-          result[k] = mod[k];
-    }
-    result["default"] = mod;
-    return result;
-  };
-  Object.defineProperty(exports2, "__esModule", {value: true});
-  var tr = __importStar(require_toolrunner());
-  function exec7(commandLine, args, options) {
-    return __awaiter(this, void 0, void 0, function* () {
-      const commandArgs = tr.argStringToArray(commandLine);
-      if (commandArgs.length === 0) {
-        throw new Error(`Parameter 'commandLine' cannot be null or empty.`);
-      }
-      const toolPath = commandArgs[0];
-      args = commandArgs.slice(1).concat(args || []);
-      const runner = new tr.ToolRunner(toolPath, args, options);
-      return runner.exec();
-    });
+    exports2.exec = exec7;
   }
-  exports2.exec = exec7;
+});
+
+// node_modules/@actions/io/lib/io-util.js
+var require_io_util2 = __commonJS({
+  "node_modules/@actions/io/lib/io-util.js"(exports2) {
+    "use strict";
+    var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve) {
+          resolve(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+      });
+    };
+    var _a;
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    var assert_1 = require("assert");
+    var fs2 = require("fs");
+    var path2 = require("path");
+    _a = fs2.promises, exports2.chmod = _a.chmod, exports2.copyFile = _a.copyFile, exports2.lstat = _a.lstat, exports2.mkdir = _a.mkdir, exports2.readdir = _a.readdir, exports2.readlink = _a.readlink, exports2.rename = _a.rename, exports2.rmdir = _a.rmdir, exports2.stat = _a.stat, exports2.symlink = _a.symlink, exports2.unlink = _a.unlink;
+    exports2.IS_WINDOWS = process.platform === "win32";
+    function exists(fsPath) {
+      return __awaiter(this, void 0, void 0, function* () {
+        try {
+          yield exports2.stat(fsPath);
+        } catch (err) {
+          if (err.code === "ENOENT") {
+            return false;
+          }
+          throw err;
+        }
+        return true;
+      });
+    }
+    exports2.exists = exists;
+    function isDirectory(fsPath, useStat = false) {
+      return __awaiter(this, void 0, void 0, function* () {
+        const stats = useStat ? yield exports2.stat(fsPath) : yield exports2.lstat(fsPath);
+        return stats.isDirectory();
+      });
+    }
+    exports2.isDirectory = isDirectory;
+    function isRooted(p) {
+      p = normalizeSeparators(p);
+      if (!p) {
+        throw new Error('isRooted() parameter "p" cannot be empty');
+      }
+      if (exports2.IS_WINDOWS) {
+        return p.startsWith("\\") || /^[A-Z]:/i.test(p);
+      }
+      return p.startsWith("/");
+    }
+    exports2.isRooted = isRooted;
+    function mkdirP(fsPath, maxDepth = 1e3, depth = 1) {
+      return __awaiter(this, void 0, void 0, function* () {
+        assert_1.ok(fsPath, "a path argument must be provided");
+        fsPath = path2.resolve(fsPath);
+        if (depth >= maxDepth)
+          return exports2.mkdir(fsPath);
+        try {
+          yield exports2.mkdir(fsPath);
+          return;
+        } catch (err) {
+          switch (err.code) {
+            case "ENOENT": {
+              yield mkdirP(path2.dirname(fsPath), maxDepth, depth + 1);
+              yield exports2.mkdir(fsPath);
+              return;
+            }
+            default: {
+              let stats;
+              try {
+                stats = yield exports2.stat(fsPath);
+              } catch (err2) {
+                throw err;
+              }
+              if (!stats.isDirectory())
+                throw err;
+            }
+          }
+        }
+      });
+    }
+    exports2.mkdirP = mkdirP;
+    function tryGetExecutablePath(filePath, extensions) {
+      return __awaiter(this, void 0, void 0, function* () {
+        let stats = void 0;
+        try {
+          stats = yield exports2.stat(filePath);
+        } catch (err) {
+          if (err.code !== "ENOENT") {
+            console.log(`Unexpected error attempting to determine if executable file exists '${filePath}': ${err}`);
+          }
+        }
+        if (stats && stats.isFile()) {
+          if (exports2.IS_WINDOWS) {
+            const upperExt = path2.extname(filePath).toUpperCase();
+            if (extensions.some((validExt) => validExt.toUpperCase() === upperExt)) {
+              return filePath;
+            }
+          } else {
+            if (isUnixExecutable(stats)) {
+              return filePath;
+            }
+          }
+        }
+        const originalFilePath = filePath;
+        for (const extension of extensions) {
+          filePath = originalFilePath + extension;
+          stats = void 0;
+          try {
+            stats = yield exports2.stat(filePath);
+          } catch (err) {
+            if (err.code !== "ENOENT") {
+              console.log(`Unexpected error attempting to determine if executable file exists '${filePath}': ${err}`);
+            }
+          }
+          if (stats && stats.isFile()) {
+            if (exports2.IS_WINDOWS) {
+              try {
+                const directory = path2.dirname(filePath);
+                const upperName = path2.basename(filePath).toUpperCase();
+                for (const actualName of yield exports2.readdir(directory)) {
+                  if (upperName === actualName.toUpperCase()) {
+                    filePath = path2.join(directory, actualName);
+                    break;
+                  }
+                }
+              } catch (err) {
+                console.log(`Unexpected error attempting to determine the actual case of the file '${filePath}': ${err}`);
+              }
+              return filePath;
+            } else {
+              if (isUnixExecutable(stats)) {
+                return filePath;
+              }
+            }
+          }
+        }
+        return "";
+      });
+    }
+    exports2.tryGetExecutablePath = tryGetExecutablePath;
+    function normalizeSeparators(p) {
+      p = p || "";
+      if (exports2.IS_WINDOWS) {
+        p = p.replace(/\//g, "\\");
+        return p.replace(/\\\\+/g, "\\");
+      }
+      return p.replace(/\/\/+/g, "/");
+    }
+    function isUnixExecutable(stats) {
+      return (stats.mode & 1) > 0 || (stats.mode & 8) > 0 && stats.gid === process.getgid() || (stats.mode & 64) > 0 && stats.uid === process.getuid();
+    }
+  }
+});
+
+// node_modules/@actions/io/lib/io.js
+var require_io2 = __commonJS({
+  "node_modules/@actions/io/lib/io.js"(exports2) {
+    "use strict";
+    var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve) {
+          resolve(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+      });
+    };
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    var childProcess = require("child_process");
+    var path2 = require("path");
+    var util_1 = require("util");
+    var ioUtil = require_io_util2();
+    var exec7 = util_1.promisify(childProcess.exec);
+    function cp(source, dest, options = {}) {
+      return __awaiter(this, void 0, void 0, function* () {
+        const { force, recursive } = readCopyOptions(options);
+        const destStat = (yield ioUtil.exists(dest)) ? yield ioUtil.stat(dest) : null;
+        if (destStat && destStat.isFile() && !force) {
+          return;
+        }
+        const newDest = destStat && destStat.isDirectory() ? path2.join(dest, path2.basename(source)) : dest;
+        if (!(yield ioUtil.exists(source))) {
+          throw new Error(`no such file or directory: ${source}`);
+        }
+        const sourceStat = yield ioUtil.stat(source);
+        if (sourceStat.isDirectory()) {
+          if (!recursive) {
+            throw new Error(`Failed to copy. ${source} is a directory, but tried to copy without recursive flag.`);
+          } else {
+            yield cpDirRecursive(source, newDest, 0, force);
+          }
+        } else {
+          if (path2.relative(source, newDest) === "") {
+            throw new Error(`'${newDest}' and '${source}' are the same file`);
+          }
+          yield copyFile(source, newDest, force);
+        }
+      });
+    }
+    exports2.cp = cp;
+    function mv(source, dest, options = {}) {
+      return __awaiter(this, void 0, void 0, function* () {
+        if (yield ioUtil.exists(dest)) {
+          let destExists = true;
+          if (yield ioUtil.isDirectory(dest)) {
+            dest = path2.join(dest, path2.basename(source));
+            destExists = yield ioUtil.exists(dest);
+          }
+          if (destExists) {
+            if (options.force == null || options.force) {
+              yield rmRF(dest);
+            } else {
+              throw new Error("Destination already exists");
+            }
+          }
+        }
+        yield mkdirP(path2.dirname(dest));
+        yield ioUtil.rename(source, dest);
+      });
+    }
+    exports2.mv = mv;
+    function rmRF(inputPath) {
+      return __awaiter(this, void 0, void 0, function* () {
+        if (ioUtil.IS_WINDOWS) {
+          try {
+            if (yield ioUtil.isDirectory(inputPath, true)) {
+              yield exec7(`rd /s /q "${inputPath}"`);
+            } else {
+              yield exec7(`del /f /a "${inputPath}"`);
+            }
+          } catch (err) {
+            if (err.code !== "ENOENT")
+              throw err;
+          }
+          try {
+            yield ioUtil.unlink(inputPath);
+          } catch (err) {
+            if (err.code !== "ENOENT")
+              throw err;
+          }
+        } else {
+          let isDir = false;
+          try {
+            isDir = yield ioUtil.isDirectory(inputPath);
+          } catch (err) {
+            if (err.code !== "ENOENT")
+              throw err;
+            return;
+          }
+          if (isDir) {
+            yield exec7(`rm -rf "${inputPath}"`);
+          } else {
+            yield ioUtil.unlink(inputPath);
+          }
+        }
+      });
+    }
+    exports2.rmRF = rmRF;
+    function mkdirP(fsPath) {
+      return __awaiter(this, void 0, void 0, function* () {
+        yield ioUtil.mkdirP(fsPath);
+      });
+    }
+    exports2.mkdirP = mkdirP;
+    function which2(tool, check) {
+      return __awaiter(this, void 0, void 0, function* () {
+        if (!tool) {
+          throw new Error("parameter 'tool' is required");
+        }
+        if (check) {
+          const result = yield which2(tool, false);
+          if (!result) {
+            if (ioUtil.IS_WINDOWS) {
+              throw new Error(`Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also verify the file has a valid extension for an executable file.`);
+            } else {
+              throw new Error(`Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also check the file mode to verify the file is executable.`);
+            }
+          }
+        }
+        try {
+          const extensions = [];
+          if (ioUtil.IS_WINDOWS && process.env.PATHEXT) {
+            for (const extension of process.env.PATHEXT.split(path2.delimiter)) {
+              if (extension) {
+                extensions.push(extension);
+              }
+            }
+          }
+          if (ioUtil.isRooted(tool)) {
+            const filePath = yield ioUtil.tryGetExecutablePath(tool, extensions);
+            if (filePath) {
+              return filePath;
+            }
+            return "";
+          }
+          if (tool.includes("/") || ioUtil.IS_WINDOWS && tool.includes("\\")) {
+            return "";
+          }
+          const directories = [];
+          if (process.env.PATH) {
+            for (const p of process.env.PATH.split(path2.delimiter)) {
+              if (p) {
+                directories.push(p);
+              }
+            }
+          }
+          for (const directory of directories) {
+            const filePath = yield ioUtil.tryGetExecutablePath(directory + path2.sep + tool, extensions);
+            if (filePath) {
+              return filePath;
+            }
+          }
+          return "";
+        } catch (err) {
+          throw new Error(`which failed with message ${err.message}`);
+        }
+      });
+    }
+    exports2.which = which2;
+    function readCopyOptions(options) {
+      const force = options.force == null ? true : options.force;
+      const recursive = Boolean(options.recursive);
+      return { force, recursive };
+    }
+    function cpDirRecursive(sourceDir, destDir, currentDepth, force) {
+      return __awaiter(this, void 0, void 0, function* () {
+        if (currentDepth >= 255)
+          return;
+        currentDepth++;
+        yield mkdirP(destDir);
+        const files = yield ioUtil.readdir(sourceDir);
+        for (const fileName of files) {
+          const srcFile = `${sourceDir}/${fileName}`;
+          const destFile = `${destDir}/${fileName}`;
+          const srcFileStat = yield ioUtil.lstat(srcFile);
+          if (srcFileStat.isDirectory()) {
+            yield cpDirRecursive(srcFile, destFile, currentDepth, force);
+          } else {
+            yield copyFile(srcFile, destFile, force);
+          }
+        }
+        yield ioUtil.chmod(destDir, (yield ioUtil.stat(sourceDir)).mode);
+      });
+    }
+    function copyFile(srcFile, destFile, force) {
+      return __awaiter(this, void 0, void 0, function* () {
+        if ((yield ioUtil.lstat(srcFile)).isSymbolicLink()) {
+          try {
+            yield ioUtil.lstat(destFile);
+            yield ioUtil.unlink(destFile);
+          } catch (e) {
+            if (e.code === "EPERM") {
+              yield ioUtil.chmod(destFile, "0666");
+              yield ioUtil.unlink(destFile);
+            }
+          }
+          const symlinkFull = yield ioUtil.readlink(srcFile);
+          yield ioUtil.symlink(symlinkFull, destFile, ioUtil.IS_WINDOWS ? "junction" : null);
+        } else if (!(yield ioUtil.exists(destFile)) || force) {
+          yield ioUtil.copyFile(srcFile, destFile);
+        }
+      });
+    }
+  }
 });
 
 // lib/install/main.ts
@@ -1226,7 +1693,7 @@ var fs = __toModule(require("fs"));
 // lib/setup/index.ts
 var core = __toModule(require_core());
 var exec = __toModule(require_exec());
-var io = __toModule(require_io());
+var io = __toModule(require_io2());
 var os = __toModule(require("os"));
 var path = __toModule(require("path"));
 async function setupAsdf() {
@@ -1240,7 +1707,7 @@ async function setupAsdf() {
   core.addPath(`${asdfDir}/bin`);
   core.addPath(`${asdfDir}/shims`);
   core.info(`Cloning asdf into ASDF_DIR: ${asdfDir}`);
-  const branch = core.getInput("asdf_branch", {required: true});
+  const branch = core.getInput("asdf_branch", { required: true });
   await exec.exec("git", [
     "clone",
     "--depth",
@@ -1277,7 +1744,7 @@ async function pluginList() {
 }
 async function pluginsAdd() {
   await setupAsdf();
-  let toolVersions = core2.getInput("tool_versions", {required: false});
+  let toolVersions = core2.getInput("tool_versions", { required: false });
   if (toolVersions) {
     await fs.promises.writeFile(".tool-versions", toolVersions, {
       encoding: "utf8"
@@ -1301,8 +1768,12 @@ async function pluginsAdd() {
 
 // lib/install/index.ts
 async function toolsInstall() {
+  const dir = core3.getInput("directory", { required: false });
+  if (dir) {
+    process.chdir(dir);
+  }
   await pluginsAdd();
-  const before = core3.getInput("before_install", {required: false});
+  const before = core3.getInput("before_install", { required: false });
   if (before) {
     await exec5.exec("bash", ["-c", before]);
   }

--- a/install/main.js
+++ b/install/main.js
@@ -1,403 +1,424 @@
 var __create = Object.create;
 var __defProp = Object.defineProperty;
-var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
-var __getOwnPropNames = Object.getOwnPropertyNames;
 var __getProtoOf = Object.getPrototypeOf;
 var __hasOwnProp = Object.prototype.hasOwnProperty;
-var __markAsModule = (target) => __defProp(target, "__esModule", { value: true });
-var __commonJS = (cb, mod) => function __require() {
-  return mod || (0, cb[Object.keys(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __markAsModule = (target) => __defProp(target, "__esModule", {value: true});
+var __commonJS = (callback, module2) => () => {
+  if (!module2) {
+    module2 = {exports: {}};
+    callback(module2.exports, module2);
+  }
+  return module2.exports;
 };
-var __reExport = (target, module2, desc) => {
+var __exportStar = (target, module2, desc) => {
+  __markAsModule(target);
   if (module2 && typeof module2 === "object" || typeof module2 === "function") {
     for (let key of __getOwnPropNames(module2))
       if (!__hasOwnProp.call(target, key) && key !== "default")
-        __defProp(target, key, { get: () => module2[key], enumerable: !(desc = __getOwnPropDesc(module2, key)) || desc.enumerable });
+        __defProp(target, key, {get: () => module2[key], enumerable: !(desc = __getOwnPropDesc(module2, key)) || desc.enumerable});
   }
   return target;
 };
 var __toModule = (module2) => {
-  return __reExport(__markAsModule(__defProp(module2 != null ? __create(__getProtoOf(module2)) : {}, "default", module2 && module2.__esModule && "default" in module2 ? { get: () => module2.default, enumerable: true } : { value: module2, enumerable: true })), module2);
+  if (module2 && module2.__esModule)
+    return module2;
+  return __exportStar(__defProp(module2 != null ? __create(__getProtoOf(module2)) : {}, "default", {value: module2, enumerable: true}), module2);
 };
 
 // node_modules/@actions/core/lib/utils.js
-var require_utils = __commonJS({
-  "node_modules/@actions/core/lib/utils.js"(exports2) {
-    "use strict";
-    Object.defineProperty(exports2, "__esModule", { value: true });
-    function toCommandValue(input) {
-      if (input === null || input === void 0) {
-        return "";
-      } else if (typeof input === "string" || input instanceof String) {
-        return input;
-      }
-      return JSON.stringify(input);
+var require_utils = __commonJS((exports2) => {
+  "use strict";
+  Object.defineProperty(exports2, "__esModule", {value: true});
+  function toCommandValue(input) {
+    if (input === null || input === void 0) {
+      return "";
+    } else if (typeof input === "string" || input instanceof String) {
+      return input;
     }
-    exports2.toCommandValue = toCommandValue;
+    return JSON.stringify(input);
   }
+  exports2.toCommandValue = toCommandValue;
 });
 
 // node_modules/@actions/core/lib/command.js
-var require_command = __commonJS({
-  "node_modules/@actions/core/lib/command.js"(exports2) {
-    "use strict";
-    var __importStar = exports2 && exports2.__importStar || function(mod) {
-      if (mod && mod.__esModule)
-        return mod;
-      var result = {};
-      if (mod != null) {
-        for (var k in mod)
-          if (Object.hasOwnProperty.call(mod, k))
-            result[k] = mod[k];
-      }
-      result["default"] = mod;
-      return result;
-    };
-    Object.defineProperty(exports2, "__esModule", { value: true });
-    var os2 = __importStar(require("os"));
-    var utils_1 = require_utils();
-    function issueCommand(command, properties, message) {
-      const cmd = new Command(command, properties, message);
-      process.stdout.write(cmd.toString() + os2.EOL);
+var require_command = __commonJS((exports2) => {
+  "use strict";
+  var __importStar = exports2 && exports2.__importStar || function(mod) {
+    if (mod && mod.__esModule)
+      return mod;
+    var result = {};
+    if (mod != null) {
+      for (var k in mod)
+        if (Object.hasOwnProperty.call(mod, k))
+          result[k] = mod[k];
     }
-    exports2.issueCommand = issueCommand;
-    function issue(name, message = "") {
-      issueCommand(name, {}, message);
-    }
-    exports2.issue = issue;
-    var CMD_STRING = "::";
-    var Command = class {
-      constructor(command, properties, message) {
-        if (!command) {
-          command = "missing.command";
-        }
-        this.command = command;
-        this.properties = properties;
-        this.message = message;
+    result["default"] = mod;
+    return result;
+  };
+  Object.defineProperty(exports2, "__esModule", {value: true});
+  var os2 = __importStar(require("os"));
+  var utils_1 = require_utils();
+  function issueCommand(command, properties, message) {
+    const cmd = new Command(command, properties, message);
+    process.stdout.write(cmd.toString() + os2.EOL);
+  }
+  exports2.issueCommand = issueCommand;
+  function issue(name, message = "") {
+    issueCommand(name, {}, message);
+  }
+  exports2.issue = issue;
+  var CMD_STRING = "::";
+  var Command = class {
+    constructor(command, properties, message) {
+      if (!command) {
+        command = "missing.command";
       }
-      toString() {
-        let cmdStr = CMD_STRING + this.command;
-        if (this.properties && Object.keys(this.properties).length > 0) {
-          cmdStr += " ";
-          let first = true;
-          for (const key in this.properties) {
-            if (this.properties.hasOwnProperty(key)) {
-              const val = this.properties[key];
-              if (val) {
-                if (first) {
-                  first = false;
-                } else {
-                  cmdStr += ",";
-                }
-                cmdStr += `${key}=${escapeProperty(val)}`;
+      this.command = command;
+      this.properties = properties;
+      this.message = message;
+    }
+    toString() {
+      let cmdStr = CMD_STRING + this.command;
+      if (this.properties && Object.keys(this.properties).length > 0) {
+        cmdStr += " ";
+        let first = true;
+        for (const key in this.properties) {
+          if (this.properties.hasOwnProperty(key)) {
+            const val = this.properties[key];
+            if (val) {
+              if (first) {
+                first = false;
+              } else {
+                cmdStr += ",";
               }
+              cmdStr += `${key}=${escapeProperty(val)}`;
             }
           }
         }
-        cmdStr += `${CMD_STRING}${escapeData(this.message)}`;
-        return cmdStr;
       }
-    };
-    function escapeData(s) {
-      return utils_1.toCommandValue(s).replace(/%/g, "%25").replace(/\r/g, "%0D").replace(/\n/g, "%0A");
+      cmdStr += `${CMD_STRING}${escapeData(this.message)}`;
+      return cmdStr;
     }
-    function escapeProperty(s) {
-      return utils_1.toCommandValue(s).replace(/%/g, "%25").replace(/\r/g, "%0D").replace(/\n/g, "%0A").replace(/:/g, "%3A").replace(/,/g, "%2C");
-    }
+  };
+  function escapeData(s) {
+    return utils_1.toCommandValue(s).replace(/%/g, "%25").replace(/\r/g, "%0D").replace(/\n/g, "%0A");
+  }
+  function escapeProperty(s) {
+    return utils_1.toCommandValue(s).replace(/%/g, "%25").replace(/\r/g, "%0D").replace(/\n/g, "%0A").replace(/:/g, "%3A").replace(/,/g, "%2C");
   }
 });
 
 // node_modules/@actions/core/lib/file-command.js
-var require_file_command = __commonJS({
-  "node_modules/@actions/core/lib/file-command.js"(exports2) {
-    "use strict";
-    var __importStar = exports2 && exports2.__importStar || function(mod) {
-      if (mod && mod.__esModule)
-        return mod;
-      var result = {};
-      if (mod != null) {
-        for (var k in mod)
-          if (Object.hasOwnProperty.call(mod, k))
-            result[k] = mod[k];
-      }
-      result["default"] = mod;
-      return result;
-    };
-    Object.defineProperty(exports2, "__esModule", { value: true });
-    var fs2 = __importStar(require("fs"));
-    var os2 = __importStar(require("os"));
-    var utils_1 = require_utils();
-    function issueCommand(command, message) {
-      const filePath = process.env[`GITHUB_${command}`];
-      if (!filePath) {
-        throw new Error(`Unable to find environment variable for file command ${command}`);
-      }
-      if (!fs2.existsSync(filePath)) {
-        throw new Error(`Missing file at path: ${filePath}`);
-      }
-      fs2.appendFileSync(filePath, `${utils_1.toCommandValue(message)}${os2.EOL}`, {
-        encoding: "utf8"
-      });
+var require_file_command = __commonJS((exports2) => {
+  "use strict";
+  var __importStar = exports2 && exports2.__importStar || function(mod) {
+    if (mod && mod.__esModule)
+      return mod;
+    var result = {};
+    if (mod != null) {
+      for (var k in mod)
+        if (Object.hasOwnProperty.call(mod, k))
+          result[k] = mod[k];
     }
-    exports2.issueCommand = issueCommand;
+    result["default"] = mod;
+    return result;
+  };
+  Object.defineProperty(exports2, "__esModule", {value: true});
+  var fs2 = __importStar(require("fs"));
+  var os2 = __importStar(require("os"));
+  var utils_1 = require_utils();
+  function issueCommand(command, message) {
+    const filePath = process.env[`GITHUB_${command}`];
+    if (!filePath) {
+      throw new Error(`Unable to find environment variable for file command ${command}`);
+    }
+    if (!fs2.existsSync(filePath)) {
+      throw new Error(`Missing file at path: ${filePath}`);
+    }
+    fs2.appendFileSync(filePath, `${utils_1.toCommandValue(message)}${os2.EOL}`, {
+      encoding: "utf8"
+    });
   }
+  exports2.issueCommand = issueCommand;
 });
 
 // node_modules/@actions/core/lib/core.js
-var require_core = __commonJS({
-  "node_modules/@actions/core/lib/core.js"(exports2) {
-    "use strict";
-    var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
-      function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve) {
-          resolve(value);
-        });
-      }
-      return new (P || (P = Promise))(function(resolve, reject) {
-        function fulfilled(value) {
-          try {
-            step(generator.next(value));
-          } catch (e) {
-            reject(e);
-          }
-        }
-        function rejected(value) {
-          try {
-            step(generator["throw"](value));
-          } catch (e) {
-            reject(e);
-          }
-        }
-        function step(result) {
-          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
-        }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
+var require_core = __commonJS((exports2) => {
+  "use strict";
+  var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+    function adopt(value) {
+      return value instanceof P ? value : new P(function(resolve) {
+        resolve(value);
       });
-    };
-    var __importStar = exports2 && exports2.__importStar || function(mod) {
-      if (mod && mod.__esModule)
-        return mod;
-      var result = {};
-      if (mod != null) {
-        for (var k in mod)
-          if (Object.hasOwnProperty.call(mod, k))
-            result[k] = mod[k];
-      }
-      result["default"] = mod;
-      return result;
-    };
-    Object.defineProperty(exports2, "__esModule", { value: true });
-    var command_1 = require_command();
-    var file_command_1 = require_file_command();
-    var utils_1 = require_utils();
-    var os2 = __importStar(require("os"));
-    var path2 = __importStar(require("path"));
-    var ExitCode;
-    (function(ExitCode2) {
-      ExitCode2[ExitCode2["Success"] = 0] = "Success";
-      ExitCode2[ExitCode2["Failure"] = 1] = "Failure";
-    })(ExitCode = exports2.ExitCode || (exports2.ExitCode = {}));
-    function exportVariable2(name, val) {
-      const convertedVal = utils_1.toCommandValue(val);
-      process.env[name] = convertedVal;
-      const filePath = process.env["GITHUB_ENV"] || "";
-      if (filePath) {
-        const delimiter = "_GitHubActionsFileCommandDelimeter_";
-        const commandValue = `${name}<<${delimiter}${os2.EOL}${convertedVal}${os2.EOL}${delimiter}`;
-        file_command_1.issueCommand("ENV", commandValue);
-      } else {
-        command_1.issueCommand("set-env", { name }, convertedVal);
-      }
     }
-    exports2.exportVariable = exportVariable2;
-    function setSecret(secret) {
-      command_1.issueCommand("add-mask", {}, secret);
-    }
-    exports2.setSecret = setSecret;
-    function addPath2(inputPath) {
-      const filePath = process.env["GITHUB_PATH"] || "";
-      if (filePath) {
-        file_command_1.issueCommand("PATH", inputPath);
-      } else {
-        command_1.issueCommand("add-path", {}, inputPath);
-      }
-      process.env["PATH"] = `${inputPath}${path2.delimiter}${process.env["PATH"]}`;
-    }
-    exports2.addPath = addPath2;
-    function getInput4(name, options) {
-      const val = process.env[`INPUT_${name.replace(/ /g, "_").toUpperCase()}`] || "";
-      if (options && options.required && !val) {
-        throw new Error(`Input required and not supplied: ${name}`);
-      }
-      return val.trim();
-    }
-    exports2.getInput = getInput4;
-    function setOutput(name, value) {
-      command_1.issueCommand("set-output", { name }, value);
-    }
-    exports2.setOutput = setOutput;
-    function setCommandEcho(enabled) {
-      command_1.issue("echo", enabled ? "on" : "off");
-    }
-    exports2.setCommandEcho = setCommandEcho;
-    function setFailed2(message) {
-      process.exitCode = ExitCode.Failure;
-      error(message);
-    }
-    exports2.setFailed = setFailed2;
-    function isDebug() {
-      return process.env["RUNNER_DEBUG"] === "1";
-    }
-    exports2.isDebug = isDebug;
-    function debug(message) {
-      command_1.issueCommand("debug", {}, message);
-    }
-    exports2.debug = debug;
-    function error(message) {
-      command_1.issue("error", message instanceof Error ? message.toString() : message);
-    }
-    exports2.error = error;
-    function warning(message) {
-      command_1.issue("warning", message instanceof Error ? message.toString() : message);
-    }
-    exports2.warning = warning;
-    function info3(message) {
-      process.stdout.write(message + os2.EOL);
-    }
-    exports2.info = info3;
-    function startGroup(name) {
-      command_1.issue("group", name);
-    }
-    exports2.startGroup = startGroup;
-    function endGroup() {
-      command_1.issue("endgroup");
-    }
-    exports2.endGroup = endGroup;
-    function group(name, fn) {
-      return __awaiter(this, void 0, void 0, function* () {
-        startGroup(name);
-        let result;
+    return new (P || (P = Promise))(function(resolve, reject) {
+      function fulfilled(value) {
         try {
-          result = yield fn();
-        } finally {
-          endGroup();
+          step(generator.next(value));
+        } catch (e) {
+          reject(e);
         }
-        return result;
-      });
+      }
+      function rejected(value) {
+        try {
+          step(generator["throw"](value));
+        } catch (e) {
+          reject(e);
+        }
+      }
+      function step(result) {
+        result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+      }
+      step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+  };
+  var __importStar = exports2 && exports2.__importStar || function(mod) {
+    if (mod && mod.__esModule)
+      return mod;
+    var result = {};
+    if (mod != null) {
+      for (var k in mod)
+        if (Object.hasOwnProperty.call(mod, k))
+          result[k] = mod[k];
     }
-    exports2.group = group;
-    function saveState(name, value) {
-      command_1.issueCommand("save-state", { name }, value);
+    result["default"] = mod;
+    return result;
+  };
+  Object.defineProperty(exports2, "__esModule", {value: true});
+  var command_1 = require_command();
+  var file_command_1 = require_file_command();
+  var utils_1 = require_utils();
+  var os2 = __importStar(require("os"));
+  var path2 = __importStar(require("path"));
+  var ExitCode;
+  (function(ExitCode2) {
+    ExitCode2[ExitCode2["Success"] = 0] = "Success";
+    ExitCode2[ExitCode2["Failure"] = 1] = "Failure";
+  })(ExitCode = exports2.ExitCode || (exports2.ExitCode = {}));
+  function exportVariable2(name, val) {
+    const convertedVal = utils_1.toCommandValue(val);
+    process.env[name] = convertedVal;
+    const filePath = process.env["GITHUB_ENV"] || "";
+    if (filePath) {
+      const delimiter = "_GitHubActionsFileCommandDelimeter_";
+      const commandValue = `${name}<<${delimiter}${os2.EOL}${convertedVal}${os2.EOL}${delimiter}`;
+      file_command_1.issueCommand("ENV", commandValue);
+    } else {
+      command_1.issueCommand("set-env", {name}, convertedVal);
     }
-    exports2.saveState = saveState;
-    function getState(name) {
-      return process.env[`STATE_${name}`] || "";
-    }
-    exports2.getState = getState;
   }
+  exports2.exportVariable = exportVariable2;
+  function setSecret(secret) {
+    command_1.issueCommand("add-mask", {}, secret);
+  }
+  exports2.setSecret = setSecret;
+  function addPath2(inputPath) {
+    const filePath = process.env["GITHUB_PATH"] || "";
+    if (filePath) {
+      file_command_1.issueCommand("PATH", inputPath);
+    } else {
+      command_1.issueCommand("add-path", {}, inputPath);
+    }
+    process.env["PATH"] = `${inputPath}${path2.delimiter}${process.env["PATH"]}`;
+  }
+  exports2.addPath = addPath2;
+  function getInput4(name, options) {
+    const val = process.env[`INPUT_${name.replace(/ /g, "_").toUpperCase()}`] || "";
+    if (options && options.required && !val) {
+      throw new Error(`Input required and not supplied: ${name}`);
+    }
+    return val.trim();
+  }
+  exports2.getInput = getInput4;
+  function setOutput(name, value) {
+    command_1.issueCommand("set-output", {name}, value);
+  }
+  exports2.setOutput = setOutput;
+  function setCommandEcho(enabled) {
+    command_1.issue("echo", enabled ? "on" : "off");
+  }
+  exports2.setCommandEcho = setCommandEcho;
+  function setFailed2(message) {
+    process.exitCode = ExitCode.Failure;
+    error(message);
+  }
+  exports2.setFailed = setFailed2;
+  function isDebug() {
+    return process.env["RUNNER_DEBUG"] === "1";
+  }
+  exports2.isDebug = isDebug;
+  function debug(message) {
+    command_1.issueCommand("debug", {}, message);
+  }
+  exports2.debug = debug;
+  function error(message) {
+    command_1.issue("error", message instanceof Error ? message.toString() : message);
+  }
+  exports2.error = error;
+  function warning(message) {
+    command_1.issue("warning", message instanceof Error ? message.toString() : message);
+  }
+  exports2.warning = warning;
+  function info3(message) {
+    process.stdout.write(message + os2.EOL);
+  }
+  exports2.info = info3;
+  function startGroup(name) {
+    command_1.issue("group", name);
+  }
+  exports2.startGroup = startGroup;
+  function endGroup() {
+    command_1.issue("endgroup");
+  }
+  exports2.endGroup = endGroup;
+  function group(name, fn) {
+    return __awaiter(this, void 0, void 0, function* () {
+      startGroup(name);
+      let result;
+      try {
+        result = yield fn();
+      } finally {
+        endGroup();
+      }
+      return result;
+    });
+  }
+  exports2.group = group;
+  function saveState(name, value) {
+    command_1.issueCommand("save-state", {name}, value);
+  }
+  exports2.saveState = saveState;
+  function getState(name) {
+    return process.env[`STATE_${name}`] || "";
+  }
+  exports2.getState = getState;
 });
 
 // node_modules/@actions/exec/node_modules/@actions/io/lib/io-util.js
-var require_io_util = __commonJS({
-  "node_modules/@actions/exec/node_modules/@actions/io/lib/io-util.js"(exports2) {
-    "use strict";
-    var __createBinding = exports2 && exports2.__createBinding || (Object.create ? function(o, m, k, k2) {
-      if (k2 === void 0)
-        k2 = k;
-      Object.defineProperty(o, k2, { enumerable: true, get: function() {
-        return m[k];
-      } });
-    } : function(o, m, k, k2) {
-      if (k2 === void 0)
-        k2 = k;
-      o[k2] = m[k];
-    });
-    var __setModuleDefault = exports2 && exports2.__setModuleDefault || (Object.create ? function(o, v) {
-      Object.defineProperty(o, "default", { enumerable: true, value: v });
-    } : function(o, v) {
-      o["default"] = v;
-    });
-    var __importStar = exports2 && exports2.__importStar || function(mod) {
-      if (mod && mod.__esModule)
-        return mod;
-      var result = {};
-      if (mod != null) {
-        for (var k in mod)
-          if (k !== "default" && Object.hasOwnProperty.call(mod, k))
-            __createBinding(result, mod, k);
-      }
-      __setModuleDefault(result, mod);
-      return result;
-    };
-    var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
-      function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve) {
-          resolve(value);
-        });
-      }
-      return new (P || (P = Promise))(function(resolve, reject) {
-        function fulfilled(value) {
-          try {
-            step(generator.next(value));
-          } catch (e) {
-            reject(e);
-          }
-        }
-        function rejected(value) {
-          try {
-            step(generator["throw"](value));
-          } catch (e) {
-            reject(e);
-          }
-        }
-        function step(result) {
-          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
-        }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
+var require_io_util = __commonJS((exports2) => {
+  "use strict";
+  var __createBinding = exports2 && exports2.__createBinding || (Object.create ? function(o, m, k, k2) {
+    if (k2 === void 0)
+      k2 = k;
+    Object.defineProperty(o, k2, {enumerable: true, get: function() {
+      return m[k];
+    }});
+  } : function(o, m, k, k2) {
+    if (k2 === void 0)
+      k2 = k;
+    o[k2] = m[k];
+  });
+  var __setModuleDefault = exports2 && exports2.__setModuleDefault || (Object.create ? function(o, v) {
+    Object.defineProperty(o, "default", {enumerable: true, value: v});
+  } : function(o, v) {
+    o["default"] = v;
+  });
+  var __importStar = exports2 && exports2.__importStar || function(mod) {
+    if (mod && mod.__esModule)
+      return mod;
+    var result = {};
+    if (mod != null) {
+      for (var k in mod)
+        if (k !== "default" && Object.hasOwnProperty.call(mod, k))
+          __createBinding(result, mod, k);
+    }
+    __setModuleDefault(result, mod);
+    return result;
+  };
+  var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+    function adopt(value) {
+      return value instanceof P ? value : new P(function(resolve) {
+        resolve(value);
       });
-    };
-    var _a;
-    Object.defineProperty(exports2, "__esModule", { value: true });
-    exports2.getCmdPath = exports2.tryGetExecutablePath = exports2.isRooted = exports2.isDirectory = exports2.exists = exports2.IS_WINDOWS = exports2.unlink = exports2.symlink = exports2.stat = exports2.rmdir = exports2.rename = exports2.readlink = exports2.readdir = exports2.mkdir = exports2.lstat = exports2.copyFile = exports2.chmod = void 0;
-    var fs2 = __importStar(require("fs"));
-    var path2 = __importStar(require("path"));
-    _a = fs2.promises, exports2.chmod = _a.chmod, exports2.copyFile = _a.copyFile, exports2.lstat = _a.lstat, exports2.mkdir = _a.mkdir, exports2.readdir = _a.readdir, exports2.readlink = _a.readlink, exports2.rename = _a.rename, exports2.rmdir = _a.rmdir, exports2.stat = _a.stat, exports2.symlink = _a.symlink, exports2.unlink = _a.unlink;
-    exports2.IS_WINDOWS = process.platform === "win32";
-    function exists(fsPath) {
-      return __awaiter(this, void 0, void 0, function* () {
+    }
+    return new (P || (P = Promise))(function(resolve, reject) {
+      function fulfilled(value) {
         try {
-          yield exports2.stat(fsPath);
-        } catch (err) {
-          if (err.code === "ENOENT") {
-            return false;
-          }
-          throw err;
+          step(generator.next(value));
+        } catch (e) {
+          reject(e);
         }
-        return true;
-      });
-    }
-    exports2.exists = exists;
-    function isDirectory(fsPath, useStat = false) {
-      return __awaiter(this, void 0, void 0, function* () {
-        const stats = useStat ? yield exports2.stat(fsPath) : yield exports2.lstat(fsPath);
-        return stats.isDirectory();
-      });
-    }
-    exports2.isDirectory = isDirectory;
-    function isRooted(p) {
-      p = normalizeSeparators(p);
-      if (!p) {
-        throw new Error('isRooted() parameter "p" cannot be empty');
       }
-      if (exports2.IS_WINDOWS) {
-        return p.startsWith("\\") || /^[A-Z]:/i.test(p);
+      function rejected(value) {
+        try {
+          step(generator["throw"](value));
+        } catch (e) {
+          reject(e);
+        }
       }
-      return p.startsWith("/");
+      function step(result) {
+        result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+      }
+      step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+  };
+  var _a;
+  Object.defineProperty(exports2, "__esModule", {value: true});
+  exports2.getCmdPath = exports2.tryGetExecutablePath = exports2.isRooted = exports2.isDirectory = exports2.exists = exports2.IS_WINDOWS = exports2.unlink = exports2.symlink = exports2.stat = exports2.rmdir = exports2.rename = exports2.readlink = exports2.readdir = exports2.mkdir = exports2.lstat = exports2.copyFile = exports2.chmod = void 0;
+  var fs2 = __importStar(require("fs"));
+  var path2 = __importStar(require("path"));
+  _a = fs2.promises, exports2.chmod = _a.chmod, exports2.copyFile = _a.copyFile, exports2.lstat = _a.lstat, exports2.mkdir = _a.mkdir, exports2.readdir = _a.readdir, exports2.readlink = _a.readlink, exports2.rename = _a.rename, exports2.rmdir = _a.rmdir, exports2.stat = _a.stat, exports2.symlink = _a.symlink, exports2.unlink = _a.unlink;
+  exports2.IS_WINDOWS = process.platform === "win32";
+  function exists(fsPath) {
+    return __awaiter(this, void 0, void 0, function* () {
+      try {
+        yield exports2.stat(fsPath);
+      } catch (err) {
+        if (err.code === "ENOENT") {
+          return false;
+        }
+        throw err;
+      }
+      return true;
+    });
+  }
+  exports2.exists = exists;
+  function isDirectory(fsPath, useStat = false) {
+    return __awaiter(this, void 0, void 0, function* () {
+      const stats = useStat ? yield exports2.stat(fsPath) : yield exports2.lstat(fsPath);
+      return stats.isDirectory();
+    });
+  }
+  exports2.isDirectory = isDirectory;
+  function isRooted(p) {
+    p = normalizeSeparators(p);
+    if (!p) {
+      throw new Error('isRooted() parameter "p" cannot be empty');
     }
-    exports2.isRooted = isRooted;
-    function tryGetExecutablePath(filePath, extensions) {
-      return __awaiter(this, void 0, void 0, function* () {
-        let stats = void 0;
+    if (exports2.IS_WINDOWS) {
+      return p.startsWith("\\") || /^[A-Z]:/i.test(p);
+    }
+    return p.startsWith("/");
+  }
+  exports2.isRooted = isRooted;
+  function tryGetExecutablePath(filePath, extensions) {
+    return __awaiter(this, void 0, void 0, function* () {
+      let stats = void 0;
+      try {
+        stats = yield exports2.stat(filePath);
+      } catch (err) {
+        if (err.code !== "ENOENT") {
+          console.log(`Unexpected error attempting to determine if executable file exists '${filePath}': ${err}`);
+        }
+      }
+      if (stats && stats.isFile()) {
+        if (exports2.IS_WINDOWS) {
+          const upperExt = path2.extname(filePath).toUpperCase();
+          if (extensions.some((validExt) => validExt.toUpperCase() === upperExt)) {
+            return filePath;
+          }
+        } else {
+          if (isUnixExecutable(stats)) {
+            return filePath;
+          }
+        }
+      }
+      const originalFilePath = filePath;
+      for (const extension of extensions) {
+        filePath = originalFilePath + extension;
+        stats = void 0;
         try {
           stats = yield exports2.stat(filePath);
         } catch (err) {
@@ -407,272 +428,1161 @@ var require_io_util = __commonJS({
         }
         if (stats && stats.isFile()) {
           if (exports2.IS_WINDOWS) {
-            const upperExt = path2.extname(filePath).toUpperCase();
-            if (extensions.some((validExt) => validExt.toUpperCase() === upperExt)) {
-              return filePath;
+            try {
+              const directory = path2.dirname(filePath);
+              const upperName = path2.basename(filePath).toUpperCase();
+              for (const actualName of yield exports2.readdir(directory)) {
+                if (upperName === actualName.toUpperCase()) {
+                  filePath = path2.join(directory, actualName);
+                  break;
+                }
+              }
+            } catch (err) {
+              console.log(`Unexpected error attempting to determine the actual case of the file '${filePath}': ${err}`);
             }
+            return filePath;
           } else {
             if (isUnixExecutable(stats)) {
               return filePath;
             }
           }
         }
-        const originalFilePath = filePath;
-        for (const extension of extensions) {
-          filePath = originalFilePath + extension;
-          stats = void 0;
-          try {
-            stats = yield exports2.stat(filePath);
-          } catch (err) {
-            if (err.code !== "ENOENT") {
-              console.log(`Unexpected error attempting to determine if executable file exists '${filePath}': ${err}`);
-            }
-          }
-          if (stats && stats.isFile()) {
-            if (exports2.IS_WINDOWS) {
-              try {
-                const directory = path2.dirname(filePath);
-                const upperName = path2.basename(filePath).toUpperCase();
-                for (const actualName of yield exports2.readdir(directory)) {
-                  if (upperName === actualName.toUpperCase()) {
-                    filePath = path2.join(directory, actualName);
-                    break;
-                  }
-                }
-              } catch (err) {
-                console.log(`Unexpected error attempting to determine the actual case of the file '${filePath}': ${err}`);
-              }
-              return filePath;
-            } else {
-              if (isUnixExecutable(stats)) {
-                return filePath;
-              }
-            }
-          }
-        }
-        return "";
-      });
-    }
-    exports2.tryGetExecutablePath = tryGetExecutablePath;
-    function normalizeSeparators(p) {
-      p = p || "";
-      if (exports2.IS_WINDOWS) {
-        p = p.replace(/\//g, "\\");
-        return p.replace(/\\\\+/g, "\\");
       }
-      return p.replace(/\/\/+/g, "/");
-    }
-    function isUnixExecutable(stats) {
-      return (stats.mode & 1) > 0 || (stats.mode & 8) > 0 && stats.gid === process.getgid() || (stats.mode & 64) > 0 && stats.uid === process.getuid();
-    }
-    function getCmdPath() {
-      var _a2;
-      return (_a2 = process.env["COMSPEC"]) !== null && _a2 !== void 0 ? _a2 : `cmd.exe`;
-    }
-    exports2.getCmdPath = getCmdPath;
+      return "";
+    });
   }
+  exports2.tryGetExecutablePath = tryGetExecutablePath;
+  function normalizeSeparators(p) {
+    p = p || "";
+    if (exports2.IS_WINDOWS) {
+      p = p.replace(/\//g, "\\");
+      return p.replace(/\\\\+/g, "\\");
+    }
+    return p.replace(/\/\/+/g, "/");
+  }
+  function isUnixExecutable(stats) {
+    return (stats.mode & 1) > 0 || (stats.mode & 8) > 0 && stats.gid === process.getgid() || (stats.mode & 64) > 0 && stats.uid === process.getuid();
+  }
+  function getCmdPath() {
+    var _a2;
+    return (_a2 = process.env["COMSPEC"]) !== null && _a2 !== void 0 ? _a2 : `cmd.exe`;
+  }
+  exports2.getCmdPath = getCmdPath;
 });
 
 // node_modules/@actions/exec/node_modules/@actions/io/lib/io.js
-var require_io = __commonJS({
-  "node_modules/@actions/exec/node_modules/@actions/io/lib/io.js"(exports2) {
-    "use strict";
-    var __createBinding = exports2 && exports2.__createBinding || (Object.create ? function(o, m, k, k2) {
-      if (k2 === void 0)
-        k2 = k;
-      Object.defineProperty(o, k2, { enumerable: true, get: function() {
-        return m[k];
-      } });
-    } : function(o, m, k, k2) {
-      if (k2 === void 0)
-        k2 = k;
-      o[k2] = m[k];
-    });
-    var __setModuleDefault = exports2 && exports2.__setModuleDefault || (Object.create ? function(o, v) {
-      Object.defineProperty(o, "default", { enumerable: true, value: v });
-    } : function(o, v) {
-      o["default"] = v;
-    });
-    var __importStar = exports2 && exports2.__importStar || function(mod) {
-      if (mod && mod.__esModule)
-        return mod;
-      var result = {};
-      if (mod != null) {
-        for (var k in mod)
-          if (k !== "default" && Object.hasOwnProperty.call(mod, k))
-            __createBinding(result, mod, k);
-      }
-      __setModuleDefault(result, mod);
-      return result;
-    };
-    var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
-      function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve) {
-          resolve(value);
-        });
-      }
-      return new (P || (P = Promise))(function(resolve, reject) {
-        function fulfilled(value) {
-          try {
-            step(generator.next(value));
-          } catch (e) {
-            reject(e);
-          }
-        }
-        function rejected(value) {
-          try {
-            step(generator["throw"](value));
-          } catch (e) {
-            reject(e);
-          }
-        }
-        function step(result) {
-          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
-        }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
+var require_io = __commonJS((exports2) => {
+  "use strict";
+  var __createBinding = exports2 && exports2.__createBinding || (Object.create ? function(o, m, k, k2) {
+    if (k2 === void 0)
+      k2 = k;
+    Object.defineProperty(o, k2, {enumerable: true, get: function() {
+      return m[k];
+    }});
+  } : function(o, m, k, k2) {
+    if (k2 === void 0)
+      k2 = k;
+    o[k2] = m[k];
+  });
+  var __setModuleDefault = exports2 && exports2.__setModuleDefault || (Object.create ? function(o, v) {
+    Object.defineProperty(o, "default", {enumerable: true, value: v});
+  } : function(o, v) {
+    o["default"] = v;
+  });
+  var __importStar = exports2 && exports2.__importStar || function(mod) {
+    if (mod && mod.__esModule)
+      return mod;
+    var result = {};
+    if (mod != null) {
+      for (var k in mod)
+        if (k !== "default" && Object.hasOwnProperty.call(mod, k))
+          __createBinding(result, mod, k);
+    }
+    __setModuleDefault(result, mod);
+    return result;
+  };
+  var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+    function adopt(value) {
+      return value instanceof P ? value : new P(function(resolve) {
+        resolve(value);
       });
-    };
-    Object.defineProperty(exports2, "__esModule", { value: true });
-    exports2.findInPath = exports2.which = exports2.mkdirP = exports2.rmRF = exports2.mv = exports2.cp = void 0;
-    var assert_1 = require("assert");
-    var childProcess = __importStar(require("child_process"));
-    var path2 = __importStar(require("path"));
-    var util_1 = require("util");
-    var ioUtil = __importStar(require_io_util());
-    var exec7 = util_1.promisify(childProcess.exec);
-    var execFile = util_1.promisify(childProcess.execFile);
-    function cp(source, dest, options = {}) {
-      return __awaiter(this, void 0, void 0, function* () {
-        const { force, recursive, copySourceDirectory } = readCopyOptions(options);
-        const destStat = (yield ioUtil.exists(dest)) ? yield ioUtil.stat(dest) : null;
-        if (destStat && destStat.isFile() && !force) {
+    }
+    return new (P || (P = Promise))(function(resolve, reject) {
+      function fulfilled(value) {
+        try {
+          step(generator.next(value));
+        } catch (e) {
+          reject(e);
+        }
+      }
+      function rejected(value) {
+        try {
+          step(generator["throw"](value));
+        } catch (e) {
+          reject(e);
+        }
+      }
+      function step(result) {
+        result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+      }
+      step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+  };
+  Object.defineProperty(exports2, "__esModule", {value: true});
+  exports2.findInPath = exports2.which = exports2.mkdirP = exports2.rmRF = exports2.mv = exports2.cp = void 0;
+  var assert_1 = require("assert");
+  var childProcess = __importStar(require("child_process"));
+  var path2 = __importStar(require("path"));
+  var util_1 = require("util");
+  var ioUtil = __importStar(require_io_util());
+  var exec7 = util_1.promisify(childProcess.exec);
+  var execFile = util_1.promisify(childProcess.execFile);
+  function cp(source, dest, options = {}) {
+    return __awaiter(this, void 0, void 0, function* () {
+      const {force, recursive, copySourceDirectory} = readCopyOptions(options);
+      const destStat = (yield ioUtil.exists(dest)) ? yield ioUtil.stat(dest) : null;
+      if (destStat && destStat.isFile() && !force) {
+        return;
+      }
+      const newDest = destStat && destStat.isDirectory() && copySourceDirectory ? path2.join(dest, path2.basename(source)) : dest;
+      if (!(yield ioUtil.exists(source))) {
+        throw new Error(`no such file or directory: ${source}`);
+      }
+      const sourceStat = yield ioUtil.stat(source);
+      if (sourceStat.isDirectory()) {
+        if (!recursive) {
+          throw new Error(`Failed to copy. ${source} is a directory, but tried to copy without recursive flag.`);
+        } else {
+          yield cpDirRecursive(source, newDest, 0, force);
+        }
+      } else {
+        if (path2.relative(source, newDest) === "") {
+          throw new Error(`'${newDest}' and '${source}' are the same file`);
+        }
+        yield copyFile(source, newDest, force);
+      }
+    });
+  }
+  exports2.cp = cp;
+  function mv(source, dest, options = {}) {
+    return __awaiter(this, void 0, void 0, function* () {
+      if (yield ioUtil.exists(dest)) {
+        let destExists = true;
+        if (yield ioUtil.isDirectory(dest)) {
+          dest = path2.join(dest, path2.basename(source));
+          destExists = yield ioUtil.exists(dest);
+        }
+        if (destExists) {
+          if (options.force == null || options.force) {
+            yield rmRF(dest);
+          } else {
+            throw new Error("Destination already exists");
+          }
+        }
+      }
+      yield mkdirP(path2.dirname(dest));
+      yield ioUtil.rename(source, dest);
+    });
+  }
+  exports2.mv = mv;
+  function rmRF(inputPath) {
+    return __awaiter(this, void 0, void 0, function* () {
+      if (ioUtil.IS_WINDOWS) {
+        if (/[*"<>|]/.test(inputPath)) {
+          throw new Error('File path must not contain `*`, `"`, `<`, `>` or `|` on Windows');
+        }
+        try {
+          const cmdPath = ioUtil.getCmdPath();
+          if (yield ioUtil.isDirectory(inputPath, true)) {
+            yield exec7(`${cmdPath} /s /c "rd /s /q "%inputPath%""`, {
+              env: {inputPath}
+            });
+          } else {
+            yield exec7(`${cmdPath} /s /c "del /f /a "%inputPath%""`, {
+              env: {inputPath}
+            });
+          }
+        } catch (err) {
+          if (err.code !== "ENOENT")
+            throw err;
+        }
+        try {
+          yield ioUtil.unlink(inputPath);
+        } catch (err) {
+          if (err.code !== "ENOENT")
+            throw err;
+        }
+      } else {
+        let isDir = false;
+        try {
+          isDir = yield ioUtil.isDirectory(inputPath);
+        } catch (err) {
+          if (err.code !== "ENOENT")
+            throw err;
           return;
         }
-        const newDest = destStat && destStat.isDirectory() && copySourceDirectory ? path2.join(dest, path2.basename(source)) : dest;
-        if (!(yield ioUtil.exists(source))) {
-          throw new Error(`no such file or directory: ${source}`);
+        if (isDir) {
+          yield execFile(`rm`, [`-rf`, `${inputPath}`]);
+        } else {
+          yield ioUtil.unlink(inputPath);
         }
-        const sourceStat = yield ioUtil.stat(source);
-        if (sourceStat.isDirectory()) {
-          if (!recursive) {
-            throw new Error(`Failed to copy. ${source} is a directory, but tried to copy without recursive flag.`);
+      }
+    });
+  }
+  exports2.rmRF = rmRF;
+  function mkdirP(fsPath) {
+    return __awaiter(this, void 0, void 0, function* () {
+      assert_1.ok(fsPath, "a path argument must be provided");
+      yield ioUtil.mkdir(fsPath, {recursive: true});
+    });
+  }
+  exports2.mkdirP = mkdirP;
+  function which2(tool, check) {
+    return __awaiter(this, void 0, void 0, function* () {
+      if (!tool) {
+        throw new Error("parameter 'tool' is required");
+      }
+      if (check) {
+        const result = yield which2(tool, false);
+        if (!result) {
+          if (ioUtil.IS_WINDOWS) {
+            throw new Error(`Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also verify the file has a valid extension for an executable file.`);
           } else {
-            yield cpDirRecursive(source, newDest, 0, force);
-          }
-        } else {
-          if (path2.relative(source, newDest) === "") {
-            throw new Error(`'${newDest}' and '${source}' are the same file`);
-          }
-          yield copyFile(source, newDest, force);
-        }
-      });
-    }
-    exports2.cp = cp;
-    function mv(source, dest, options = {}) {
-      return __awaiter(this, void 0, void 0, function* () {
-        if (yield ioUtil.exists(dest)) {
-          let destExists = true;
-          if (yield ioUtil.isDirectory(dest)) {
-            dest = path2.join(dest, path2.basename(source));
-            destExists = yield ioUtil.exists(dest);
-          }
-          if (destExists) {
-            if (options.force == null || options.force) {
-              yield rmRF(dest);
-            } else {
-              throw new Error("Destination already exists");
-            }
+            throw new Error(`Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also check the file mode to verify the file is executable.`);
           }
         }
-        yield mkdirP(path2.dirname(dest));
-        yield ioUtil.rename(source, dest);
+        return result;
+      }
+      const matches = yield findInPath(tool);
+      if (matches && matches.length > 0) {
+        return matches[0];
+      }
+      return "";
+    });
+  }
+  exports2.which = which2;
+  function findInPath(tool) {
+    return __awaiter(this, void 0, void 0, function* () {
+      if (!tool) {
+        throw new Error("parameter 'tool' is required");
+      }
+      const extensions = [];
+      if (ioUtil.IS_WINDOWS && process.env["PATHEXT"]) {
+        for (const extension of process.env["PATHEXT"].split(path2.delimiter)) {
+          if (extension) {
+            extensions.push(extension);
+          }
+        }
+      }
+      if (ioUtil.isRooted(tool)) {
+        const filePath = yield ioUtil.tryGetExecutablePath(tool, extensions);
+        if (filePath) {
+          return [filePath];
+        }
+        return [];
+      }
+      if (tool.includes(path2.sep)) {
+        return [];
+      }
+      const directories = [];
+      if (process.env.PATH) {
+        for (const p of process.env.PATH.split(path2.delimiter)) {
+          if (p) {
+            directories.push(p);
+          }
+        }
+      }
+      const matches = [];
+      for (const directory of directories) {
+        const filePath = yield ioUtil.tryGetExecutablePath(path2.join(directory, tool), extensions);
+        if (filePath) {
+          matches.push(filePath);
+        }
+      }
+      return matches;
+    });
+  }
+  exports2.findInPath = findInPath;
+  function readCopyOptions(options) {
+    const force = options.force == null ? true : options.force;
+    const recursive = Boolean(options.recursive);
+    const copySourceDirectory = options.copySourceDirectory == null ? true : Boolean(options.copySourceDirectory);
+    return {force, recursive, copySourceDirectory};
+  }
+  function cpDirRecursive(sourceDir, destDir, currentDepth, force) {
+    return __awaiter(this, void 0, void 0, function* () {
+      if (currentDepth >= 255)
+        return;
+      currentDepth++;
+      yield mkdirP(destDir);
+      const files = yield ioUtil.readdir(sourceDir);
+      for (const fileName of files) {
+        const srcFile = `${sourceDir}/${fileName}`;
+        const destFile = `${destDir}/${fileName}`;
+        const srcFileStat = yield ioUtil.lstat(srcFile);
+        if (srcFileStat.isDirectory()) {
+          yield cpDirRecursive(srcFile, destFile, currentDepth, force);
+        } else {
+          yield copyFile(srcFile, destFile, force);
+        }
+      }
+      yield ioUtil.chmod(destDir, (yield ioUtil.stat(sourceDir)).mode);
+    });
+  }
+  function copyFile(srcFile, destFile, force) {
+    return __awaiter(this, void 0, void 0, function* () {
+      if ((yield ioUtil.lstat(srcFile)).isSymbolicLink()) {
+        try {
+          yield ioUtil.lstat(destFile);
+          yield ioUtil.unlink(destFile);
+        } catch (e) {
+          if (e.code === "EPERM") {
+            yield ioUtil.chmod(destFile, "0666");
+            yield ioUtil.unlink(destFile);
+          }
+        }
+        const symlinkFull = yield ioUtil.readlink(srcFile);
+        yield ioUtil.symlink(symlinkFull, destFile, ioUtil.IS_WINDOWS ? "junction" : null);
+      } else if (!(yield ioUtil.exists(destFile)) || force) {
+        yield ioUtil.copyFile(srcFile, destFile);
+      }
+    });
+  }
+});
+
+// node_modules/@actions/exec/lib/toolrunner.js
+var require_toolrunner = __commonJS((exports2) => {
+  "use strict";
+  var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+    function adopt(value) {
+      return value instanceof P ? value : new P(function(resolve) {
+        resolve(value);
       });
     }
-    exports2.mv = mv;
-    function rmRF(inputPath) {
-      return __awaiter(this, void 0, void 0, function* () {
-        if (ioUtil.IS_WINDOWS) {
-          if (/[*"<>|]/.test(inputPath)) {
-            throw new Error('File path must not contain `*`, `"`, `<`, `>` or `|` on Windows');
+    return new (P || (P = Promise))(function(resolve, reject) {
+      function fulfilled(value) {
+        try {
+          step(generator.next(value));
+        } catch (e) {
+          reject(e);
+        }
+      }
+      function rejected(value) {
+        try {
+          step(generator["throw"](value));
+        } catch (e) {
+          reject(e);
+        }
+      }
+      function step(result) {
+        result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+      }
+      step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+  };
+  var __importStar = exports2 && exports2.__importStar || function(mod) {
+    if (mod && mod.__esModule)
+      return mod;
+    var result = {};
+    if (mod != null) {
+      for (var k in mod)
+        if (Object.hasOwnProperty.call(mod, k))
+          result[k] = mod[k];
+    }
+    result["default"] = mod;
+    return result;
+  };
+  Object.defineProperty(exports2, "__esModule", {value: true});
+  var os2 = __importStar(require("os"));
+  var events = __importStar(require("events"));
+  var child = __importStar(require("child_process"));
+  var path2 = __importStar(require("path"));
+  var io2 = __importStar(require_io());
+  var ioUtil = __importStar(require_io_util());
+  var IS_WINDOWS = process.platform === "win32";
+  var ToolRunner = class extends events.EventEmitter {
+    constructor(toolPath, args, options) {
+      super();
+      if (!toolPath) {
+        throw new Error("Parameter 'toolPath' cannot be null or empty.");
+      }
+      this.toolPath = toolPath;
+      this.args = args || [];
+      this.options = options || {};
+    }
+    _debug(message) {
+      if (this.options.listeners && this.options.listeners.debug) {
+        this.options.listeners.debug(message);
+      }
+    }
+    _getCommandString(options, noPrefix) {
+      const toolPath = this._getSpawnFileName();
+      const args = this._getSpawnArgs(options);
+      let cmd = noPrefix ? "" : "[command]";
+      if (IS_WINDOWS) {
+        if (this._isCmdFile()) {
+          cmd += toolPath;
+          for (const a of args) {
+            cmd += ` ${a}`;
           }
-          try {
-            const cmdPath = ioUtil.getCmdPath();
-            if (yield ioUtil.isDirectory(inputPath, true)) {
-              yield exec7(`${cmdPath} /s /c "rd /s /q "%inputPath%""`, {
-                env: { inputPath }
-              });
-            } else {
-              yield exec7(`${cmdPath} /s /c "del /f /a "%inputPath%""`, {
-                env: { inputPath }
-              });
-            }
-          } catch (err) {
-            if (err.code !== "ENOENT")
-              throw err;
-          }
-          try {
-            yield ioUtil.unlink(inputPath);
-          } catch (err) {
-            if (err.code !== "ENOENT")
-              throw err;
+        } else if (options.windowsVerbatimArguments) {
+          cmd += `"${toolPath}"`;
+          for (const a of args) {
+            cmd += ` ${a}`;
           }
         } else {
-          let isDir = false;
-          try {
-            isDir = yield ioUtil.isDirectory(inputPath);
-          } catch (err) {
-            if (err.code !== "ENOENT")
-              throw err;
+          cmd += this._windowsQuoteCmdArg(toolPath);
+          for (const a of args) {
+            cmd += ` ${this._windowsQuoteCmdArg(a)}`;
+          }
+        }
+      } else {
+        cmd += toolPath;
+        for (const a of args) {
+          cmd += ` ${a}`;
+        }
+      }
+      return cmd;
+    }
+    _processLineBuffer(data, strBuffer, onLine) {
+      try {
+        let s = strBuffer + data.toString();
+        let n = s.indexOf(os2.EOL);
+        while (n > -1) {
+          const line = s.substring(0, n);
+          onLine(line);
+          s = s.substring(n + os2.EOL.length);
+          n = s.indexOf(os2.EOL);
+        }
+        strBuffer = s;
+      } catch (err) {
+        this._debug(`error processing line. Failed with error ${err}`);
+      }
+    }
+    _getSpawnFileName() {
+      if (IS_WINDOWS) {
+        if (this._isCmdFile()) {
+          return process.env["COMSPEC"] || "cmd.exe";
+        }
+      }
+      return this.toolPath;
+    }
+    _getSpawnArgs(options) {
+      if (IS_WINDOWS) {
+        if (this._isCmdFile()) {
+          let argline = `/D /S /C "${this._windowsQuoteCmdArg(this.toolPath)}`;
+          for (const a of this.args) {
+            argline += " ";
+            argline += options.windowsVerbatimArguments ? a : this._windowsQuoteCmdArg(a);
+          }
+          argline += '"';
+          return [argline];
+        }
+      }
+      return this.args;
+    }
+    _endsWith(str, end) {
+      return str.endsWith(end);
+    }
+    _isCmdFile() {
+      const upperToolPath = this.toolPath.toUpperCase();
+      return this._endsWith(upperToolPath, ".CMD") || this._endsWith(upperToolPath, ".BAT");
+    }
+    _windowsQuoteCmdArg(arg) {
+      if (!this._isCmdFile()) {
+        return this._uvQuoteCmdArg(arg);
+      }
+      if (!arg) {
+        return '""';
+      }
+      const cmdSpecialChars = [
+        " ",
+        "	",
+        "&",
+        "(",
+        ")",
+        "[",
+        "]",
+        "{",
+        "}",
+        "^",
+        "=",
+        ";",
+        "!",
+        "'",
+        "+",
+        ",",
+        "`",
+        "~",
+        "|",
+        "<",
+        ">",
+        '"'
+      ];
+      let needsQuotes = false;
+      for (const char of arg) {
+        if (cmdSpecialChars.some((x) => x === char)) {
+          needsQuotes = true;
+          break;
+        }
+      }
+      if (!needsQuotes) {
+        return arg;
+      }
+      let reverse = '"';
+      let quoteHit = true;
+      for (let i = arg.length; i > 0; i--) {
+        reverse += arg[i - 1];
+        if (quoteHit && arg[i - 1] === "\\") {
+          reverse += "\\";
+        } else if (arg[i - 1] === '"') {
+          quoteHit = true;
+          reverse += '"';
+        } else {
+          quoteHit = false;
+        }
+      }
+      reverse += '"';
+      return reverse.split("").reverse().join("");
+    }
+    _uvQuoteCmdArg(arg) {
+      if (!arg) {
+        return '""';
+      }
+      if (!arg.includes(" ") && !arg.includes("	") && !arg.includes('"')) {
+        return arg;
+      }
+      if (!arg.includes('"') && !arg.includes("\\")) {
+        return `"${arg}"`;
+      }
+      let reverse = '"';
+      let quoteHit = true;
+      for (let i = arg.length; i > 0; i--) {
+        reverse += arg[i - 1];
+        if (quoteHit && arg[i - 1] === "\\") {
+          reverse += "\\";
+        } else if (arg[i - 1] === '"') {
+          quoteHit = true;
+          reverse += "\\";
+        } else {
+          quoteHit = false;
+        }
+      }
+      reverse += '"';
+      return reverse.split("").reverse().join("");
+    }
+    _cloneExecOptions(options) {
+      options = options || {};
+      const result = {
+        cwd: options.cwd || process.cwd(),
+        env: options.env || process.env,
+        silent: options.silent || false,
+        windowsVerbatimArguments: options.windowsVerbatimArguments || false,
+        failOnStdErr: options.failOnStdErr || false,
+        ignoreReturnCode: options.ignoreReturnCode || false,
+        delay: options.delay || 1e4
+      };
+      result.outStream = options.outStream || process.stdout;
+      result.errStream = options.errStream || process.stderr;
+      return result;
+    }
+    _getSpawnOptions(options, toolPath) {
+      options = options || {};
+      const result = {};
+      result.cwd = options.cwd;
+      result.env = options.env;
+      result["windowsVerbatimArguments"] = options.windowsVerbatimArguments || this._isCmdFile();
+      if (options.windowsVerbatimArguments) {
+        result.argv0 = `"${toolPath}"`;
+      }
+      return result;
+    }
+    exec() {
+      return __awaiter(this, void 0, void 0, function* () {
+        if (!ioUtil.isRooted(this.toolPath) && (this.toolPath.includes("/") || IS_WINDOWS && this.toolPath.includes("\\"))) {
+          this.toolPath = path2.resolve(process.cwd(), this.options.cwd || process.cwd(), this.toolPath);
+        }
+        this.toolPath = yield io2.which(this.toolPath, true);
+        return new Promise((resolve, reject) => {
+          this._debug(`exec tool: ${this.toolPath}`);
+          this._debug("arguments:");
+          for (const arg of this.args) {
+            this._debug(`   ${arg}`);
+          }
+          const optionsNonNull = this._cloneExecOptions(this.options);
+          if (!optionsNonNull.silent && optionsNonNull.outStream) {
+            optionsNonNull.outStream.write(this._getCommandString(optionsNonNull) + os2.EOL);
+          }
+          const state = new ExecState(optionsNonNull, this.toolPath);
+          state.on("debug", (message) => {
+            this._debug(message);
+          });
+          const fileName = this._getSpawnFileName();
+          const cp = child.spawn(fileName, this._getSpawnArgs(optionsNonNull), this._getSpawnOptions(this.options, fileName));
+          const stdbuffer = "";
+          if (cp.stdout) {
+            cp.stdout.on("data", (data) => {
+              if (this.options.listeners && this.options.listeners.stdout) {
+                this.options.listeners.stdout(data);
+              }
+              if (!optionsNonNull.silent && optionsNonNull.outStream) {
+                optionsNonNull.outStream.write(data);
+              }
+              this._processLineBuffer(data, stdbuffer, (line) => {
+                if (this.options.listeners && this.options.listeners.stdline) {
+                  this.options.listeners.stdline(line);
+                }
+              });
+            });
+          }
+          const errbuffer = "";
+          if (cp.stderr) {
+            cp.stderr.on("data", (data) => {
+              state.processStderr = true;
+              if (this.options.listeners && this.options.listeners.stderr) {
+                this.options.listeners.stderr(data);
+              }
+              if (!optionsNonNull.silent && optionsNonNull.errStream && optionsNonNull.outStream) {
+                const s = optionsNonNull.failOnStdErr ? optionsNonNull.errStream : optionsNonNull.outStream;
+                s.write(data);
+              }
+              this._processLineBuffer(data, errbuffer, (line) => {
+                if (this.options.listeners && this.options.listeners.errline) {
+                  this.options.listeners.errline(line);
+                }
+              });
+            });
+          }
+          cp.on("error", (err) => {
+            state.processError = err.message;
+            state.processExited = true;
+            state.processClosed = true;
+            state.CheckComplete();
+          });
+          cp.on("exit", (code) => {
+            state.processExitCode = code;
+            state.processExited = true;
+            this._debug(`Exit code ${code} received from tool '${this.toolPath}'`);
+            state.CheckComplete();
+          });
+          cp.on("close", (code) => {
+            state.processExitCode = code;
+            state.processExited = true;
+            state.processClosed = true;
+            this._debug(`STDIO streams have closed for tool '${this.toolPath}'`);
+            state.CheckComplete();
+          });
+          state.on("done", (error, exitCode) => {
+            if (stdbuffer.length > 0) {
+              this.emit("stdline", stdbuffer);
+            }
+            if (errbuffer.length > 0) {
+              this.emit("errline", errbuffer);
+            }
+            cp.removeAllListeners();
+            if (error) {
+              reject(error);
+            } else {
+              resolve(exitCode);
+            }
+          });
+          if (this.options.input) {
+            if (!cp.stdin) {
+              throw new Error("child process missing stdin");
+            }
+            cp.stdin.end(this.options.input);
+          }
+        });
+      });
+    }
+  };
+  exports2.ToolRunner = ToolRunner;
+  function argStringToArray(argString) {
+    const args = [];
+    let inQuotes = false;
+    let escaped = false;
+    let arg = "";
+    function append(c) {
+      if (escaped && c !== '"') {
+        arg += "\\";
+      }
+      arg += c;
+      escaped = false;
+    }
+    for (let i = 0; i < argString.length; i++) {
+      const c = argString.charAt(i);
+      if (c === '"') {
+        if (!escaped) {
+          inQuotes = !inQuotes;
+        } else {
+          append(c);
+        }
+        continue;
+      }
+      if (c === "\\" && escaped) {
+        append(c);
+        continue;
+      }
+      if (c === "\\" && inQuotes) {
+        escaped = true;
+        continue;
+      }
+      if (c === " " && !inQuotes) {
+        if (arg.length > 0) {
+          args.push(arg);
+          arg = "";
+        }
+        continue;
+      }
+      append(c);
+    }
+    if (arg.length > 0) {
+      args.push(arg.trim());
+    }
+    return args;
+  }
+  exports2.argStringToArray = argStringToArray;
+  var ExecState = class extends events.EventEmitter {
+    constructor(options, toolPath) {
+      super();
+      this.processClosed = false;
+      this.processError = "";
+      this.processExitCode = 0;
+      this.processExited = false;
+      this.processStderr = false;
+      this.delay = 1e4;
+      this.done = false;
+      this.timeout = null;
+      if (!toolPath) {
+        throw new Error("toolPath must not be empty");
+      }
+      this.options = options;
+      this.toolPath = toolPath;
+      if (options.delay) {
+        this.delay = options.delay;
+      }
+    }
+    CheckComplete() {
+      if (this.done) {
+        return;
+      }
+      if (this.processClosed) {
+        this._setResult();
+      } else if (this.processExited) {
+        this.timeout = setTimeout(ExecState.HandleTimeout, this.delay, this);
+      }
+    }
+    _debug(message) {
+      this.emit("debug", message);
+    }
+    _setResult() {
+      let error;
+      if (this.processExited) {
+        if (this.processError) {
+          error = new Error(`There was an error when attempting to execute the process '${this.toolPath}'. This may indicate the process failed to start. Error: ${this.processError}`);
+        } else if (this.processExitCode !== 0 && !this.options.ignoreReturnCode) {
+          error = new Error(`The process '${this.toolPath}' failed with exit code ${this.processExitCode}`);
+        } else if (this.processStderr && this.options.failOnStdErr) {
+          error = new Error(`The process '${this.toolPath}' failed because one or more lines were written to the STDERR stream`);
+        }
+      }
+      if (this.timeout) {
+        clearTimeout(this.timeout);
+        this.timeout = null;
+      }
+      this.done = true;
+      this.emit("done", error, this.processExitCode);
+    }
+    static HandleTimeout(state) {
+      if (state.done) {
+        return;
+      }
+      if (!state.processClosed && state.processExited) {
+        const message = `The STDIO streams did not close within ${state.delay / 1e3} seconds of the exit event from process '${state.toolPath}'. This may indicate a child process inherited the STDIO streams and has not yet exited.`;
+        state._debug(message);
+      }
+      state._setResult();
+    }
+  };
+});
+
+// node_modules/@actions/exec/lib/exec.js
+var require_exec = __commonJS((exports2) => {
+  "use strict";
+  var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+    function adopt(value) {
+      return value instanceof P ? value : new P(function(resolve) {
+        resolve(value);
+      });
+    }
+    return new (P || (P = Promise))(function(resolve, reject) {
+      function fulfilled(value) {
+        try {
+          step(generator.next(value));
+        } catch (e) {
+          reject(e);
+        }
+      }
+      function rejected(value) {
+        try {
+          step(generator["throw"](value));
+        } catch (e) {
+          reject(e);
+        }
+      }
+      function step(result) {
+        result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+      }
+      step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+  };
+  var __importStar = exports2 && exports2.__importStar || function(mod) {
+    if (mod && mod.__esModule)
+      return mod;
+    var result = {};
+    if (mod != null) {
+      for (var k in mod)
+        if (Object.hasOwnProperty.call(mod, k))
+          result[k] = mod[k];
+    }
+    result["default"] = mod;
+    return result;
+  };
+  Object.defineProperty(exports2, "__esModule", {value: true});
+  var tr = __importStar(require_toolrunner());
+  function exec7(commandLine, args, options) {
+    return __awaiter(this, void 0, void 0, function* () {
+      const commandArgs = tr.argStringToArray(commandLine);
+      if (commandArgs.length === 0) {
+        throw new Error(`Parameter 'commandLine' cannot be null or empty.`);
+      }
+      const toolPath = commandArgs[0];
+      args = commandArgs.slice(1).concat(args || []);
+      const runner = new tr.ToolRunner(toolPath, args, options);
+      return runner.exec();
+    });
+  }
+  exports2.exec = exec7;
+});
+
+// node_modules/@actions/io/lib/io-util.js
+var require_io_util2 = __commonJS((exports2) => {
+  "use strict";
+  var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+    function adopt(value) {
+      return value instanceof P ? value : new P(function(resolve) {
+        resolve(value);
+      });
+    }
+    return new (P || (P = Promise))(function(resolve, reject) {
+      function fulfilled(value) {
+        try {
+          step(generator.next(value));
+        } catch (e) {
+          reject(e);
+        }
+      }
+      function rejected(value) {
+        try {
+          step(generator["throw"](value));
+        } catch (e) {
+          reject(e);
+        }
+      }
+      function step(result) {
+        result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+      }
+      step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+  };
+  var _a;
+  Object.defineProperty(exports2, "__esModule", {value: true});
+  var assert_1 = require("assert");
+  var fs2 = require("fs");
+  var path2 = require("path");
+  _a = fs2.promises, exports2.chmod = _a.chmod, exports2.copyFile = _a.copyFile, exports2.lstat = _a.lstat, exports2.mkdir = _a.mkdir, exports2.readdir = _a.readdir, exports2.readlink = _a.readlink, exports2.rename = _a.rename, exports2.rmdir = _a.rmdir, exports2.stat = _a.stat, exports2.symlink = _a.symlink, exports2.unlink = _a.unlink;
+  exports2.IS_WINDOWS = process.platform === "win32";
+  function exists(fsPath) {
+    return __awaiter(this, void 0, void 0, function* () {
+      try {
+        yield exports2.stat(fsPath);
+      } catch (err) {
+        if (err.code === "ENOENT") {
+          return false;
+        }
+        throw err;
+      }
+      return true;
+    });
+  }
+  exports2.exists = exists;
+  function isDirectory(fsPath, useStat = false) {
+    return __awaiter(this, void 0, void 0, function* () {
+      const stats = useStat ? yield exports2.stat(fsPath) : yield exports2.lstat(fsPath);
+      return stats.isDirectory();
+    });
+  }
+  exports2.isDirectory = isDirectory;
+  function isRooted(p) {
+    p = normalizeSeparators(p);
+    if (!p) {
+      throw new Error('isRooted() parameter "p" cannot be empty');
+    }
+    if (exports2.IS_WINDOWS) {
+      return p.startsWith("\\") || /^[A-Z]:/i.test(p);
+    }
+    return p.startsWith("/");
+  }
+  exports2.isRooted = isRooted;
+  function mkdirP(fsPath, maxDepth = 1e3, depth = 1) {
+    return __awaiter(this, void 0, void 0, function* () {
+      assert_1.ok(fsPath, "a path argument must be provided");
+      fsPath = path2.resolve(fsPath);
+      if (depth >= maxDepth)
+        return exports2.mkdir(fsPath);
+      try {
+        yield exports2.mkdir(fsPath);
+        return;
+      } catch (err) {
+        switch (err.code) {
+          case "ENOENT": {
+            yield mkdirP(path2.dirname(fsPath), maxDepth, depth + 1);
+            yield exports2.mkdir(fsPath);
             return;
           }
-          if (isDir) {
-            yield execFile(`rm`, [`-rf`, `${inputPath}`]);
-          } else {
-            yield ioUtil.unlink(inputPath);
+          default: {
+            let stats;
+            try {
+              stats = yield exports2.stat(fsPath);
+            } catch (err2) {
+              throw err;
+            }
+            if (!stats.isDirectory())
+              throw err;
           }
         }
-      });
-    }
-    exports2.rmRF = rmRF;
-    function mkdirP(fsPath) {
-      return __awaiter(this, void 0, void 0, function* () {
-        assert_1.ok(fsPath, "a path argument must be provided");
-        yield ioUtil.mkdir(fsPath, { recursive: true });
-      });
-    }
-    exports2.mkdirP = mkdirP;
-    function which2(tool, check) {
-      return __awaiter(this, void 0, void 0, function* () {
-        if (!tool) {
-          throw new Error("parameter 'tool' is required");
+      }
+    });
+  }
+  exports2.mkdirP = mkdirP;
+  function tryGetExecutablePath(filePath, extensions) {
+    return __awaiter(this, void 0, void 0, function* () {
+      let stats = void 0;
+      try {
+        stats = yield exports2.stat(filePath);
+      } catch (err) {
+        if (err.code !== "ENOENT") {
+          console.log(`Unexpected error attempting to determine if executable file exists '${filePath}': ${err}`);
         }
-        if (check) {
-          const result = yield which2(tool, false);
-          if (!result) {
-            if (ioUtil.IS_WINDOWS) {
-              throw new Error(`Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also verify the file has a valid extension for an executable file.`);
-            } else {
-              throw new Error(`Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also check the file mode to verify the file is executable.`);
+      }
+      if (stats && stats.isFile()) {
+        if (exports2.IS_WINDOWS) {
+          const upperExt = path2.extname(filePath).toUpperCase();
+          if (extensions.some((validExt) => validExt.toUpperCase() === upperExt)) {
+            return filePath;
+          }
+        } else {
+          if (isUnixExecutable(stats)) {
+            return filePath;
+          }
+        }
+      }
+      const originalFilePath = filePath;
+      for (const extension of extensions) {
+        filePath = originalFilePath + extension;
+        stats = void 0;
+        try {
+          stats = yield exports2.stat(filePath);
+        } catch (err) {
+          if (err.code !== "ENOENT") {
+            console.log(`Unexpected error attempting to determine if executable file exists '${filePath}': ${err}`);
+          }
+        }
+        if (stats && stats.isFile()) {
+          if (exports2.IS_WINDOWS) {
+            try {
+              const directory = path2.dirname(filePath);
+              const upperName = path2.basename(filePath).toUpperCase();
+              for (const actualName of yield exports2.readdir(directory)) {
+                if (upperName === actualName.toUpperCase()) {
+                  filePath = path2.join(directory, actualName);
+                  break;
+                }
+              }
+            } catch (err) {
+              console.log(`Unexpected error attempting to determine the actual case of the file '${filePath}': ${err}`);
+            }
+            return filePath;
+          } else {
+            if (isUnixExecutable(stats)) {
+              return filePath;
             }
           }
-          return result;
         }
-        const matches = yield findInPath(tool);
-        if (matches && matches.length > 0) {
-          return matches[0];
-        }
-        return "";
+      }
+      return "";
+    });
+  }
+  exports2.tryGetExecutablePath = tryGetExecutablePath;
+  function normalizeSeparators(p) {
+    p = p || "";
+    if (exports2.IS_WINDOWS) {
+      p = p.replace(/\//g, "\\");
+      return p.replace(/\\\\+/g, "\\");
+    }
+    return p.replace(/\/\/+/g, "/");
+  }
+  function isUnixExecutable(stats) {
+    return (stats.mode & 1) > 0 || (stats.mode & 8) > 0 && stats.gid === process.getgid() || (stats.mode & 64) > 0 && stats.uid === process.getuid();
+  }
+});
+
+// node_modules/@actions/io/lib/io.js
+var require_io2 = __commonJS((exports2) => {
+  "use strict";
+  var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+    function adopt(value) {
+      return value instanceof P ? value : new P(function(resolve) {
+        resolve(value);
       });
     }
-    exports2.which = which2;
-    function findInPath(tool) {
-      return __awaiter(this, void 0, void 0, function* () {
-        if (!tool) {
-          throw new Error("parameter 'tool' is required");
+    return new (P || (P = Promise))(function(resolve, reject) {
+      function fulfilled(value) {
+        try {
+          step(generator.next(value));
+        } catch (e) {
+          reject(e);
         }
+      }
+      function rejected(value) {
+        try {
+          step(generator["throw"](value));
+        } catch (e) {
+          reject(e);
+        }
+      }
+      function step(result) {
+        result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+      }
+      step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+  };
+  Object.defineProperty(exports2, "__esModule", {value: true});
+  var childProcess = require("child_process");
+  var path2 = require("path");
+  var util_1 = require("util");
+  var ioUtil = require_io_util2();
+  var exec7 = util_1.promisify(childProcess.exec);
+  function cp(source, dest, options = {}) {
+    return __awaiter(this, void 0, void 0, function* () {
+      const {force, recursive} = readCopyOptions(options);
+      const destStat = (yield ioUtil.exists(dest)) ? yield ioUtil.stat(dest) : null;
+      if (destStat && destStat.isFile() && !force) {
+        return;
+      }
+      const newDest = destStat && destStat.isDirectory() ? path2.join(dest, path2.basename(source)) : dest;
+      if (!(yield ioUtil.exists(source))) {
+        throw new Error(`no such file or directory: ${source}`);
+      }
+      const sourceStat = yield ioUtil.stat(source);
+      if (sourceStat.isDirectory()) {
+        if (!recursive) {
+          throw new Error(`Failed to copy. ${source} is a directory, but tried to copy without recursive flag.`);
+        } else {
+          yield cpDirRecursive(source, newDest, 0, force);
+        }
+      } else {
+        if (path2.relative(source, newDest) === "") {
+          throw new Error(`'${newDest}' and '${source}' are the same file`);
+        }
+        yield copyFile(source, newDest, force);
+      }
+    });
+  }
+  exports2.cp = cp;
+  function mv(source, dest, options = {}) {
+    return __awaiter(this, void 0, void 0, function* () {
+      if (yield ioUtil.exists(dest)) {
+        let destExists = true;
+        if (yield ioUtil.isDirectory(dest)) {
+          dest = path2.join(dest, path2.basename(source));
+          destExists = yield ioUtil.exists(dest);
+        }
+        if (destExists) {
+          if (options.force == null || options.force) {
+            yield rmRF(dest);
+          } else {
+            throw new Error("Destination already exists");
+          }
+        }
+      }
+      yield mkdirP(path2.dirname(dest));
+      yield ioUtil.rename(source, dest);
+    });
+  }
+  exports2.mv = mv;
+  function rmRF(inputPath) {
+    return __awaiter(this, void 0, void 0, function* () {
+      if (ioUtil.IS_WINDOWS) {
+        try {
+          if (yield ioUtil.isDirectory(inputPath, true)) {
+            yield exec7(`rd /s /q "${inputPath}"`);
+          } else {
+            yield exec7(`del /f /a "${inputPath}"`);
+          }
+        } catch (err) {
+          if (err.code !== "ENOENT")
+            throw err;
+        }
+        try {
+          yield ioUtil.unlink(inputPath);
+        } catch (err) {
+          if (err.code !== "ENOENT")
+            throw err;
+        }
+      } else {
+        let isDir = false;
+        try {
+          isDir = yield ioUtil.isDirectory(inputPath);
+        } catch (err) {
+          if (err.code !== "ENOENT")
+            throw err;
+          return;
+        }
+        if (isDir) {
+          yield exec7(`rm -rf "${inputPath}"`);
+        } else {
+          yield ioUtil.unlink(inputPath);
+        }
+      }
+    });
+  }
+  exports2.rmRF = rmRF;
+  function mkdirP(fsPath) {
+    return __awaiter(this, void 0, void 0, function* () {
+      yield ioUtil.mkdirP(fsPath);
+    });
+  }
+  exports2.mkdirP = mkdirP;
+  function which2(tool, check) {
+    return __awaiter(this, void 0, void 0, function* () {
+      if (!tool) {
+        throw new Error("parameter 'tool' is required");
+      }
+      if (check) {
+        const result = yield which2(tool, false);
+        if (!result) {
+          if (ioUtil.IS_WINDOWS) {
+            throw new Error(`Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also verify the file has a valid extension for an executable file.`);
+          } else {
+            throw new Error(`Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also check the file mode to verify the file is executable.`);
+          }
+        }
+      }
+      try {
         const extensions = [];
-        if (ioUtil.IS_WINDOWS && process.env["PATHEXT"]) {
-          for (const extension of process.env["PATHEXT"].split(path2.delimiter)) {
+        if (ioUtil.IS_WINDOWS && process.env.PATHEXT) {
+          for (const extension of process.env.PATHEXT.split(path2.delimiter)) {
             if (extension) {
               extensions.push(extension);
             }
@@ -681,12 +1591,12 @@ var require_io = __commonJS({
         if (ioUtil.isRooted(tool)) {
           const filePath = yield ioUtil.tryGetExecutablePath(tool, extensions);
           if (filePath) {
-            return [filePath];
+            return filePath;
           }
-          return [];
+          return "";
         }
-        if (tool.includes(path2.sep)) {
-          return [];
+        if (tool.includes("/") || ioUtil.IS_WINDOWS && tool.includes("\\")) {
+          return "";
         }
         const directories = [];
         if (process.env.PATH) {
@@ -696,985 +1606,62 @@ var require_io = __commonJS({
             }
           }
         }
-        const matches = [];
         for (const directory of directories) {
-          const filePath = yield ioUtil.tryGetExecutablePath(path2.join(directory, tool), extensions);
+          const filePath = yield ioUtil.tryGetExecutablePath(directory + path2.sep + tool, extensions);
           if (filePath) {
-            matches.push(filePath);
-          }
-        }
-        return matches;
-      });
-    }
-    exports2.findInPath = findInPath;
-    function readCopyOptions(options) {
-      const force = options.force == null ? true : options.force;
-      const recursive = Boolean(options.recursive);
-      const copySourceDirectory = options.copySourceDirectory == null ? true : Boolean(options.copySourceDirectory);
-      return { force, recursive, copySourceDirectory };
-    }
-    function cpDirRecursive(sourceDir, destDir, currentDepth, force) {
-      return __awaiter(this, void 0, void 0, function* () {
-        if (currentDepth >= 255)
-          return;
-        currentDepth++;
-        yield mkdirP(destDir);
-        const files = yield ioUtil.readdir(sourceDir);
-        for (const fileName of files) {
-          const srcFile = `${sourceDir}/${fileName}`;
-          const destFile = `${destDir}/${fileName}`;
-          const srcFileStat = yield ioUtil.lstat(srcFile);
-          if (srcFileStat.isDirectory()) {
-            yield cpDirRecursive(srcFile, destFile, currentDepth, force);
-          } else {
-            yield copyFile(srcFile, destFile, force);
-          }
-        }
-        yield ioUtil.chmod(destDir, (yield ioUtil.stat(sourceDir)).mode);
-      });
-    }
-    function copyFile(srcFile, destFile, force) {
-      return __awaiter(this, void 0, void 0, function* () {
-        if ((yield ioUtil.lstat(srcFile)).isSymbolicLink()) {
-          try {
-            yield ioUtil.lstat(destFile);
-            yield ioUtil.unlink(destFile);
-          } catch (e) {
-            if (e.code === "EPERM") {
-              yield ioUtil.chmod(destFile, "0666");
-              yield ioUtil.unlink(destFile);
-            }
-          }
-          const symlinkFull = yield ioUtil.readlink(srcFile);
-          yield ioUtil.symlink(symlinkFull, destFile, ioUtil.IS_WINDOWS ? "junction" : null);
-        } else if (!(yield ioUtil.exists(destFile)) || force) {
-          yield ioUtil.copyFile(srcFile, destFile);
-        }
-      });
-    }
-  }
-});
-
-// node_modules/@actions/exec/lib/toolrunner.js
-var require_toolrunner = __commonJS({
-  "node_modules/@actions/exec/lib/toolrunner.js"(exports2) {
-    "use strict";
-    var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
-      function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve) {
-          resolve(value);
-        });
-      }
-      return new (P || (P = Promise))(function(resolve, reject) {
-        function fulfilled(value) {
-          try {
-            step(generator.next(value));
-          } catch (e) {
-            reject(e);
-          }
-        }
-        function rejected(value) {
-          try {
-            step(generator["throw"](value));
-          } catch (e) {
-            reject(e);
-          }
-        }
-        function step(result) {
-          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
-        }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-      });
-    };
-    var __importStar = exports2 && exports2.__importStar || function(mod) {
-      if (mod && mod.__esModule)
-        return mod;
-      var result = {};
-      if (mod != null) {
-        for (var k in mod)
-          if (Object.hasOwnProperty.call(mod, k))
-            result[k] = mod[k];
-      }
-      result["default"] = mod;
-      return result;
-    };
-    Object.defineProperty(exports2, "__esModule", { value: true });
-    var os2 = __importStar(require("os"));
-    var events = __importStar(require("events"));
-    var child = __importStar(require("child_process"));
-    var path2 = __importStar(require("path"));
-    var io2 = __importStar(require_io());
-    var ioUtil = __importStar(require_io_util());
-    var IS_WINDOWS = process.platform === "win32";
-    var ToolRunner = class extends events.EventEmitter {
-      constructor(toolPath, args, options) {
-        super();
-        if (!toolPath) {
-          throw new Error("Parameter 'toolPath' cannot be null or empty.");
-        }
-        this.toolPath = toolPath;
-        this.args = args || [];
-        this.options = options || {};
-      }
-      _debug(message) {
-        if (this.options.listeners && this.options.listeners.debug) {
-          this.options.listeners.debug(message);
-        }
-      }
-      _getCommandString(options, noPrefix) {
-        const toolPath = this._getSpawnFileName();
-        const args = this._getSpawnArgs(options);
-        let cmd = noPrefix ? "" : "[command]";
-        if (IS_WINDOWS) {
-          if (this._isCmdFile()) {
-            cmd += toolPath;
-            for (const a of args) {
-              cmd += ` ${a}`;
-            }
-          } else if (options.windowsVerbatimArguments) {
-            cmd += `"${toolPath}"`;
-            for (const a of args) {
-              cmd += ` ${a}`;
-            }
-          } else {
-            cmd += this._windowsQuoteCmdArg(toolPath);
-            for (const a of args) {
-              cmd += ` ${this._windowsQuoteCmdArg(a)}`;
-            }
-          }
-        } else {
-          cmd += toolPath;
-          for (const a of args) {
-            cmd += ` ${a}`;
-          }
-        }
-        return cmd;
-      }
-      _processLineBuffer(data, strBuffer, onLine) {
-        try {
-          let s = strBuffer + data.toString();
-          let n = s.indexOf(os2.EOL);
-          while (n > -1) {
-            const line = s.substring(0, n);
-            onLine(line);
-            s = s.substring(n + os2.EOL.length);
-            n = s.indexOf(os2.EOL);
-          }
-          strBuffer = s;
-        } catch (err) {
-          this._debug(`error processing line. Failed with error ${err}`);
-        }
-      }
-      _getSpawnFileName() {
-        if (IS_WINDOWS) {
-          if (this._isCmdFile()) {
-            return process.env["COMSPEC"] || "cmd.exe";
-          }
-        }
-        return this.toolPath;
-      }
-      _getSpawnArgs(options) {
-        if (IS_WINDOWS) {
-          if (this._isCmdFile()) {
-            let argline = `/D /S /C "${this._windowsQuoteCmdArg(this.toolPath)}`;
-            for (const a of this.args) {
-              argline += " ";
-              argline += options.windowsVerbatimArguments ? a : this._windowsQuoteCmdArg(a);
-            }
-            argline += '"';
-            return [argline];
-          }
-        }
-        return this.args;
-      }
-      _endsWith(str, end) {
-        return str.endsWith(end);
-      }
-      _isCmdFile() {
-        const upperToolPath = this.toolPath.toUpperCase();
-        return this._endsWith(upperToolPath, ".CMD") || this._endsWith(upperToolPath, ".BAT");
-      }
-      _windowsQuoteCmdArg(arg) {
-        if (!this._isCmdFile()) {
-          return this._uvQuoteCmdArg(arg);
-        }
-        if (!arg) {
-          return '""';
-        }
-        const cmdSpecialChars = [
-          " ",
-          "	",
-          "&",
-          "(",
-          ")",
-          "[",
-          "]",
-          "{",
-          "}",
-          "^",
-          "=",
-          ";",
-          "!",
-          "'",
-          "+",
-          ",",
-          "`",
-          "~",
-          "|",
-          "<",
-          ">",
-          '"'
-        ];
-        let needsQuotes = false;
-        for (const char of arg) {
-          if (cmdSpecialChars.some((x) => x === char)) {
-            needsQuotes = true;
-            break;
-          }
-        }
-        if (!needsQuotes) {
-          return arg;
-        }
-        let reverse = '"';
-        let quoteHit = true;
-        for (let i = arg.length; i > 0; i--) {
-          reverse += arg[i - 1];
-          if (quoteHit && arg[i - 1] === "\\") {
-            reverse += "\\";
-          } else if (arg[i - 1] === '"') {
-            quoteHit = true;
-            reverse += '"';
-          } else {
-            quoteHit = false;
-          }
-        }
-        reverse += '"';
-        return reverse.split("").reverse().join("");
-      }
-      _uvQuoteCmdArg(arg) {
-        if (!arg) {
-          return '""';
-        }
-        if (!arg.includes(" ") && !arg.includes("	") && !arg.includes('"')) {
-          return arg;
-        }
-        if (!arg.includes('"') && !arg.includes("\\")) {
-          return `"${arg}"`;
-        }
-        let reverse = '"';
-        let quoteHit = true;
-        for (let i = arg.length; i > 0; i--) {
-          reverse += arg[i - 1];
-          if (quoteHit && arg[i - 1] === "\\") {
-            reverse += "\\";
-          } else if (arg[i - 1] === '"') {
-            quoteHit = true;
-            reverse += "\\";
-          } else {
-            quoteHit = false;
-          }
-        }
-        reverse += '"';
-        return reverse.split("").reverse().join("");
-      }
-      _cloneExecOptions(options) {
-        options = options || {};
-        const result = {
-          cwd: options.cwd || process.cwd(),
-          env: options.env || process.env,
-          silent: options.silent || false,
-          windowsVerbatimArguments: options.windowsVerbatimArguments || false,
-          failOnStdErr: options.failOnStdErr || false,
-          ignoreReturnCode: options.ignoreReturnCode || false,
-          delay: options.delay || 1e4
-        };
-        result.outStream = options.outStream || process.stdout;
-        result.errStream = options.errStream || process.stderr;
-        return result;
-      }
-      _getSpawnOptions(options, toolPath) {
-        options = options || {};
-        const result = {};
-        result.cwd = options.cwd;
-        result.env = options.env;
-        result["windowsVerbatimArguments"] = options.windowsVerbatimArguments || this._isCmdFile();
-        if (options.windowsVerbatimArguments) {
-          result.argv0 = `"${toolPath}"`;
-        }
-        return result;
-      }
-      exec() {
-        return __awaiter(this, void 0, void 0, function* () {
-          if (!ioUtil.isRooted(this.toolPath) && (this.toolPath.includes("/") || IS_WINDOWS && this.toolPath.includes("\\"))) {
-            this.toolPath = path2.resolve(process.cwd(), this.options.cwd || process.cwd(), this.toolPath);
-          }
-          this.toolPath = yield io2.which(this.toolPath, true);
-          return new Promise((resolve, reject) => {
-            this._debug(`exec tool: ${this.toolPath}`);
-            this._debug("arguments:");
-            for (const arg of this.args) {
-              this._debug(`   ${arg}`);
-            }
-            const optionsNonNull = this._cloneExecOptions(this.options);
-            if (!optionsNonNull.silent && optionsNonNull.outStream) {
-              optionsNonNull.outStream.write(this._getCommandString(optionsNonNull) + os2.EOL);
-            }
-            const state = new ExecState(optionsNonNull, this.toolPath);
-            state.on("debug", (message) => {
-              this._debug(message);
-            });
-            const fileName = this._getSpawnFileName();
-            const cp = child.spawn(fileName, this._getSpawnArgs(optionsNonNull), this._getSpawnOptions(this.options, fileName));
-            const stdbuffer = "";
-            if (cp.stdout) {
-              cp.stdout.on("data", (data) => {
-                if (this.options.listeners && this.options.listeners.stdout) {
-                  this.options.listeners.stdout(data);
-                }
-                if (!optionsNonNull.silent && optionsNonNull.outStream) {
-                  optionsNonNull.outStream.write(data);
-                }
-                this._processLineBuffer(data, stdbuffer, (line) => {
-                  if (this.options.listeners && this.options.listeners.stdline) {
-                    this.options.listeners.stdline(line);
-                  }
-                });
-              });
-            }
-            const errbuffer = "";
-            if (cp.stderr) {
-              cp.stderr.on("data", (data) => {
-                state.processStderr = true;
-                if (this.options.listeners && this.options.listeners.stderr) {
-                  this.options.listeners.stderr(data);
-                }
-                if (!optionsNonNull.silent && optionsNonNull.errStream && optionsNonNull.outStream) {
-                  const s = optionsNonNull.failOnStdErr ? optionsNonNull.errStream : optionsNonNull.outStream;
-                  s.write(data);
-                }
-                this._processLineBuffer(data, errbuffer, (line) => {
-                  if (this.options.listeners && this.options.listeners.errline) {
-                    this.options.listeners.errline(line);
-                  }
-                });
-              });
-            }
-            cp.on("error", (err) => {
-              state.processError = err.message;
-              state.processExited = true;
-              state.processClosed = true;
-              state.CheckComplete();
-            });
-            cp.on("exit", (code) => {
-              state.processExitCode = code;
-              state.processExited = true;
-              this._debug(`Exit code ${code} received from tool '${this.toolPath}'`);
-              state.CheckComplete();
-            });
-            cp.on("close", (code) => {
-              state.processExitCode = code;
-              state.processExited = true;
-              state.processClosed = true;
-              this._debug(`STDIO streams have closed for tool '${this.toolPath}'`);
-              state.CheckComplete();
-            });
-            state.on("done", (error, exitCode) => {
-              if (stdbuffer.length > 0) {
-                this.emit("stdline", stdbuffer);
-              }
-              if (errbuffer.length > 0) {
-                this.emit("errline", errbuffer);
-              }
-              cp.removeAllListeners();
-              if (error) {
-                reject(error);
-              } else {
-                resolve(exitCode);
-              }
-            });
-            if (this.options.input) {
-              if (!cp.stdin) {
-                throw new Error("child process missing stdin");
-              }
-              cp.stdin.end(this.options.input);
-            }
-          });
-        });
-      }
-    };
-    exports2.ToolRunner = ToolRunner;
-    function argStringToArray(argString) {
-      const args = [];
-      let inQuotes = false;
-      let escaped = false;
-      let arg = "";
-      function append(c) {
-        if (escaped && c !== '"') {
-          arg += "\\";
-        }
-        arg += c;
-        escaped = false;
-      }
-      for (let i = 0; i < argString.length; i++) {
-        const c = argString.charAt(i);
-        if (c === '"') {
-          if (!escaped) {
-            inQuotes = !inQuotes;
-          } else {
-            append(c);
-          }
-          continue;
-        }
-        if (c === "\\" && escaped) {
-          append(c);
-          continue;
-        }
-        if (c === "\\" && inQuotes) {
-          escaped = true;
-          continue;
-        }
-        if (c === " " && !inQuotes) {
-          if (arg.length > 0) {
-            args.push(arg);
-            arg = "";
-          }
-          continue;
-        }
-        append(c);
-      }
-      if (arg.length > 0) {
-        args.push(arg.trim());
-      }
-      return args;
-    }
-    exports2.argStringToArray = argStringToArray;
-    var ExecState = class extends events.EventEmitter {
-      constructor(options, toolPath) {
-        super();
-        this.processClosed = false;
-        this.processError = "";
-        this.processExitCode = 0;
-        this.processExited = false;
-        this.processStderr = false;
-        this.delay = 1e4;
-        this.done = false;
-        this.timeout = null;
-        if (!toolPath) {
-          throw new Error("toolPath must not be empty");
-        }
-        this.options = options;
-        this.toolPath = toolPath;
-        if (options.delay) {
-          this.delay = options.delay;
-        }
-      }
-      CheckComplete() {
-        if (this.done) {
-          return;
-        }
-        if (this.processClosed) {
-          this._setResult();
-        } else if (this.processExited) {
-          this.timeout = setTimeout(ExecState.HandleTimeout, this.delay, this);
-        }
-      }
-      _debug(message) {
-        this.emit("debug", message);
-      }
-      _setResult() {
-        let error;
-        if (this.processExited) {
-          if (this.processError) {
-            error = new Error(`There was an error when attempting to execute the process '${this.toolPath}'. This may indicate the process failed to start. Error: ${this.processError}`);
-          } else if (this.processExitCode !== 0 && !this.options.ignoreReturnCode) {
-            error = new Error(`The process '${this.toolPath}' failed with exit code ${this.processExitCode}`);
-          } else if (this.processStderr && this.options.failOnStdErr) {
-            error = new Error(`The process '${this.toolPath}' failed because one or more lines were written to the STDERR stream`);
-          }
-        }
-        if (this.timeout) {
-          clearTimeout(this.timeout);
-          this.timeout = null;
-        }
-        this.done = true;
-        this.emit("done", error, this.processExitCode);
-      }
-      static HandleTimeout(state) {
-        if (state.done) {
-          return;
-        }
-        if (!state.processClosed && state.processExited) {
-          const message = `The STDIO streams did not close within ${state.delay / 1e3} seconds of the exit event from process '${state.toolPath}'. This may indicate a child process inherited the STDIO streams and has not yet exited.`;
-          state._debug(message);
-        }
-        state._setResult();
-      }
-    };
-  }
-});
-
-// node_modules/@actions/exec/lib/exec.js
-var require_exec = __commonJS({
-  "node_modules/@actions/exec/lib/exec.js"(exports2) {
-    "use strict";
-    var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
-      function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve) {
-          resolve(value);
-        });
-      }
-      return new (P || (P = Promise))(function(resolve, reject) {
-        function fulfilled(value) {
-          try {
-            step(generator.next(value));
-          } catch (e) {
-            reject(e);
-          }
-        }
-        function rejected(value) {
-          try {
-            step(generator["throw"](value));
-          } catch (e) {
-            reject(e);
-          }
-        }
-        function step(result) {
-          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
-        }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-      });
-    };
-    var __importStar = exports2 && exports2.__importStar || function(mod) {
-      if (mod && mod.__esModule)
-        return mod;
-      var result = {};
-      if (mod != null) {
-        for (var k in mod)
-          if (Object.hasOwnProperty.call(mod, k))
-            result[k] = mod[k];
-      }
-      result["default"] = mod;
-      return result;
-    };
-    Object.defineProperty(exports2, "__esModule", { value: true });
-    var tr = __importStar(require_toolrunner());
-    function exec7(commandLine, args, options) {
-      return __awaiter(this, void 0, void 0, function* () {
-        const commandArgs = tr.argStringToArray(commandLine);
-        if (commandArgs.length === 0) {
-          throw new Error(`Parameter 'commandLine' cannot be null or empty.`);
-        }
-        const toolPath = commandArgs[0];
-        args = commandArgs.slice(1).concat(args || []);
-        const runner = new tr.ToolRunner(toolPath, args, options);
-        return runner.exec();
-      });
-    }
-    exports2.exec = exec7;
-  }
-});
-
-// node_modules/@actions/io/lib/io-util.js
-var require_io_util2 = __commonJS({
-  "node_modules/@actions/io/lib/io-util.js"(exports2) {
-    "use strict";
-    var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
-      function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve) {
-          resolve(value);
-        });
-      }
-      return new (P || (P = Promise))(function(resolve, reject) {
-        function fulfilled(value) {
-          try {
-            step(generator.next(value));
-          } catch (e) {
-            reject(e);
-          }
-        }
-        function rejected(value) {
-          try {
-            step(generator["throw"](value));
-          } catch (e) {
-            reject(e);
-          }
-        }
-        function step(result) {
-          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
-        }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-      });
-    };
-    var _a;
-    Object.defineProperty(exports2, "__esModule", { value: true });
-    var assert_1 = require("assert");
-    var fs2 = require("fs");
-    var path2 = require("path");
-    _a = fs2.promises, exports2.chmod = _a.chmod, exports2.copyFile = _a.copyFile, exports2.lstat = _a.lstat, exports2.mkdir = _a.mkdir, exports2.readdir = _a.readdir, exports2.readlink = _a.readlink, exports2.rename = _a.rename, exports2.rmdir = _a.rmdir, exports2.stat = _a.stat, exports2.symlink = _a.symlink, exports2.unlink = _a.unlink;
-    exports2.IS_WINDOWS = process.platform === "win32";
-    function exists(fsPath) {
-      return __awaiter(this, void 0, void 0, function* () {
-        try {
-          yield exports2.stat(fsPath);
-        } catch (err) {
-          if (err.code === "ENOENT") {
-            return false;
-          }
-          throw err;
-        }
-        return true;
-      });
-    }
-    exports2.exists = exists;
-    function isDirectory(fsPath, useStat = false) {
-      return __awaiter(this, void 0, void 0, function* () {
-        const stats = useStat ? yield exports2.stat(fsPath) : yield exports2.lstat(fsPath);
-        return stats.isDirectory();
-      });
-    }
-    exports2.isDirectory = isDirectory;
-    function isRooted(p) {
-      p = normalizeSeparators(p);
-      if (!p) {
-        throw new Error('isRooted() parameter "p" cannot be empty');
-      }
-      if (exports2.IS_WINDOWS) {
-        return p.startsWith("\\") || /^[A-Z]:/i.test(p);
-      }
-      return p.startsWith("/");
-    }
-    exports2.isRooted = isRooted;
-    function mkdirP(fsPath, maxDepth = 1e3, depth = 1) {
-      return __awaiter(this, void 0, void 0, function* () {
-        assert_1.ok(fsPath, "a path argument must be provided");
-        fsPath = path2.resolve(fsPath);
-        if (depth >= maxDepth)
-          return exports2.mkdir(fsPath);
-        try {
-          yield exports2.mkdir(fsPath);
-          return;
-        } catch (err) {
-          switch (err.code) {
-            case "ENOENT": {
-              yield mkdirP(path2.dirname(fsPath), maxDepth, depth + 1);
-              yield exports2.mkdir(fsPath);
-              return;
-            }
-            default: {
-              let stats;
-              try {
-                stats = yield exports2.stat(fsPath);
-              } catch (err2) {
-                throw err;
-              }
-              if (!stats.isDirectory())
-                throw err;
-            }
-          }
-        }
-      });
-    }
-    exports2.mkdirP = mkdirP;
-    function tryGetExecutablePath(filePath, extensions) {
-      return __awaiter(this, void 0, void 0, function* () {
-        let stats = void 0;
-        try {
-          stats = yield exports2.stat(filePath);
-        } catch (err) {
-          if (err.code !== "ENOENT") {
-            console.log(`Unexpected error attempting to determine if executable file exists '${filePath}': ${err}`);
-          }
-        }
-        if (stats && stats.isFile()) {
-          if (exports2.IS_WINDOWS) {
-            const upperExt = path2.extname(filePath).toUpperCase();
-            if (extensions.some((validExt) => validExt.toUpperCase() === upperExt)) {
-              return filePath;
-            }
-          } else {
-            if (isUnixExecutable(stats)) {
-              return filePath;
-            }
-          }
-        }
-        const originalFilePath = filePath;
-        for (const extension of extensions) {
-          filePath = originalFilePath + extension;
-          stats = void 0;
-          try {
-            stats = yield exports2.stat(filePath);
-          } catch (err) {
-            if (err.code !== "ENOENT") {
-              console.log(`Unexpected error attempting to determine if executable file exists '${filePath}': ${err}`);
-            }
-          }
-          if (stats && stats.isFile()) {
-            if (exports2.IS_WINDOWS) {
-              try {
-                const directory = path2.dirname(filePath);
-                const upperName = path2.basename(filePath).toUpperCase();
-                for (const actualName of yield exports2.readdir(directory)) {
-                  if (upperName === actualName.toUpperCase()) {
-                    filePath = path2.join(directory, actualName);
-                    break;
-                  }
-                }
-              } catch (err) {
-                console.log(`Unexpected error attempting to determine the actual case of the file '${filePath}': ${err}`);
-              }
-              return filePath;
-            } else {
-              if (isUnixExecutable(stats)) {
-                return filePath;
-              }
-            }
+            return filePath;
           }
         }
         return "";
-      });
-    }
-    exports2.tryGetExecutablePath = tryGetExecutablePath;
-    function normalizeSeparators(p) {
-      p = p || "";
-      if (exports2.IS_WINDOWS) {
-        p = p.replace(/\//g, "\\");
-        return p.replace(/\\\\+/g, "\\");
+      } catch (err) {
+        throw new Error(`which failed with message ${err.message}`);
       }
-      return p.replace(/\/\/+/g, "/");
-    }
-    function isUnixExecutable(stats) {
-      return (stats.mode & 1) > 0 || (stats.mode & 8) > 0 && stats.gid === process.getgid() || (stats.mode & 64) > 0 && stats.uid === process.getuid();
-    }
+    });
   }
-});
-
-// node_modules/@actions/io/lib/io.js
-var require_io2 = __commonJS({
-  "node_modules/@actions/io/lib/io.js"(exports2) {
-    "use strict";
-    var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
-      function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve) {
-          resolve(value);
-        });
+  exports2.which = which2;
+  function readCopyOptions(options) {
+    const force = options.force == null ? true : options.force;
+    const recursive = Boolean(options.recursive);
+    return {force, recursive};
+  }
+  function cpDirRecursive(sourceDir, destDir, currentDepth, force) {
+    return __awaiter(this, void 0, void 0, function* () {
+      if (currentDepth >= 255)
+        return;
+      currentDepth++;
+      yield mkdirP(destDir);
+      const files = yield ioUtil.readdir(sourceDir);
+      for (const fileName of files) {
+        const srcFile = `${sourceDir}/${fileName}`;
+        const destFile = `${destDir}/${fileName}`;
+        const srcFileStat = yield ioUtil.lstat(srcFile);
+        if (srcFileStat.isDirectory()) {
+          yield cpDirRecursive(srcFile, destFile, currentDepth, force);
+        } else {
+          yield copyFile(srcFile, destFile, force);
+        }
       }
-      return new (P || (P = Promise))(function(resolve, reject) {
-        function fulfilled(value) {
-          try {
-            step(generator.next(value));
-          } catch (e) {
-            reject(e);
-          }
-        }
-        function rejected(value) {
-          try {
-            step(generator["throw"](value));
-          } catch (e) {
-            reject(e);
-          }
-        }
-        function step(result) {
-          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
-        }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-      });
-    };
-    Object.defineProperty(exports2, "__esModule", { value: true });
-    var childProcess = require("child_process");
-    var path2 = require("path");
-    var util_1 = require("util");
-    var ioUtil = require_io_util2();
-    var exec7 = util_1.promisify(childProcess.exec);
-    function cp(source, dest, options = {}) {
-      return __awaiter(this, void 0, void 0, function* () {
-        const { force, recursive } = readCopyOptions(options);
-        const destStat = (yield ioUtil.exists(dest)) ? yield ioUtil.stat(dest) : null;
-        if (destStat && destStat.isFile() && !force) {
-          return;
-        }
-        const newDest = destStat && destStat.isDirectory() ? path2.join(dest, path2.basename(source)) : dest;
-        if (!(yield ioUtil.exists(source))) {
-          throw new Error(`no such file or directory: ${source}`);
-        }
-        const sourceStat = yield ioUtil.stat(source);
-        if (sourceStat.isDirectory()) {
-          if (!recursive) {
-            throw new Error(`Failed to copy. ${source} is a directory, but tried to copy without recursive flag.`);
-          } else {
-            yield cpDirRecursive(source, newDest, 0, force);
-          }
-        } else {
-          if (path2.relative(source, newDest) === "") {
-            throw new Error(`'${newDest}' and '${source}' are the same file`);
-          }
-          yield copyFile(source, newDest, force);
-        }
-      });
-    }
-    exports2.cp = cp;
-    function mv(source, dest, options = {}) {
-      return __awaiter(this, void 0, void 0, function* () {
-        if (yield ioUtil.exists(dest)) {
-          let destExists = true;
-          if (yield ioUtil.isDirectory(dest)) {
-            dest = path2.join(dest, path2.basename(source));
-            destExists = yield ioUtil.exists(dest);
-          }
-          if (destExists) {
-            if (options.force == null || options.force) {
-              yield rmRF(dest);
-            } else {
-              throw new Error("Destination already exists");
-            }
-          }
-        }
-        yield mkdirP(path2.dirname(dest));
-        yield ioUtil.rename(source, dest);
-      });
-    }
-    exports2.mv = mv;
-    function rmRF(inputPath) {
-      return __awaiter(this, void 0, void 0, function* () {
-        if (ioUtil.IS_WINDOWS) {
-          try {
-            if (yield ioUtil.isDirectory(inputPath, true)) {
-              yield exec7(`rd /s /q "${inputPath}"`);
-            } else {
-              yield exec7(`del /f /a "${inputPath}"`);
-            }
-          } catch (err) {
-            if (err.code !== "ENOENT")
-              throw err;
-          }
-          try {
-            yield ioUtil.unlink(inputPath);
-          } catch (err) {
-            if (err.code !== "ENOENT")
-              throw err;
-          }
-        } else {
-          let isDir = false;
-          try {
-            isDir = yield ioUtil.isDirectory(inputPath);
-          } catch (err) {
-            if (err.code !== "ENOENT")
-              throw err;
-            return;
-          }
-          if (isDir) {
-            yield exec7(`rm -rf "${inputPath}"`);
-          } else {
-            yield ioUtil.unlink(inputPath);
-          }
-        }
-      });
-    }
-    exports2.rmRF = rmRF;
-    function mkdirP(fsPath) {
-      return __awaiter(this, void 0, void 0, function* () {
-        yield ioUtil.mkdirP(fsPath);
-      });
-    }
-    exports2.mkdirP = mkdirP;
-    function which2(tool, check) {
-      return __awaiter(this, void 0, void 0, function* () {
-        if (!tool) {
-          throw new Error("parameter 'tool' is required");
-        }
-        if (check) {
-          const result = yield which2(tool, false);
-          if (!result) {
-            if (ioUtil.IS_WINDOWS) {
-              throw new Error(`Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also verify the file has a valid extension for an executable file.`);
-            } else {
-              throw new Error(`Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also check the file mode to verify the file is executable.`);
-            }
-          }
-        }
+      yield ioUtil.chmod(destDir, (yield ioUtil.stat(sourceDir)).mode);
+    });
+  }
+  function copyFile(srcFile, destFile, force) {
+    return __awaiter(this, void 0, void 0, function* () {
+      if ((yield ioUtil.lstat(srcFile)).isSymbolicLink()) {
         try {
-          const extensions = [];
-          if (ioUtil.IS_WINDOWS && process.env.PATHEXT) {
-            for (const extension of process.env.PATHEXT.split(path2.delimiter)) {
-              if (extension) {
-                extensions.push(extension);
-              }
-            }
-          }
-          if (ioUtil.isRooted(tool)) {
-            const filePath = yield ioUtil.tryGetExecutablePath(tool, extensions);
-            if (filePath) {
-              return filePath;
-            }
-            return "";
-          }
-          if (tool.includes("/") || ioUtil.IS_WINDOWS && tool.includes("\\")) {
-            return "";
-          }
-          const directories = [];
-          if (process.env.PATH) {
-            for (const p of process.env.PATH.split(path2.delimiter)) {
-              if (p) {
-                directories.push(p);
-              }
-            }
-          }
-          for (const directory of directories) {
-            const filePath = yield ioUtil.tryGetExecutablePath(directory + path2.sep + tool, extensions);
-            if (filePath) {
-              return filePath;
-            }
-          }
-          return "";
-        } catch (err) {
-          throw new Error(`which failed with message ${err.message}`);
-        }
-      });
-    }
-    exports2.which = which2;
-    function readCopyOptions(options) {
-      const force = options.force == null ? true : options.force;
-      const recursive = Boolean(options.recursive);
-      return { force, recursive };
-    }
-    function cpDirRecursive(sourceDir, destDir, currentDepth, force) {
-      return __awaiter(this, void 0, void 0, function* () {
-        if (currentDepth >= 255)
-          return;
-        currentDepth++;
-        yield mkdirP(destDir);
-        const files = yield ioUtil.readdir(sourceDir);
-        for (const fileName of files) {
-          const srcFile = `${sourceDir}/${fileName}`;
-          const destFile = `${destDir}/${fileName}`;
-          const srcFileStat = yield ioUtil.lstat(srcFile);
-          if (srcFileStat.isDirectory()) {
-            yield cpDirRecursive(srcFile, destFile, currentDepth, force);
-          } else {
-            yield copyFile(srcFile, destFile, force);
-          }
-        }
-        yield ioUtil.chmod(destDir, (yield ioUtil.stat(sourceDir)).mode);
-      });
-    }
-    function copyFile(srcFile, destFile, force) {
-      return __awaiter(this, void 0, void 0, function* () {
-        if ((yield ioUtil.lstat(srcFile)).isSymbolicLink()) {
-          try {
-            yield ioUtil.lstat(destFile);
+          yield ioUtil.lstat(destFile);
+          yield ioUtil.unlink(destFile);
+        } catch (e) {
+          if (e.code === "EPERM") {
+            yield ioUtil.chmod(destFile, "0666");
             yield ioUtil.unlink(destFile);
-          } catch (e) {
-            if (e.code === "EPERM") {
-              yield ioUtil.chmod(destFile, "0666");
-              yield ioUtil.unlink(destFile);
-            }
           }
-          const symlinkFull = yield ioUtil.readlink(srcFile);
-          yield ioUtil.symlink(symlinkFull, destFile, ioUtil.IS_WINDOWS ? "junction" : null);
-        } else if (!(yield ioUtil.exists(destFile)) || force) {
-          yield ioUtil.copyFile(srcFile, destFile);
         }
-      });
-    }
+        const symlinkFull = yield ioUtil.readlink(srcFile);
+        yield ioUtil.symlink(symlinkFull, destFile, ioUtil.IS_WINDOWS ? "junction" : null);
+      } else if (!(yield ioUtil.exists(destFile)) || force) {
+        yield ioUtil.copyFile(srcFile, destFile);
+      }
+    });
   }
 });
 
@@ -1707,7 +1694,7 @@ async function setupAsdf() {
   core.addPath(`${asdfDir}/bin`);
   core.addPath(`${asdfDir}/shims`);
   core.info(`Cloning asdf into ASDF_DIR: ${asdfDir}`);
-  const branch = core.getInput("asdf_branch", { required: true });
+  const branch = core.getInput("asdf_branch", {required: true});
   await exec.exec("git", [
     "clone",
     "--depth",
@@ -1744,7 +1731,7 @@ async function pluginList() {
 }
 async function pluginsAdd() {
   await setupAsdf();
-  let toolVersions = core2.getInput("tool_versions", { required: false });
+  let toolVersions = core2.getInput("tool_versions", {required: false});
   if (toolVersions) {
     await fs.promises.writeFile(".tool-versions", toolVersions, {
       encoding: "utf8"
@@ -1768,12 +1755,12 @@ async function pluginsAdd() {
 
 // lib/install/index.ts
 async function toolsInstall() {
-  const dir = core3.getInput("directory", { required: false });
+  const dir = core3.getInput("directory", {required: false});
   if (dir) {
     process.chdir(dir);
   }
   await pluginsAdd();
-  const before = core3.getInput("before_install", { required: false });
+  const before = core3.getInput("before_install", {required: false});
   if (before) {
     await exec5.exec("bash", ["-c", before]);
   }

--- a/lib/install/index.ts
+++ b/lib/install/index.ts
@@ -3,6 +3,12 @@ import * as exec from "@actions/exec";
 import { pluginsAdd } from "../plugins-add";
 
 export async function toolsInstall(): Promise<void> {
+
+  const dir = core.getInput("directory", { required: false });
+  if (dir) {
+    process.chdir(dir)
+  }
+
   await pluginsAdd();
 
   const before = core.getInput("before_install", { required: false });

--- a/lib/install/index.ts
+++ b/lib/install/index.ts
@@ -3,10 +3,9 @@ import * as exec from "@actions/exec";
 import { pluginsAdd } from "../plugins-add";
 
 export async function toolsInstall(): Promise<void> {
-
   const dir = core.getInput("directory", { required: false });
   if (dir) {
-    process.chdir(dir)
+    process.chdir(dir);
   }
 
   await pluginsAdd();

--- a/plugin-test/main.js
+++ b/plugin-test/main.js
@@ -1,427 +1,403 @@
 var __create = Object.create;
 var __defProp = Object.defineProperty;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __getOwnPropNames = Object.getOwnPropertyNames;
 var __getProtoOf = Object.getPrototypeOf;
 var __hasOwnProp = Object.prototype.hasOwnProperty;
-var __getOwnPropNames = Object.getOwnPropertyNames;
-var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
-var __markAsModule = (target) => __defProp(target, "__esModule", {value: true});
-var __commonJS = (callback, module2) => () => {
-  if (!module2) {
-    module2 = {exports: {}};
-    callback(module2.exports, module2);
-  }
-  return module2.exports;
+var __markAsModule = (target) => __defProp(target, "__esModule", { value: true });
+var __commonJS = (cb, mod) => function __require() {
+  return mod || (0, cb[Object.keys(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports;
 };
-var __exportStar = (target, module2, desc) => {
-  __markAsModule(target);
+var __reExport = (target, module2, desc) => {
   if (module2 && typeof module2 === "object" || typeof module2 === "function") {
     for (let key of __getOwnPropNames(module2))
       if (!__hasOwnProp.call(target, key) && key !== "default")
-        __defProp(target, key, {get: () => module2[key], enumerable: !(desc = __getOwnPropDesc(module2, key)) || desc.enumerable});
+        __defProp(target, key, { get: () => module2[key], enumerable: !(desc = __getOwnPropDesc(module2, key)) || desc.enumerable });
   }
   return target;
 };
 var __toModule = (module2) => {
-  if (module2 && module2.__esModule)
-    return module2;
-  return __exportStar(__defProp(module2 != null ? __create(__getProtoOf(module2)) : {}, "default", {value: module2, enumerable: true}), module2);
+  return __reExport(__markAsModule(__defProp(module2 != null ? __create(__getProtoOf(module2)) : {}, "default", module2 && module2.__esModule && "default" in module2 ? { get: () => module2.default, enumerable: true } : { value: module2, enumerable: true })), module2);
 };
 
 // node_modules/@actions/core/lib/utils.js
-var require_utils = __commonJS((exports2) => {
-  "use strict";
-  Object.defineProperty(exports2, "__esModule", {value: true});
-  function toCommandValue(input) {
-    if (input === null || input === void 0) {
-      return "";
-    } else if (typeof input === "string" || input instanceof String) {
-      return input;
+var require_utils = __commonJS({
+  "node_modules/@actions/core/lib/utils.js"(exports2) {
+    "use strict";
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    function toCommandValue(input) {
+      if (input === null || input === void 0) {
+        return "";
+      } else if (typeof input === "string" || input instanceof String) {
+        return input;
+      }
+      return JSON.stringify(input);
     }
-    return JSON.stringify(input);
+    exports2.toCommandValue = toCommandValue;
   }
-  exports2.toCommandValue = toCommandValue;
 });
 
 // node_modules/@actions/core/lib/command.js
-var require_command = __commonJS((exports2) => {
-  "use strict";
-  var __importStar = exports2 && exports2.__importStar || function(mod) {
-    if (mod && mod.__esModule)
-      return mod;
-    var result = {};
-    if (mod != null) {
-      for (var k in mod)
-        if (Object.hasOwnProperty.call(mod, k))
-          result[k] = mod[k];
-    }
-    result["default"] = mod;
-    return result;
-  };
-  Object.defineProperty(exports2, "__esModule", {value: true});
-  var os2 = __importStar(require("os"));
-  var utils_1 = require_utils();
-  function issueCommand(command, properties, message) {
-    const cmd = new Command(command, properties, message);
-    process.stdout.write(cmd.toString() + os2.EOL);
-  }
-  exports2.issueCommand = issueCommand;
-  function issue(name, message = "") {
-    issueCommand(name, {}, message);
-  }
-  exports2.issue = issue;
-  var CMD_STRING = "::";
-  var Command = class {
-    constructor(command, properties, message) {
-      if (!command) {
-        command = "missing.command";
+var require_command = __commonJS({
+  "node_modules/@actions/core/lib/command.js"(exports2) {
+    "use strict";
+    var __importStar = exports2 && exports2.__importStar || function(mod) {
+      if (mod && mod.__esModule)
+        return mod;
+      var result = {};
+      if (mod != null) {
+        for (var k in mod)
+          if (Object.hasOwnProperty.call(mod, k))
+            result[k] = mod[k];
       }
-      this.command = command;
-      this.properties = properties;
-      this.message = message;
+      result["default"] = mod;
+      return result;
+    };
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    var os2 = __importStar(require("os"));
+    var utils_1 = require_utils();
+    function issueCommand(command, properties, message) {
+      const cmd = new Command(command, properties, message);
+      process.stdout.write(cmd.toString() + os2.EOL);
     }
-    toString() {
-      let cmdStr = CMD_STRING + this.command;
-      if (this.properties && Object.keys(this.properties).length > 0) {
-        cmdStr += " ";
-        let first = true;
-        for (const key in this.properties) {
-          if (this.properties.hasOwnProperty(key)) {
-            const val = this.properties[key];
-            if (val) {
-              if (first) {
-                first = false;
-              } else {
-                cmdStr += ",";
+    exports2.issueCommand = issueCommand;
+    function issue(name, message = "") {
+      issueCommand(name, {}, message);
+    }
+    exports2.issue = issue;
+    var CMD_STRING = "::";
+    var Command = class {
+      constructor(command, properties, message) {
+        if (!command) {
+          command = "missing.command";
+        }
+        this.command = command;
+        this.properties = properties;
+        this.message = message;
+      }
+      toString() {
+        let cmdStr = CMD_STRING + this.command;
+        if (this.properties && Object.keys(this.properties).length > 0) {
+          cmdStr += " ";
+          let first = true;
+          for (const key in this.properties) {
+            if (this.properties.hasOwnProperty(key)) {
+              const val = this.properties[key];
+              if (val) {
+                if (first) {
+                  first = false;
+                } else {
+                  cmdStr += ",";
+                }
+                cmdStr += `${key}=${escapeProperty(val)}`;
               }
-              cmdStr += `${key}=${escapeProperty(val)}`;
             }
           }
         }
+        cmdStr += `${CMD_STRING}${escapeData(this.message)}`;
+        return cmdStr;
       }
-      cmdStr += `${CMD_STRING}${escapeData(this.message)}`;
-      return cmdStr;
+    };
+    function escapeData(s) {
+      return utils_1.toCommandValue(s).replace(/%/g, "%25").replace(/\r/g, "%0D").replace(/\n/g, "%0A");
     }
-  };
-  function escapeData(s) {
-    return utils_1.toCommandValue(s).replace(/%/g, "%25").replace(/\r/g, "%0D").replace(/\n/g, "%0A");
-  }
-  function escapeProperty(s) {
-    return utils_1.toCommandValue(s).replace(/%/g, "%25").replace(/\r/g, "%0D").replace(/\n/g, "%0A").replace(/:/g, "%3A").replace(/,/g, "%2C");
+    function escapeProperty(s) {
+      return utils_1.toCommandValue(s).replace(/%/g, "%25").replace(/\r/g, "%0D").replace(/\n/g, "%0A").replace(/:/g, "%3A").replace(/,/g, "%2C");
+    }
   }
 });
 
 // node_modules/@actions/core/lib/file-command.js
-var require_file_command = __commonJS((exports2) => {
-  "use strict";
-  var __importStar = exports2 && exports2.__importStar || function(mod) {
-    if (mod && mod.__esModule)
-      return mod;
-    var result = {};
-    if (mod != null) {
-      for (var k in mod)
-        if (Object.hasOwnProperty.call(mod, k))
-          result[k] = mod[k];
+var require_file_command = __commonJS({
+  "node_modules/@actions/core/lib/file-command.js"(exports2) {
+    "use strict";
+    var __importStar = exports2 && exports2.__importStar || function(mod) {
+      if (mod && mod.__esModule)
+        return mod;
+      var result = {};
+      if (mod != null) {
+        for (var k in mod)
+          if (Object.hasOwnProperty.call(mod, k))
+            result[k] = mod[k];
+      }
+      result["default"] = mod;
+      return result;
+    };
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    var fs = __importStar(require("fs"));
+    var os2 = __importStar(require("os"));
+    var utils_1 = require_utils();
+    function issueCommand(command, message) {
+      const filePath = process.env[`GITHUB_${command}`];
+      if (!filePath) {
+        throw new Error(`Unable to find environment variable for file command ${command}`);
+      }
+      if (!fs.existsSync(filePath)) {
+        throw new Error(`Missing file at path: ${filePath}`);
+      }
+      fs.appendFileSync(filePath, `${utils_1.toCommandValue(message)}${os2.EOL}`, {
+        encoding: "utf8"
+      });
     }
-    result["default"] = mod;
-    return result;
-  };
-  Object.defineProperty(exports2, "__esModule", {value: true});
-  var fs = __importStar(require("fs"));
-  var os2 = __importStar(require("os"));
-  var utils_1 = require_utils();
-  function issueCommand(command, message) {
-    const filePath = process.env[`GITHUB_${command}`];
-    if (!filePath) {
-      throw new Error(`Unable to find environment variable for file command ${command}`);
-    }
-    if (!fs.existsSync(filePath)) {
-      throw new Error(`Missing file at path: ${filePath}`);
-    }
-    fs.appendFileSync(filePath, `${utils_1.toCommandValue(message)}${os2.EOL}`, {
-      encoding: "utf8"
-    });
+    exports2.issueCommand = issueCommand;
   }
-  exports2.issueCommand = issueCommand;
 });
 
 // node_modules/@actions/core/lib/core.js
-var require_core = __commonJS((exports2) => {
-  "use strict";
-  var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
-    function adopt(value) {
-      return value instanceof P ? value : new P(function(resolve) {
-        resolve(value);
+var require_core = __commonJS({
+  "node_modules/@actions/core/lib/core.js"(exports2) {
+    "use strict";
+    var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve) {
+          resolve(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+      });
+    };
+    var __importStar = exports2 && exports2.__importStar || function(mod) {
+      if (mod && mod.__esModule)
+        return mod;
+      var result = {};
+      if (mod != null) {
+        for (var k in mod)
+          if (Object.hasOwnProperty.call(mod, k))
+            result[k] = mod[k];
+      }
+      result["default"] = mod;
+      return result;
+    };
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    var command_1 = require_command();
+    var file_command_1 = require_file_command();
+    var utils_1 = require_utils();
+    var os2 = __importStar(require("os"));
+    var path2 = __importStar(require("path"));
+    var ExitCode;
+    (function(ExitCode2) {
+      ExitCode2[ExitCode2["Success"] = 0] = "Success";
+      ExitCode2[ExitCode2["Failure"] = 1] = "Failure";
+    })(ExitCode = exports2.ExitCode || (exports2.ExitCode = {}));
+    function exportVariable3(name, val) {
+      const convertedVal = utils_1.toCommandValue(val);
+      process.env[name] = convertedVal;
+      const filePath = process.env["GITHUB_ENV"] || "";
+      if (filePath) {
+        const delimiter = "_GitHubActionsFileCommandDelimeter_";
+        const commandValue = `${name}<<${delimiter}${os2.EOL}${convertedVal}${os2.EOL}${delimiter}`;
+        file_command_1.issueCommand("ENV", commandValue);
+      } else {
+        command_1.issueCommand("set-env", { name }, convertedVal);
+      }
+    }
+    exports2.exportVariable = exportVariable3;
+    function setSecret(secret) {
+      command_1.issueCommand("add-mask", {}, secret);
+    }
+    exports2.setSecret = setSecret;
+    function addPath2(inputPath) {
+      const filePath = process.env["GITHUB_PATH"] || "";
+      if (filePath) {
+        file_command_1.issueCommand("PATH", inputPath);
+      } else {
+        command_1.issueCommand("add-path", {}, inputPath);
+      }
+      process.env["PATH"] = `${inputPath}${path2.delimiter}${process.env["PATH"]}`;
+    }
+    exports2.addPath = addPath2;
+    function getInput3(name, options) {
+      const val = process.env[`INPUT_${name.replace(/ /g, "_").toUpperCase()}`] || "";
+      if (options && options.required && !val) {
+        throw new Error(`Input required and not supplied: ${name}`);
+      }
+      return val.trim();
+    }
+    exports2.getInput = getInput3;
+    function setOutput(name, value) {
+      command_1.issueCommand("set-output", { name }, value);
+    }
+    exports2.setOutput = setOutput;
+    function setCommandEcho(enabled) {
+      command_1.issue("echo", enabled ? "on" : "off");
+    }
+    exports2.setCommandEcho = setCommandEcho;
+    function setFailed2(message) {
+      process.exitCode = ExitCode.Failure;
+      error(message);
+    }
+    exports2.setFailed = setFailed2;
+    function isDebug() {
+      return process.env["RUNNER_DEBUG"] === "1";
+    }
+    exports2.isDebug = isDebug;
+    function debug(message) {
+      command_1.issueCommand("debug", {}, message);
+    }
+    exports2.debug = debug;
+    function error(message) {
+      command_1.issue("error", message instanceof Error ? message.toString() : message);
+    }
+    exports2.error = error;
+    function warning(message) {
+      command_1.issue("warning", message instanceof Error ? message.toString() : message);
+    }
+    exports2.warning = warning;
+    function info2(message) {
+      process.stdout.write(message + os2.EOL);
+    }
+    exports2.info = info2;
+    function startGroup2(name) {
+      command_1.issue("group", name);
+    }
+    exports2.startGroup = startGroup2;
+    function endGroup2() {
+      command_1.issue("endgroup");
+    }
+    exports2.endGroup = endGroup2;
+    function group(name, fn) {
+      return __awaiter(this, void 0, void 0, function* () {
+        startGroup2(name);
+        let result;
+        try {
+          result = yield fn();
+        } finally {
+          endGroup2();
+        }
+        return result;
       });
     }
-    return new (P || (P = Promise))(function(resolve, reject) {
-      function fulfilled(value) {
-        try {
-          step(generator.next(value));
-        } catch (e) {
-          reject(e);
-        }
-      }
-      function rejected(value) {
-        try {
-          step(generator["throw"](value));
-        } catch (e) {
-          reject(e);
-        }
-      }
-      function step(result) {
-        result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
-      }
-      step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-  };
-  var __importStar = exports2 && exports2.__importStar || function(mod) {
-    if (mod && mod.__esModule)
-      return mod;
-    var result = {};
-    if (mod != null) {
-      for (var k in mod)
-        if (Object.hasOwnProperty.call(mod, k))
-          result[k] = mod[k];
+    exports2.group = group;
+    function saveState(name, value) {
+      command_1.issueCommand("save-state", { name }, value);
     }
-    result["default"] = mod;
-    return result;
-  };
-  Object.defineProperty(exports2, "__esModule", {value: true});
-  var command_1 = require_command();
-  var file_command_1 = require_file_command();
-  var utils_1 = require_utils();
-  var os2 = __importStar(require("os"));
-  var path2 = __importStar(require("path"));
-  var ExitCode;
-  (function(ExitCode2) {
-    ExitCode2[ExitCode2["Success"] = 0] = "Success";
-    ExitCode2[ExitCode2["Failure"] = 1] = "Failure";
-  })(ExitCode = exports2.ExitCode || (exports2.ExitCode = {}));
-  function exportVariable3(name, val) {
-    const convertedVal = utils_1.toCommandValue(val);
-    process.env[name] = convertedVal;
-    const filePath = process.env["GITHUB_ENV"] || "";
-    if (filePath) {
-      const delimiter = "_GitHubActionsFileCommandDelimeter_";
-      const commandValue = `${name}<<${delimiter}${os2.EOL}${convertedVal}${os2.EOL}${delimiter}`;
-      file_command_1.issueCommand("ENV", commandValue);
-    } else {
-      command_1.issueCommand("set-env", {name}, convertedVal);
+    exports2.saveState = saveState;
+    function getState(name) {
+      return process.env[`STATE_${name}`] || "";
     }
+    exports2.getState = getState;
   }
-  exports2.exportVariable = exportVariable3;
-  function setSecret(secret) {
-    command_1.issueCommand("add-mask", {}, secret);
-  }
-  exports2.setSecret = setSecret;
-  function addPath2(inputPath) {
-    const filePath = process.env["GITHUB_PATH"] || "";
-    if (filePath) {
-      file_command_1.issueCommand("PATH", inputPath);
-    } else {
-      command_1.issueCommand("add-path", {}, inputPath);
-    }
-    process.env["PATH"] = `${inputPath}${path2.delimiter}${process.env["PATH"]}`;
-  }
-  exports2.addPath = addPath2;
-  function getInput3(name, options) {
-    const val = process.env[`INPUT_${name.replace(/ /g, "_").toUpperCase()}`] || "";
-    if (options && options.required && !val) {
-      throw new Error(`Input required and not supplied: ${name}`);
-    }
-    return val.trim();
-  }
-  exports2.getInput = getInput3;
-  function setOutput(name, value) {
-    command_1.issueCommand("set-output", {name}, value);
-  }
-  exports2.setOutput = setOutput;
-  function setCommandEcho(enabled) {
-    command_1.issue("echo", enabled ? "on" : "off");
-  }
-  exports2.setCommandEcho = setCommandEcho;
-  function setFailed2(message) {
-    process.exitCode = ExitCode.Failure;
-    error(message);
-  }
-  exports2.setFailed = setFailed2;
-  function isDebug() {
-    return process.env["RUNNER_DEBUG"] === "1";
-  }
-  exports2.isDebug = isDebug;
-  function debug(message) {
-    command_1.issueCommand("debug", {}, message);
-  }
-  exports2.debug = debug;
-  function error(message) {
-    command_1.issue("error", message instanceof Error ? message.toString() : message);
-  }
-  exports2.error = error;
-  function warning(message) {
-    command_1.issue("warning", message instanceof Error ? message.toString() : message);
-  }
-  exports2.warning = warning;
-  function info2(message) {
-    process.stdout.write(message + os2.EOL);
-  }
-  exports2.info = info2;
-  function startGroup2(name) {
-    command_1.issue("group", name);
-  }
-  exports2.startGroup = startGroup2;
-  function endGroup2() {
-    command_1.issue("endgroup");
-  }
-  exports2.endGroup = endGroup2;
-  function group(name, fn) {
-    return __awaiter(this, void 0, void 0, function* () {
-      startGroup2(name);
-      let result;
-      try {
-        result = yield fn();
-      } finally {
-        endGroup2();
-      }
-      return result;
-    });
-  }
-  exports2.group = group;
-  function saveState(name, value) {
-    command_1.issueCommand("save-state", {name}, value);
-  }
-  exports2.saveState = saveState;
-  function getState(name) {
-    return process.env[`STATE_${name}`] || "";
-  }
-  exports2.getState = getState;
 });
 
-// node_modules/@actions/io/lib/io-util.js
-var require_io_util = __commonJS((exports2) => {
-  "use strict";
-  var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
-    function adopt(value) {
-      return value instanceof P ? value : new P(function(resolve) {
-        resolve(value);
+// node_modules/@actions/exec/node_modules/@actions/io/lib/io-util.js
+var require_io_util = __commonJS({
+  "node_modules/@actions/exec/node_modules/@actions/io/lib/io-util.js"(exports2) {
+    "use strict";
+    var __createBinding = exports2 && exports2.__createBinding || (Object.create ? function(o, m, k, k2) {
+      if (k2 === void 0)
+        k2 = k;
+      Object.defineProperty(o, k2, { enumerable: true, get: function() {
+        return m[k];
+      } });
+    } : function(o, m, k, k2) {
+      if (k2 === void 0)
+        k2 = k;
+      o[k2] = m[k];
+    });
+    var __setModuleDefault = exports2 && exports2.__setModuleDefault || (Object.create ? function(o, v) {
+      Object.defineProperty(o, "default", { enumerable: true, value: v });
+    } : function(o, v) {
+      o["default"] = v;
+    });
+    var __importStar = exports2 && exports2.__importStar || function(mod) {
+      if (mod && mod.__esModule)
+        return mod;
+      var result = {};
+      if (mod != null) {
+        for (var k in mod)
+          if (k !== "default" && Object.hasOwnProperty.call(mod, k))
+            __createBinding(result, mod, k);
+      }
+      __setModuleDefault(result, mod);
+      return result;
+    };
+    var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve) {
+          resolve(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+      });
+    };
+    var _a;
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    exports2.getCmdPath = exports2.tryGetExecutablePath = exports2.isRooted = exports2.isDirectory = exports2.exists = exports2.IS_WINDOWS = exports2.unlink = exports2.symlink = exports2.stat = exports2.rmdir = exports2.rename = exports2.readlink = exports2.readdir = exports2.mkdir = exports2.lstat = exports2.copyFile = exports2.chmod = void 0;
+    var fs = __importStar(require("fs"));
+    var path2 = __importStar(require("path"));
+    _a = fs.promises, exports2.chmod = _a.chmod, exports2.copyFile = _a.copyFile, exports2.lstat = _a.lstat, exports2.mkdir = _a.mkdir, exports2.readdir = _a.readdir, exports2.readlink = _a.readlink, exports2.rename = _a.rename, exports2.rmdir = _a.rmdir, exports2.stat = _a.stat, exports2.symlink = _a.symlink, exports2.unlink = _a.unlink;
+    exports2.IS_WINDOWS = process.platform === "win32";
+    function exists(fsPath) {
+      return __awaiter(this, void 0, void 0, function* () {
+        try {
+          yield exports2.stat(fsPath);
+        } catch (err) {
+          if (err.code === "ENOENT") {
+            return false;
+          }
+          throw err;
+        }
+        return true;
       });
     }
-    return new (P || (P = Promise))(function(resolve, reject) {
-      function fulfilled(value) {
-        try {
-          step(generator.next(value));
-        } catch (e) {
-          reject(e);
-        }
-      }
-      function rejected(value) {
-        try {
-          step(generator["throw"](value));
-        } catch (e) {
-          reject(e);
-        }
-      }
-      function step(result) {
-        result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
-      }
-      step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-  };
-  var _a;
-  Object.defineProperty(exports2, "__esModule", {value: true});
-  var assert_1 = require("assert");
-  var fs = require("fs");
-  var path2 = require("path");
-  _a = fs.promises, exports2.chmod = _a.chmod, exports2.copyFile = _a.copyFile, exports2.lstat = _a.lstat, exports2.mkdir = _a.mkdir, exports2.readdir = _a.readdir, exports2.readlink = _a.readlink, exports2.rename = _a.rename, exports2.rmdir = _a.rmdir, exports2.stat = _a.stat, exports2.symlink = _a.symlink, exports2.unlink = _a.unlink;
-  exports2.IS_WINDOWS = process.platform === "win32";
-  function exists(fsPath) {
-    return __awaiter(this, void 0, void 0, function* () {
-      try {
-        yield exports2.stat(fsPath);
-      } catch (err) {
-        if (err.code === "ENOENT") {
-          return false;
-        }
-        throw err;
-      }
-      return true;
-    });
-  }
-  exports2.exists = exists;
-  function isDirectory(fsPath, useStat = false) {
-    return __awaiter(this, void 0, void 0, function* () {
-      const stats = useStat ? yield exports2.stat(fsPath) : yield exports2.lstat(fsPath);
-      return stats.isDirectory();
-    });
-  }
-  exports2.isDirectory = isDirectory;
-  function isRooted(p) {
-    p = normalizeSeparators(p);
-    if (!p) {
-      throw new Error('isRooted() parameter "p" cannot be empty');
+    exports2.exists = exists;
+    function isDirectory(fsPath, useStat = false) {
+      return __awaiter(this, void 0, void 0, function* () {
+        const stats = useStat ? yield exports2.stat(fsPath) : yield exports2.lstat(fsPath);
+        return stats.isDirectory();
+      });
     }
-    if (exports2.IS_WINDOWS) {
-      return p.startsWith("\\") || /^[A-Z]:/i.test(p);
+    exports2.isDirectory = isDirectory;
+    function isRooted(p) {
+      p = normalizeSeparators(p);
+      if (!p) {
+        throw new Error('isRooted() parameter "p" cannot be empty');
+      }
+      if (exports2.IS_WINDOWS) {
+        return p.startsWith("\\") || /^[A-Z]:/i.test(p);
+      }
+      return p.startsWith("/");
     }
-    return p.startsWith("/");
-  }
-  exports2.isRooted = isRooted;
-  function mkdirP(fsPath, maxDepth = 1e3, depth = 1) {
-    return __awaiter(this, void 0, void 0, function* () {
-      assert_1.ok(fsPath, "a path argument must be provided");
-      fsPath = path2.resolve(fsPath);
-      if (depth >= maxDepth)
-        return exports2.mkdir(fsPath);
-      try {
-        yield exports2.mkdir(fsPath);
-        return;
-      } catch (err) {
-        switch (err.code) {
-          case "ENOENT": {
-            yield mkdirP(path2.dirname(fsPath), maxDepth, depth + 1);
-            yield exports2.mkdir(fsPath);
-            return;
-          }
-          default: {
-            let stats;
-            try {
-              stats = yield exports2.stat(fsPath);
-            } catch (err2) {
-              throw err;
-            }
-            if (!stats.isDirectory())
-              throw err;
-          }
-        }
-      }
-    });
-  }
-  exports2.mkdirP = mkdirP;
-  function tryGetExecutablePath(filePath, extensions) {
-    return __awaiter(this, void 0, void 0, function* () {
-      let stats = void 0;
-      try {
-        stats = yield exports2.stat(filePath);
-      } catch (err) {
-        if (err.code !== "ENOENT") {
-          console.log(`Unexpected error attempting to determine if executable file exists '${filePath}': ${err}`);
-        }
-      }
-      if (stats && stats.isFile()) {
-        if (exports2.IS_WINDOWS) {
-          const upperExt = path2.extname(filePath).toUpperCase();
-          if (extensions.some((validExt) => validExt.toUpperCase() === upperExt)) {
-            return filePath;
-          }
-        } else {
-          if (isUnixExecutable(stats)) {
-            return filePath;
-          }
-        }
-      }
-      const originalFilePath = filePath;
-      for (const extension of extensions) {
-        filePath = originalFilePath + extension;
-        stats = void 0;
+    exports2.isRooted = isRooted;
+    function tryGetExecutablePath(filePath, extensions) {
+      return __awaiter(this, void 0, void 0, function* () {
+        let stats = void 0;
         try {
           stats = yield exports2.stat(filePath);
         } catch (err) {
@@ -431,189 +407,272 @@ var require_io_util = __commonJS((exports2) => {
         }
         if (stats && stats.isFile()) {
           if (exports2.IS_WINDOWS) {
-            try {
-              const directory = path2.dirname(filePath);
-              const upperName = path2.basename(filePath).toUpperCase();
-              for (const actualName of yield exports2.readdir(directory)) {
-                if (upperName === actualName.toUpperCase()) {
-                  filePath = path2.join(directory, actualName);
-                  break;
-                }
-              }
-            } catch (err) {
-              console.log(`Unexpected error attempting to determine the actual case of the file '${filePath}': ${err}`);
+            const upperExt = path2.extname(filePath).toUpperCase();
+            if (extensions.some((validExt) => validExt.toUpperCase() === upperExt)) {
+              return filePath;
             }
-            return filePath;
           } else {
             if (isUnixExecutable(stats)) {
               return filePath;
             }
           }
         }
-      }
-      return "";
-    });
-  }
-  exports2.tryGetExecutablePath = tryGetExecutablePath;
-  function normalizeSeparators(p) {
-    p = p || "";
-    if (exports2.IS_WINDOWS) {
-      p = p.replace(/\//g, "\\");
-      return p.replace(/\\\\+/g, "\\");
+        const originalFilePath = filePath;
+        for (const extension of extensions) {
+          filePath = originalFilePath + extension;
+          stats = void 0;
+          try {
+            stats = yield exports2.stat(filePath);
+          } catch (err) {
+            if (err.code !== "ENOENT") {
+              console.log(`Unexpected error attempting to determine if executable file exists '${filePath}': ${err}`);
+            }
+          }
+          if (stats && stats.isFile()) {
+            if (exports2.IS_WINDOWS) {
+              try {
+                const directory = path2.dirname(filePath);
+                const upperName = path2.basename(filePath).toUpperCase();
+                for (const actualName of yield exports2.readdir(directory)) {
+                  if (upperName === actualName.toUpperCase()) {
+                    filePath = path2.join(directory, actualName);
+                    break;
+                  }
+                }
+              } catch (err) {
+                console.log(`Unexpected error attempting to determine the actual case of the file '${filePath}': ${err}`);
+              }
+              return filePath;
+            } else {
+              if (isUnixExecutable(stats)) {
+                return filePath;
+              }
+            }
+          }
+        }
+        return "";
+      });
     }
-    return p.replace(/\/\/+/g, "/");
-  }
-  function isUnixExecutable(stats) {
-    return (stats.mode & 1) > 0 || (stats.mode & 8) > 0 && stats.gid === process.getgid() || (stats.mode & 64) > 0 && stats.uid === process.getuid();
+    exports2.tryGetExecutablePath = tryGetExecutablePath;
+    function normalizeSeparators(p) {
+      p = p || "";
+      if (exports2.IS_WINDOWS) {
+        p = p.replace(/\//g, "\\");
+        return p.replace(/\\\\+/g, "\\");
+      }
+      return p.replace(/\/\/+/g, "/");
+    }
+    function isUnixExecutable(stats) {
+      return (stats.mode & 1) > 0 || (stats.mode & 8) > 0 && stats.gid === process.getgid() || (stats.mode & 64) > 0 && stats.uid === process.getuid();
+    }
+    function getCmdPath() {
+      var _a2;
+      return (_a2 = process.env["COMSPEC"]) !== null && _a2 !== void 0 ? _a2 : `cmd.exe`;
+    }
+    exports2.getCmdPath = getCmdPath;
   }
 });
 
-// node_modules/@actions/io/lib/io.js
-var require_io = __commonJS((exports2) => {
-  "use strict";
-  var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
-    function adopt(value) {
-      return value instanceof P ? value : new P(function(resolve) {
-        resolve(value);
+// node_modules/@actions/exec/node_modules/@actions/io/lib/io.js
+var require_io = __commonJS({
+  "node_modules/@actions/exec/node_modules/@actions/io/lib/io.js"(exports2) {
+    "use strict";
+    var __createBinding = exports2 && exports2.__createBinding || (Object.create ? function(o, m, k, k2) {
+      if (k2 === void 0)
+        k2 = k;
+      Object.defineProperty(o, k2, { enumerable: true, get: function() {
+        return m[k];
+      } });
+    } : function(o, m, k, k2) {
+      if (k2 === void 0)
+        k2 = k;
+      o[k2] = m[k];
+    });
+    var __setModuleDefault = exports2 && exports2.__setModuleDefault || (Object.create ? function(o, v) {
+      Object.defineProperty(o, "default", { enumerable: true, value: v });
+    } : function(o, v) {
+      o["default"] = v;
+    });
+    var __importStar = exports2 && exports2.__importStar || function(mod) {
+      if (mod && mod.__esModule)
+        return mod;
+      var result = {};
+      if (mod != null) {
+        for (var k in mod)
+          if (k !== "default" && Object.hasOwnProperty.call(mod, k))
+            __createBinding(result, mod, k);
+      }
+      __setModuleDefault(result, mod);
+      return result;
+    };
+    var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve) {
+          resolve(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
-    }
-    return new (P || (P = Promise))(function(resolve, reject) {
-      function fulfilled(value) {
-        try {
-          step(generator.next(value));
-        } catch (e) {
-          reject(e);
-        }
-      }
-      function rejected(value) {
-        try {
-          step(generator["throw"](value));
-        } catch (e) {
-          reject(e);
-        }
-      }
-      function step(result) {
-        result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
-      }
-      step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-  };
-  Object.defineProperty(exports2, "__esModule", {value: true});
-  var childProcess = require("child_process");
-  var path2 = require("path");
-  var util_1 = require("util");
-  var ioUtil = require_io_util();
-  var exec5 = util_1.promisify(childProcess.exec);
-  function cp(source, dest, options = {}) {
-    return __awaiter(this, void 0, void 0, function* () {
-      const {force, recursive} = readCopyOptions(options);
-      const destStat = (yield ioUtil.exists(dest)) ? yield ioUtil.stat(dest) : null;
-      if (destStat && destStat.isFile() && !force) {
-        return;
-      }
-      const newDest = destStat && destStat.isDirectory() ? path2.join(dest, path2.basename(source)) : dest;
-      if (!(yield ioUtil.exists(source))) {
-        throw new Error(`no such file or directory: ${source}`);
-      }
-      const sourceStat = yield ioUtil.stat(source);
-      if (sourceStat.isDirectory()) {
-        if (!recursive) {
-          throw new Error(`Failed to copy. ${source} is a directory, but tried to copy without recursive flag.`);
-        } else {
-          yield cpDirRecursive(source, newDest, 0, force);
-        }
-      } else {
-        if (path2.relative(source, newDest) === "") {
-          throw new Error(`'${newDest}' and '${source}' are the same file`);
-        }
-        yield copyFile(source, newDest, force);
-      }
-    });
-  }
-  exports2.cp = cp;
-  function mv(source, dest, options = {}) {
-    return __awaiter(this, void 0, void 0, function* () {
-      if (yield ioUtil.exists(dest)) {
-        let destExists = true;
-        if (yield ioUtil.isDirectory(dest)) {
-          dest = path2.join(dest, path2.basename(source));
-          destExists = yield ioUtil.exists(dest);
-        }
-        if (destExists) {
-          if (options.force == null || options.force) {
-            yield rmRF(dest);
-          } else {
-            throw new Error("Destination already exists");
-          }
-        }
-      }
-      yield mkdirP(path2.dirname(dest));
-      yield ioUtil.rename(source, dest);
-    });
-  }
-  exports2.mv = mv;
-  function rmRF(inputPath) {
-    return __awaiter(this, void 0, void 0, function* () {
-      if (ioUtil.IS_WINDOWS) {
-        try {
-          if (yield ioUtil.isDirectory(inputPath, true)) {
-            yield exec5(`rd /s /q "${inputPath}"`);
-          } else {
-            yield exec5(`del /f /a "${inputPath}"`);
-          }
-        } catch (err) {
-          if (err.code !== "ENOENT")
-            throw err;
-        }
-        try {
-          yield ioUtil.unlink(inputPath);
-        } catch (err) {
-          if (err.code !== "ENOENT")
-            throw err;
-        }
-      } else {
-        let isDir = false;
-        try {
-          isDir = yield ioUtil.isDirectory(inputPath);
-        } catch (err) {
-          if (err.code !== "ENOENT")
-            throw err;
+    };
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    exports2.findInPath = exports2.which = exports2.mkdirP = exports2.rmRF = exports2.mv = exports2.cp = void 0;
+    var assert_1 = require("assert");
+    var childProcess = __importStar(require("child_process"));
+    var path2 = __importStar(require("path"));
+    var util_1 = require("util");
+    var ioUtil = __importStar(require_io_util());
+    var exec5 = util_1.promisify(childProcess.exec);
+    var execFile = util_1.promisify(childProcess.execFile);
+    function cp(source, dest, options = {}) {
+      return __awaiter(this, void 0, void 0, function* () {
+        const { force, recursive, copySourceDirectory } = readCopyOptions(options);
+        const destStat = (yield ioUtil.exists(dest)) ? yield ioUtil.stat(dest) : null;
+        if (destStat && destStat.isFile() && !force) {
           return;
         }
-        if (isDir) {
-          yield exec5(`rm -rf "${inputPath}"`);
-        } else {
-          yield ioUtil.unlink(inputPath);
+        const newDest = destStat && destStat.isDirectory() && copySourceDirectory ? path2.join(dest, path2.basename(source)) : dest;
+        if (!(yield ioUtil.exists(source))) {
+          throw new Error(`no such file or directory: ${source}`);
         }
-      }
-    });
-  }
-  exports2.rmRF = rmRF;
-  function mkdirP(fsPath) {
-    return __awaiter(this, void 0, void 0, function* () {
-      yield ioUtil.mkdirP(fsPath);
-    });
-  }
-  exports2.mkdirP = mkdirP;
-  function which2(tool, check) {
-    return __awaiter(this, void 0, void 0, function* () {
-      if (!tool) {
-        throw new Error("parameter 'tool' is required");
-      }
-      if (check) {
-        const result = yield which2(tool, false);
-        if (!result) {
-          if (ioUtil.IS_WINDOWS) {
-            throw new Error(`Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also verify the file has a valid extension for an executable file.`);
+        const sourceStat = yield ioUtil.stat(source);
+        if (sourceStat.isDirectory()) {
+          if (!recursive) {
+            throw new Error(`Failed to copy. ${source} is a directory, but tried to copy without recursive flag.`);
           } else {
-            throw new Error(`Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also check the file mode to verify the file is executable.`);
+            yield cpDirRecursive(source, newDest, 0, force);
+          }
+        } else {
+          if (path2.relative(source, newDest) === "") {
+            throw new Error(`'${newDest}' and '${source}' are the same file`);
+          }
+          yield copyFile(source, newDest, force);
+        }
+      });
+    }
+    exports2.cp = cp;
+    function mv(source, dest, options = {}) {
+      return __awaiter(this, void 0, void 0, function* () {
+        if (yield ioUtil.exists(dest)) {
+          let destExists = true;
+          if (yield ioUtil.isDirectory(dest)) {
+            dest = path2.join(dest, path2.basename(source));
+            destExists = yield ioUtil.exists(dest);
+          }
+          if (destExists) {
+            if (options.force == null || options.force) {
+              yield rmRF(dest);
+            } else {
+              throw new Error("Destination already exists");
+            }
           }
         }
-      }
-      try {
+        yield mkdirP(path2.dirname(dest));
+        yield ioUtil.rename(source, dest);
+      });
+    }
+    exports2.mv = mv;
+    function rmRF(inputPath) {
+      return __awaiter(this, void 0, void 0, function* () {
+        if (ioUtil.IS_WINDOWS) {
+          if (/[*"<>|]/.test(inputPath)) {
+            throw new Error('File path must not contain `*`, `"`, `<`, `>` or `|` on Windows');
+          }
+          try {
+            const cmdPath = ioUtil.getCmdPath();
+            if (yield ioUtil.isDirectory(inputPath, true)) {
+              yield exec5(`${cmdPath} /s /c "rd /s /q "%inputPath%""`, {
+                env: { inputPath }
+              });
+            } else {
+              yield exec5(`${cmdPath} /s /c "del /f /a "%inputPath%""`, {
+                env: { inputPath }
+              });
+            }
+          } catch (err) {
+            if (err.code !== "ENOENT")
+              throw err;
+          }
+          try {
+            yield ioUtil.unlink(inputPath);
+          } catch (err) {
+            if (err.code !== "ENOENT")
+              throw err;
+          }
+        } else {
+          let isDir = false;
+          try {
+            isDir = yield ioUtil.isDirectory(inputPath);
+          } catch (err) {
+            if (err.code !== "ENOENT")
+              throw err;
+            return;
+          }
+          if (isDir) {
+            yield execFile(`rm`, [`-rf`, `${inputPath}`]);
+          } else {
+            yield ioUtil.unlink(inputPath);
+          }
+        }
+      });
+    }
+    exports2.rmRF = rmRF;
+    function mkdirP(fsPath) {
+      return __awaiter(this, void 0, void 0, function* () {
+        assert_1.ok(fsPath, "a path argument must be provided");
+        yield ioUtil.mkdir(fsPath, { recursive: true });
+      });
+    }
+    exports2.mkdirP = mkdirP;
+    function which2(tool, check) {
+      return __awaiter(this, void 0, void 0, function* () {
+        if (!tool) {
+          throw new Error("parameter 'tool' is required");
+        }
+        if (check) {
+          const result = yield which2(tool, false);
+          if (!result) {
+            if (ioUtil.IS_WINDOWS) {
+              throw new Error(`Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also verify the file has a valid extension for an executable file.`);
+            } else {
+              throw new Error(`Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also check the file mode to verify the file is executable.`);
+            }
+          }
+          return result;
+        }
+        const matches = yield findInPath(tool);
+        if (matches && matches.length > 0) {
+          return matches[0];
+        }
+        return "";
+      });
+    }
+    exports2.which = which2;
+    function findInPath(tool) {
+      return __awaiter(this, void 0, void 0, function* () {
+        if (!tool) {
+          throw new Error("parameter 'tool' is required");
+        }
         const extensions = [];
-        if (ioUtil.IS_WINDOWS && process.env.PATHEXT) {
-          for (const extension of process.env.PATHEXT.split(path2.delimiter)) {
+        if (ioUtil.IS_WINDOWS && process.env["PATHEXT"]) {
+          for (const extension of process.env["PATHEXT"].split(path2.delimiter)) {
             if (extension) {
               extensions.push(extension);
             }
@@ -622,12 +681,12 @@ var require_io = __commonJS((exports2) => {
         if (ioUtil.isRooted(tool)) {
           const filePath = yield ioUtil.tryGetExecutablePath(tool, extensions);
           if (filePath) {
-            return filePath;
+            return [filePath];
           }
-          return "";
+          return [];
         }
-        if (tool.includes("/") || ioUtil.IS_WINDOWS && tool.includes("\\")) {
-          return "";
+        if (tool.includes(path2.sep)) {
+          return [];
         }
         const directories = [];
         if (process.env.PATH) {
@@ -637,578 +696,986 @@ var require_io = __commonJS((exports2) => {
             }
           }
         }
+        const matches = [];
         for (const directory of directories) {
-          const filePath = yield ioUtil.tryGetExecutablePath(directory + path2.sep + tool, extensions);
+          const filePath = yield ioUtil.tryGetExecutablePath(path2.join(directory, tool), extensions);
           if (filePath) {
-            return filePath;
+            matches.push(filePath);
           }
         }
-        return "";
-      } catch (err) {
-        throw new Error(`which failed with message ${err.message}`);
-      }
-    });
-  }
-  exports2.which = which2;
-  function readCopyOptions(options) {
-    const force = options.force == null ? true : options.force;
-    const recursive = Boolean(options.recursive);
-    return {force, recursive};
-  }
-  function cpDirRecursive(sourceDir, destDir, currentDepth, force) {
-    return __awaiter(this, void 0, void 0, function* () {
-      if (currentDepth >= 255)
-        return;
-      currentDepth++;
-      yield mkdirP(destDir);
-      const files = yield ioUtil.readdir(sourceDir);
-      for (const fileName of files) {
-        const srcFile = `${sourceDir}/${fileName}`;
-        const destFile = `${destDir}/${fileName}`;
-        const srcFileStat = yield ioUtil.lstat(srcFile);
-        if (srcFileStat.isDirectory()) {
-          yield cpDirRecursive(srcFile, destFile, currentDepth, force);
-        } else {
-          yield copyFile(srcFile, destFile, force);
+        return matches;
+      });
+    }
+    exports2.findInPath = findInPath;
+    function readCopyOptions(options) {
+      const force = options.force == null ? true : options.force;
+      const recursive = Boolean(options.recursive);
+      const copySourceDirectory = options.copySourceDirectory == null ? true : Boolean(options.copySourceDirectory);
+      return { force, recursive, copySourceDirectory };
+    }
+    function cpDirRecursive(sourceDir, destDir, currentDepth, force) {
+      return __awaiter(this, void 0, void 0, function* () {
+        if (currentDepth >= 255)
+          return;
+        currentDepth++;
+        yield mkdirP(destDir);
+        const files = yield ioUtil.readdir(sourceDir);
+        for (const fileName of files) {
+          const srcFile = `${sourceDir}/${fileName}`;
+          const destFile = `${destDir}/${fileName}`;
+          const srcFileStat = yield ioUtil.lstat(srcFile);
+          if (srcFileStat.isDirectory()) {
+            yield cpDirRecursive(srcFile, destFile, currentDepth, force);
+          } else {
+            yield copyFile(srcFile, destFile, force);
+          }
         }
-      }
-      yield ioUtil.chmod(destDir, (yield ioUtil.stat(sourceDir)).mode);
-    });
-  }
-  function copyFile(srcFile, destFile, force) {
-    return __awaiter(this, void 0, void 0, function* () {
-      if ((yield ioUtil.lstat(srcFile)).isSymbolicLink()) {
-        try {
-          yield ioUtil.lstat(destFile);
-          yield ioUtil.unlink(destFile);
-        } catch (e) {
-          if (e.code === "EPERM") {
-            yield ioUtil.chmod(destFile, "0666");
+        yield ioUtil.chmod(destDir, (yield ioUtil.stat(sourceDir)).mode);
+      });
+    }
+    function copyFile(srcFile, destFile, force) {
+      return __awaiter(this, void 0, void 0, function* () {
+        if ((yield ioUtil.lstat(srcFile)).isSymbolicLink()) {
+          try {
+            yield ioUtil.lstat(destFile);
             yield ioUtil.unlink(destFile);
+          } catch (e) {
+            if (e.code === "EPERM") {
+              yield ioUtil.chmod(destFile, "0666");
+              yield ioUtil.unlink(destFile);
+            }
           }
+          const symlinkFull = yield ioUtil.readlink(srcFile);
+          yield ioUtil.symlink(symlinkFull, destFile, ioUtil.IS_WINDOWS ? "junction" : null);
+        } else if (!(yield ioUtil.exists(destFile)) || force) {
+          yield ioUtil.copyFile(srcFile, destFile);
         }
-        const symlinkFull = yield ioUtil.readlink(srcFile);
-        yield ioUtil.symlink(symlinkFull, destFile, ioUtil.IS_WINDOWS ? "junction" : null);
-      } else if (!(yield ioUtil.exists(destFile)) || force) {
-        yield ioUtil.copyFile(srcFile, destFile);
-      }
-    });
+      });
+    }
   }
 });
 
 // node_modules/@actions/exec/lib/toolrunner.js
-var require_toolrunner = __commonJS((exports2) => {
-  "use strict";
-  var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
-    function adopt(value) {
-      return value instanceof P ? value : new P(function(resolve) {
-        resolve(value);
+var require_toolrunner = __commonJS({
+  "node_modules/@actions/exec/lib/toolrunner.js"(exports2) {
+    "use strict";
+    var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve) {
+          resolve(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
-    }
-    return new (P || (P = Promise))(function(resolve, reject) {
-      function fulfilled(value) {
-        try {
-          step(generator.next(value));
-        } catch (e) {
-          reject(e);
+    };
+    var __importStar = exports2 && exports2.__importStar || function(mod) {
+      if (mod && mod.__esModule)
+        return mod;
+      var result = {};
+      if (mod != null) {
+        for (var k in mod)
+          if (Object.hasOwnProperty.call(mod, k))
+            result[k] = mod[k];
+      }
+      result["default"] = mod;
+      return result;
+    };
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    var os2 = __importStar(require("os"));
+    var events = __importStar(require("events"));
+    var child = __importStar(require("child_process"));
+    var path2 = __importStar(require("path"));
+    var io2 = __importStar(require_io());
+    var ioUtil = __importStar(require_io_util());
+    var IS_WINDOWS = process.platform === "win32";
+    var ToolRunner = class extends events.EventEmitter {
+      constructor(toolPath, args, options) {
+        super();
+        if (!toolPath) {
+          throw new Error("Parameter 'toolPath' cannot be null or empty.");
+        }
+        this.toolPath = toolPath;
+        this.args = args || [];
+        this.options = options || {};
+      }
+      _debug(message) {
+        if (this.options.listeners && this.options.listeners.debug) {
+          this.options.listeners.debug(message);
         }
       }
-      function rejected(value) {
-        try {
-          step(generator["throw"](value));
-        } catch (e) {
-          reject(e);
-        }
-      }
-      function step(result) {
-        result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
-      }
-      step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-  };
-  var __importStar = exports2 && exports2.__importStar || function(mod) {
-    if (mod && mod.__esModule)
-      return mod;
-    var result = {};
-    if (mod != null) {
-      for (var k in mod)
-        if (Object.hasOwnProperty.call(mod, k))
-          result[k] = mod[k];
-    }
-    result["default"] = mod;
-    return result;
-  };
-  Object.defineProperty(exports2, "__esModule", {value: true});
-  var os2 = __importStar(require("os"));
-  var events = __importStar(require("events"));
-  var child = __importStar(require("child_process"));
-  var path2 = __importStar(require("path"));
-  var io2 = __importStar(require_io());
-  var ioUtil = __importStar(require_io_util());
-  var IS_WINDOWS = process.platform === "win32";
-  var ToolRunner = class extends events.EventEmitter {
-    constructor(toolPath, args, options) {
-      super();
-      if (!toolPath) {
-        throw new Error("Parameter 'toolPath' cannot be null or empty.");
-      }
-      this.toolPath = toolPath;
-      this.args = args || [];
-      this.options = options || {};
-    }
-    _debug(message) {
-      if (this.options.listeners && this.options.listeners.debug) {
-        this.options.listeners.debug(message);
-      }
-    }
-    _getCommandString(options, noPrefix) {
-      const toolPath = this._getSpawnFileName();
-      const args = this._getSpawnArgs(options);
-      let cmd = noPrefix ? "" : "[command]";
-      if (IS_WINDOWS) {
-        if (this._isCmdFile()) {
+      _getCommandString(options, noPrefix) {
+        const toolPath = this._getSpawnFileName();
+        const args = this._getSpawnArgs(options);
+        let cmd = noPrefix ? "" : "[command]";
+        if (IS_WINDOWS) {
+          if (this._isCmdFile()) {
+            cmd += toolPath;
+            for (const a of args) {
+              cmd += ` ${a}`;
+            }
+          } else if (options.windowsVerbatimArguments) {
+            cmd += `"${toolPath}"`;
+            for (const a of args) {
+              cmd += ` ${a}`;
+            }
+          } else {
+            cmd += this._windowsQuoteCmdArg(toolPath);
+            for (const a of args) {
+              cmd += ` ${this._windowsQuoteCmdArg(a)}`;
+            }
+          }
+        } else {
           cmd += toolPath;
           for (const a of args) {
             cmd += ` ${a}`;
           }
-        } else if (options.windowsVerbatimArguments) {
-          cmd += `"${toolPath}"`;
-          for (const a of args) {
-            cmd += ` ${a}`;
+        }
+        return cmd;
+      }
+      _processLineBuffer(data, strBuffer, onLine) {
+        try {
+          let s = strBuffer + data.toString();
+          let n = s.indexOf(os2.EOL);
+          while (n > -1) {
+            const line = s.substring(0, n);
+            onLine(line);
+            s = s.substring(n + os2.EOL.length);
+            n = s.indexOf(os2.EOL);
           }
-        } else {
-          cmd += this._windowsQuoteCmdArg(toolPath);
-          for (const a of args) {
-            cmd += ` ${this._windowsQuoteCmdArg(a)}`;
+          strBuffer = s;
+        } catch (err) {
+          this._debug(`error processing line. Failed with error ${err}`);
+        }
+      }
+      _getSpawnFileName() {
+        if (IS_WINDOWS) {
+          if (this._isCmdFile()) {
+            return process.env["COMSPEC"] || "cmd.exe";
           }
         }
-      } else {
-        cmd += toolPath;
-        for (const a of args) {
-          cmd += ` ${a}`;
-        }
+        return this.toolPath;
       }
-      return cmd;
-    }
-    _processLineBuffer(data, strBuffer, onLine) {
-      try {
-        let s = strBuffer + data.toString();
-        let n = s.indexOf(os2.EOL);
-        while (n > -1) {
-          const line = s.substring(0, n);
-          onLine(line);
-          s = s.substring(n + os2.EOL.length);
-          n = s.indexOf(os2.EOL);
-        }
-        strBuffer = s;
-      } catch (err) {
-        this._debug(`error processing line. Failed with error ${err}`);
-      }
-    }
-    _getSpawnFileName() {
-      if (IS_WINDOWS) {
-        if (this._isCmdFile()) {
-          return process.env["COMSPEC"] || "cmd.exe";
-        }
-      }
-      return this.toolPath;
-    }
-    _getSpawnArgs(options) {
-      if (IS_WINDOWS) {
-        if (this._isCmdFile()) {
-          let argline = `/D /S /C "${this._windowsQuoteCmdArg(this.toolPath)}`;
-          for (const a of this.args) {
-            argline += " ";
-            argline += options.windowsVerbatimArguments ? a : this._windowsQuoteCmdArg(a);
+      _getSpawnArgs(options) {
+        if (IS_WINDOWS) {
+          if (this._isCmdFile()) {
+            let argline = `/D /S /C "${this._windowsQuoteCmdArg(this.toolPath)}`;
+            for (const a of this.args) {
+              argline += " ";
+              argline += options.windowsVerbatimArguments ? a : this._windowsQuoteCmdArg(a);
+            }
+            argline += '"';
+            return [argline];
           }
-          argline += '"';
-          return [argline];
         }
+        return this.args;
       }
-      return this.args;
-    }
-    _endsWith(str, end) {
-      return str.endsWith(end);
-    }
-    _isCmdFile() {
-      const upperToolPath = this.toolPath.toUpperCase();
-      return this._endsWith(upperToolPath, ".CMD") || this._endsWith(upperToolPath, ".BAT");
-    }
-    _windowsQuoteCmdArg(arg) {
-      if (!this._isCmdFile()) {
-        return this._uvQuoteCmdArg(arg);
+      _endsWith(str, end) {
+        return str.endsWith(end);
       }
-      if (!arg) {
-        return '""';
+      _isCmdFile() {
+        const upperToolPath = this.toolPath.toUpperCase();
+        return this._endsWith(upperToolPath, ".CMD") || this._endsWith(upperToolPath, ".BAT");
       }
-      const cmdSpecialChars = [
-        " ",
-        "	",
-        "&",
-        "(",
-        ")",
-        "[",
-        "]",
-        "{",
-        "}",
-        "^",
-        "=",
-        ";",
-        "!",
-        "'",
-        "+",
-        ",",
-        "`",
-        "~",
-        "|",
-        "<",
-        ">",
-        '"'
-      ];
-      let needsQuotes = false;
-      for (const char of arg) {
-        if (cmdSpecialChars.some((x) => x === char)) {
-          needsQuotes = true;
-          break;
+      _windowsQuoteCmdArg(arg) {
+        if (!this._isCmdFile()) {
+          return this._uvQuoteCmdArg(arg);
         }
-      }
-      if (!needsQuotes) {
-        return arg;
-      }
-      let reverse = '"';
-      let quoteHit = true;
-      for (let i = arg.length; i > 0; i--) {
-        reverse += arg[i - 1];
-        if (quoteHit && arg[i - 1] === "\\") {
-          reverse += "\\";
-        } else if (arg[i - 1] === '"') {
-          quoteHit = true;
-          reverse += '"';
-        } else {
-          quoteHit = false;
+        if (!arg) {
+          return '""';
         }
-      }
-      reverse += '"';
-      return reverse.split("").reverse().join("");
-    }
-    _uvQuoteCmdArg(arg) {
-      if (!arg) {
-        return '""';
-      }
-      if (!arg.includes(" ") && !arg.includes("	") && !arg.includes('"')) {
-        return arg;
-      }
-      if (!arg.includes('"') && !arg.includes("\\")) {
-        return `"${arg}"`;
-      }
-      let reverse = '"';
-      let quoteHit = true;
-      for (let i = arg.length; i > 0; i--) {
-        reverse += arg[i - 1];
-        if (quoteHit && arg[i - 1] === "\\") {
-          reverse += "\\";
-        } else if (arg[i - 1] === '"') {
-          quoteHit = true;
-          reverse += "\\";
-        } else {
-          quoteHit = false;
-        }
-      }
-      reverse += '"';
-      return reverse.split("").reverse().join("");
-    }
-    _cloneExecOptions(options) {
-      options = options || {};
-      const result = {
-        cwd: options.cwd || process.cwd(),
-        env: options.env || process.env,
-        silent: options.silent || false,
-        windowsVerbatimArguments: options.windowsVerbatimArguments || false,
-        failOnStdErr: options.failOnStdErr || false,
-        ignoreReturnCode: options.ignoreReturnCode || false,
-        delay: options.delay || 1e4
-      };
-      result.outStream = options.outStream || process.stdout;
-      result.errStream = options.errStream || process.stderr;
-      return result;
-    }
-    _getSpawnOptions(options, toolPath) {
-      options = options || {};
-      const result = {};
-      result.cwd = options.cwd;
-      result.env = options.env;
-      result["windowsVerbatimArguments"] = options.windowsVerbatimArguments || this._isCmdFile();
-      if (options.windowsVerbatimArguments) {
-        result.argv0 = `"${toolPath}"`;
-      }
-      return result;
-    }
-    exec() {
-      return __awaiter(this, void 0, void 0, function* () {
-        if (!ioUtil.isRooted(this.toolPath) && (this.toolPath.includes("/") || IS_WINDOWS && this.toolPath.includes("\\"))) {
-          this.toolPath = path2.resolve(process.cwd(), this.options.cwd || process.cwd(), this.toolPath);
-        }
-        this.toolPath = yield io2.which(this.toolPath, true);
-        return new Promise((resolve, reject) => {
-          this._debug(`exec tool: ${this.toolPath}`);
-          this._debug("arguments:");
-          for (const arg of this.args) {
-            this._debug(`   ${arg}`);
+        const cmdSpecialChars = [
+          " ",
+          "	",
+          "&",
+          "(",
+          ")",
+          "[",
+          "]",
+          "{",
+          "}",
+          "^",
+          "=",
+          ";",
+          "!",
+          "'",
+          "+",
+          ",",
+          "`",
+          "~",
+          "|",
+          "<",
+          ">",
+          '"'
+        ];
+        let needsQuotes = false;
+        for (const char of arg) {
+          if (cmdSpecialChars.some((x) => x === char)) {
+            needsQuotes = true;
+            break;
           }
-          const optionsNonNull = this._cloneExecOptions(this.options);
-          if (!optionsNonNull.silent && optionsNonNull.outStream) {
-            optionsNonNull.outStream.write(this._getCommandString(optionsNonNull) + os2.EOL);
+        }
+        if (!needsQuotes) {
+          return arg;
+        }
+        let reverse = '"';
+        let quoteHit = true;
+        for (let i = arg.length; i > 0; i--) {
+          reverse += arg[i - 1];
+          if (quoteHit && arg[i - 1] === "\\") {
+            reverse += "\\";
+          } else if (arg[i - 1] === '"') {
+            quoteHit = true;
+            reverse += '"';
+          } else {
+            quoteHit = false;
           }
-          const state = new ExecState(optionsNonNull, this.toolPath);
-          state.on("debug", (message) => {
-            this._debug(message);
-          });
-          const fileName = this._getSpawnFileName();
-          const cp = child.spawn(fileName, this._getSpawnArgs(optionsNonNull), this._getSpawnOptions(this.options, fileName));
-          const stdbuffer = "";
-          if (cp.stdout) {
-            cp.stdout.on("data", (data) => {
-              if (this.options.listeners && this.options.listeners.stdout) {
-                this.options.listeners.stdout(data);
-              }
-              if (!optionsNonNull.silent && optionsNonNull.outStream) {
-                optionsNonNull.outStream.write(data);
-              }
-              this._processLineBuffer(data, stdbuffer, (line) => {
-                if (this.options.listeners && this.options.listeners.stdline) {
-                  this.options.listeners.stdline(line);
-                }
-              });
+        }
+        reverse += '"';
+        return reverse.split("").reverse().join("");
+      }
+      _uvQuoteCmdArg(arg) {
+        if (!arg) {
+          return '""';
+        }
+        if (!arg.includes(" ") && !arg.includes("	") && !arg.includes('"')) {
+          return arg;
+        }
+        if (!arg.includes('"') && !arg.includes("\\")) {
+          return `"${arg}"`;
+        }
+        let reverse = '"';
+        let quoteHit = true;
+        for (let i = arg.length; i > 0; i--) {
+          reverse += arg[i - 1];
+          if (quoteHit && arg[i - 1] === "\\") {
+            reverse += "\\";
+          } else if (arg[i - 1] === '"') {
+            quoteHit = true;
+            reverse += "\\";
+          } else {
+            quoteHit = false;
+          }
+        }
+        reverse += '"';
+        return reverse.split("").reverse().join("");
+      }
+      _cloneExecOptions(options) {
+        options = options || {};
+        const result = {
+          cwd: options.cwd || process.cwd(),
+          env: options.env || process.env,
+          silent: options.silent || false,
+          windowsVerbatimArguments: options.windowsVerbatimArguments || false,
+          failOnStdErr: options.failOnStdErr || false,
+          ignoreReturnCode: options.ignoreReturnCode || false,
+          delay: options.delay || 1e4
+        };
+        result.outStream = options.outStream || process.stdout;
+        result.errStream = options.errStream || process.stderr;
+        return result;
+      }
+      _getSpawnOptions(options, toolPath) {
+        options = options || {};
+        const result = {};
+        result.cwd = options.cwd;
+        result.env = options.env;
+        result["windowsVerbatimArguments"] = options.windowsVerbatimArguments || this._isCmdFile();
+        if (options.windowsVerbatimArguments) {
+          result.argv0 = `"${toolPath}"`;
+        }
+        return result;
+      }
+      exec() {
+        return __awaiter(this, void 0, void 0, function* () {
+          if (!ioUtil.isRooted(this.toolPath) && (this.toolPath.includes("/") || IS_WINDOWS && this.toolPath.includes("\\"))) {
+            this.toolPath = path2.resolve(process.cwd(), this.options.cwd || process.cwd(), this.toolPath);
+          }
+          this.toolPath = yield io2.which(this.toolPath, true);
+          return new Promise((resolve, reject) => {
+            this._debug(`exec tool: ${this.toolPath}`);
+            this._debug("arguments:");
+            for (const arg of this.args) {
+              this._debug(`   ${arg}`);
+            }
+            const optionsNonNull = this._cloneExecOptions(this.options);
+            if (!optionsNonNull.silent && optionsNonNull.outStream) {
+              optionsNonNull.outStream.write(this._getCommandString(optionsNonNull) + os2.EOL);
+            }
+            const state = new ExecState(optionsNonNull, this.toolPath);
+            state.on("debug", (message) => {
+              this._debug(message);
             });
-          }
-          const errbuffer = "";
-          if (cp.stderr) {
-            cp.stderr.on("data", (data) => {
-              state.processStderr = true;
-              if (this.options.listeners && this.options.listeners.stderr) {
-                this.options.listeners.stderr(data);
-              }
-              if (!optionsNonNull.silent && optionsNonNull.errStream && optionsNonNull.outStream) {
-                const s = optionsNonNull.failOnStdErr ? optionsNonNull.errStream : optionsNonNull.outStream;
-                s.write(data);
-              }
-              this._processLineBuffer(data, errbuffer, (line) => {
-                if (this.options.listeners && this.options.listeners.errline) {
-                  this.options.listeners.errline(line);
+            const fileName = this._getSpawnFileName();
+            const cp = child.spawn(fileName, this._getSpawnArgs(optionsNonNull), this._getSpawnOptions(this.options, fileName));
+            const stdbuffer = "";
+            if (cp.stdout) {
+              cp.stdout.on("data", (data) => {
+                if (this.options.listeners && this.options.listeners.stdout) {
+                  this.options.listeners.stdout(data);
                 }
+                if (!optionsNonNull.silent && optionsNonNull.outStream) {
+                  optionsNonNull.outStream.write(data);
+                }
+                this._processLineBuffer(data, stdbuffer, (line) => {
+                  if (this.options.listeners && this.options.listeners.stdline) {
+                    this.options.listeners.stdline(line);
+                  }
+                });
               });
+            }
+            const errbuffer = "";
+            if (cp.stderr) {
+              cp.stderr.on("data", (data) => {
+                state.processStderr = true;
+                if (this.options.listeners && this.options.listeners.stderr) {
+                  this.options.listeners.stderr(data);
+                }
+                if (!optionsNonNull.silent && optionsNonNull.errStream && optionsNonNull.outStream) {
+                  const s = optionsNonNull.failOnStdErr ? optionsNonNull.errStream : optionsNonNull.outStream;
+                  s.write(data);
+                }
+                this._processLineBuffer(data, errbuffer, (line) => {
+                  if (this.options.listeners && this.options.listeners.errline) {
+                    this.options.listeners.errline(line);
+                  }
+                });
+              });
+            }
+            cp.on("error", (err) => {
+              state.processError = err.message;
+              state.processExited = true;
+              state.processClosed = true;
+              state.CheckComplete();
             });
-          }
-          cp.on("error", (err) => {
-            state.processError = err.message;
-            state.processExited = true;
-            state.processClosed = true;
-            state.CheckComplete();
-          });
-          cp.on("exit", (code) => {
-            state.processExitCode = code;
-            state.processExited = true;
-            this._debug(`Exit code ${code} received from tool '${this.toolPath}'`);
-            state.CheckComplete();
-          });
-          cp.on("close", (code) => {
-            state.processExitCode = code;
-            state.processExited = true;
-            state.processClosed = true;
-            this._debug(`STDIO streams have closed for tool '${this.toolPath}'`);
-            state.CheckComplete();
-          });
-          state.on("done", (error, exitCode) => {
-            if (stdbuffer.length > 0) {
-              this.emit("stdline", stdbuffer);
+            cp.on("exit", (code) => {
+              state.processExitCode = code;
+              state.processExited = true;
+              this._debug(`Exit code ${code} received from tool '${this.toolPath}'`);
+              state.CheckComplete();
+            });
+            cp.on("close", (code) => {
+              state.processExitCode = code;
+              state.processExited = true;
+              state.processClosed = true;
+              this._debug(`STDIO streams have closed for tool '${this.toolPath}'`);
+              state.CheckComplete();
+            });
+            state.on("done", (error, exitCode) => {
+              if (stdbuffer.length > 0) {
+                this.emit("stdline", stdbuffer);
+              }
+              if (errbuffer.length > 0) {
+                this.emit("errline", errbuffer);
+              }
+              cp.removeAllListeners();
+              if (error) {
+                reject(error);
+              } else {
+                resolve(exitCode);
+              }
+            });
+            if (this.options.input) {
+              if (!cp.stdin) {
+                throw new Error("child process missing stdin");
+              }
+              cp.stdin.end(this.options.input);
             }
-            if (errbuffer.length > 0) {
-              this.emit("errline", errbuffer);
-            }
-            cp.removeAllListeners();
-            if (error) {
-              reject(error);
-            } else {
-              resolve(exitCode);
-            }
           });
-          if (this.options.input) {
-            if (!cp.stdin) {
-              throw new Error("child process missing stdin");
-            }
-            cp.stdin.end(this.options.input);
-          }
         });
-      });
-    }
-  };
-  exports2.ToolRunner = ToolRunner;
-  function argStringToArray(argString) {
-    const args = [];
-    let inQuotes = false;
-    let escaped = false;
-    let arg = "";
-    function append(c) {
-      if (escaped && c !== '"') {
-        arg += "\\";
       }
-      arg += c;
-      escaped = false;
-    }
-    for (let i = 0; i < argString.length; i++) {
-      const c = argString.charAt(i);
-      if (c === '"') {
-        if (!escaped) {
-          inQuotes = !inQuotes;
-        } else {
+    };
+    exports2.ToolRunner = ToolRunner;
+    function argStringToArray(argString) {
+      const args = [];
+      let inQuotes = false;
+      let escaped = false;
+      let arg = "";
+      function append(c) {
+        if (escaped && c !== '"') {
+          arg += "\\";
+        }
+        arg += c;
+        escaped = false;
+      }
+      for (let i = 0; i < argString.length; i++) {
+        const c = argString.charAt(i);
+        if (c === '"') {
+          if (!escaped) {
+            inQuotes = !inQuotes;
+          } else {
+            append(c);
+          }
+          continue;
+        }
+        if (c === "\\" && escaped) {
           append(c);
+          continue;
         }
-        continue;
-      }
-      if (c === "\\" && escaped) {
+        if (c === "\\" && inQuotes) {
+          escaped = true;
+          continue;
+        }
+        if (c === " " && !inQuotes) {
+          if (arg.length > 0) {
+            args.push(arg);
+            arg = "";
+          }
+          continue;
+        }
         append(c);
-        continue;
       }
-      if (c === "\\" && inQuotes) {
-        escaped = true;
-        continue;
+      if (arg.length > 0) {
+        args.push(arg.trim());
       }
-      if (c === " " && !inQuotes) {
-        if (arg.length > 0) {
-          args.push(arg);
-          arg = "";
-        }
-        continue;
-      }
-      append(c);
+      return args;
     }
-    if (arg.length > 0) {
-      args.push(arg.trim());
-    }
-    return args;
-  }
-  exports2.argStringToArray = argStringToArray;
-  var ExecState = class extends events.EventEmitter {
-    constructor(options, toolPath) {
-      super();
-      this.processClosed = false;
-      this.processError = "";
-      this.processExitCode = 0;
-      this.processExited = false;
-      this.processStderr = false;
-      this.delay = 1e4;
-      this.done = false;
-      this.timeout = null;
-      if (!toolPath) {
-        throw new Error("toolPath must not be empty");
-      }
-      this.options = options;
-      this.toolPath = toolPath;
-      if (options.delay) {
-        this.delay = options.delay;
-      }
-    }
-    CheckComplete() {
-      if (this.done) {
-        return;
-      }
-      if (this.processClosed) {
-        this._setResult();
-      } else if (this.processExited) {
-        this.timeout = setTimeout(ExecState.HandleTimeout, this.delay, this);
-      }
-    }
-    _debug(message) {
-      this.emit("debug", message);
-    }
-    _setResult() {
-      let error;
-      if (this.processExited) {
-        if (this.processError) {
-          error = new Error(`There was an error when attempting to execute the process '${this.toolPath}'. This may indicate the process failed to start. Error: ${this.processError}`);
-        } else if (this.processExitCode !== 0 && !this.options.ignoreReturnCode) {
-          error = new Error(`The process '${this.toolPath}' failed with exit code ${this.processExitCode}`);
-        } else if (this.processStderr && this.options.failOnStdErr) {
-          error = new Error(`The process '${this.toolPath}' failed because one or more lines were written to the STDERR stream`);
-        }
-      }
-      if (this.timeout) {
-        clearTimeout(this.timeout);
+    exports2.argStringToArray = argStringToArray;
+    var ExecState = class extends events.EventEmitter {
+      constructor(options, toolPath) {
+        super();
+        this.processClosed = false;
+        this.processError = "";
+        this.processExitCode = 0;
+        this.processExited = false;
+        this.processStderr = false;
+        this.delay = 1e4;
+        this.done = false;
         this.timeout = null;
+        if (!toolPath) {
+          throw new Error("toolPath must not be empty");
+        }
+        this.options = options;
+        this.toolPath = toolPath;
+        if (options.delay) {
+          this.delay = options.delay;
+        }
       }
-      this.done = true;
-      this.emit("done", error, this.processExitCode);
-    }
-    static HandleTimeout(state) {
-      if (state.done) {
-        return;
+      CheckComplete() {
+        if (this.done) {
+          return;
+        }
+        if (this.processClosed) {
+          this._setResult();
+        } else if (this.processExited) {
+          this.timeout = setTimeout(ExecState.HandleTimeout, this.delay, this);
+        }
       }
-      if (!state.processClosed && state.processExited) {
-        const message = `The STDIO streams did not close within ${state.delay / 1e3} seconds of the exit event from process '${state.toolPath}'. This may indicate a child process inherited the STDIO streams and has not yet exited.`;
-        state._debug(message);
+      _debug(message) {
+        this.emit("debug", message);
       }
-      state._setResult();
-    }
-  };
+      _setResult() {
+        let error;
+        if (this.processExited) {
+          if (this.processError) {
+            error = new Error(`There was an error when attempting to execute the process '${this.toolPath}'. This may indicate the process failed to start. Error: ${this.processError}`);
+          } else if (this.processExitCode !== 0 && !this.options.ignoreReturnCode) {
+            error = new Error(`The process '${this.toolPath}' failed with exit code ${this.processExitCode}`);
+          } else if (this.processStderr && this.options.failOnStdErr) {
+            error = new Error(`The process '${this.toolPath}' failed because one or more lines were written to the STDERR stream`);
+          }
+        }
+        if (this.timeout) {
+          clearTimeout(this.timeout);
+          this.timeout = null;
+        }
+        this.done = true;
+        this.emit("done", error, this.processExitCode);
+      }
+      static HandleTimeout(state) {
+        if (state.done) {
+          return;
+        }
+        if (!state.processClosed && state.processExited) {
+          const message = `The STDIO streams did not close within ${state.delay / 1e3} seconds of the exit event from process '${state.toolPath}'. This may indicate a child process inherited the STDIO streams and has not yet exited.`;
+          state._debug(message);
+        }
+        state._setResult();
+      }
+    };
+  }
 });
 
 // node_modules/@actions/exec/lib/exec.js
-var require_exec = __commonJS((exports2) => {
-  "use strict";
-  var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
-    function adopt(value) {
-      return value instanceof P ? value : new P(function(resolve) {
-        resolve(value);
+var require_exec = __commonJS({
+  "node_modules/@actions/exec/lib/exec.js"(exports2) {
+    "use strict";
+    var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve) {
+          resolve(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+      });
+    };
+    var __importStar = exports2 && exports2.__importStar || function(mod) {
+      if (mod && mod.__esModule)
+        return mod;
+      var result = {};
+      if (mod != null) {
+        for (var k in mod)
+          if (Object.hasOwnProperty.call(mod, k))
+            result[k] = mod[k];
+      }
+      result["default"] = mod;
+      return result;
+    };
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    var tr = __importStar(require_toolrunner());
+    function exec5(commandLine, args, options) {
+      return __awaiter(this, void 0, void 0, function* () {
+        const commandArgs = tr.argStringToArray(commandLine);
+        if (commandArgs.length === 0) {
+          throw new Error(`Parameter 'commandLine' cannot be null or empty.`);
+        }
+        const toolPath = commandArgs[0];
+        args = commandArgs.slice(1).concat(args || []);
+        const runner = new tr.ToolRunner(toolPath, args, options);
+        return runner.exec();
       });
     }
-    return new (P || (P = Promise))(function(resolve, reject) {
-      function fulfilled(value) {
-        try {
-          step(generator.next(value));
-        } catch (e) {
-          reject(e);
-        }
-      }
-      function rejected(value) {
-        try {
-          step(generator["throw"](value));
-        } catch (e) {
-          reject(e);
-        }
-      }
-      function step(result) {
-        result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
-      }
-      step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-  };
-  var __importStar = exports2 && exports2.__importStar || function(mod) {
-    if (mod && mod.__esModule)
-      return mod;
-    var result = {};
-    if (mod != null) {
-      for (var k in mod)
-        if (Object.hasOwnProperty.call(mod, k))
-          result[k] = mod[k];
-    }
-    result["default"] = mod;
-    return result;
-  };
-  Object.defineProperty(exports2, "__esModule", {value: true});
-  var tr = __importStar(require_toolrunner());
-  function exec5(commandLine, args, options) {
-    return __awaiter(this, void 0, void 0, function* () {
-      const commandArgs = tr.argStringToArray(commandLine);
-      if (commandArgs.length === 0) {
-        throw new Error(`Parameter 'commandLine' cannot be null or empty.`);
-      }
-      const toolPath = commandArgs[0];
-      args = commandArgs.slice(1).concat(args || []);
-      const runner = new tr.ToolRunner(toolPath, args, options);
-      return runner.exec();
-    });
+    exports2.exec = exec5;
   }
-  exports2.exec = exec5;
+});
+
+// node_modules/@actions/io/lib/io-util.js
+var require_io_util2 = __commonJS({
+  "node_modules/@actions/io/lib/io-util.js"(exports2) {
+    "use strict";
+    var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve) {
+          resolve(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+      });
+    };
+    var _a;
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    var assert_1 = require("assert");
+    var fs = require("fs");
+    var path2 = require("path");
+    _a = fs.promises, exports2.chmod = _a.chmod, exports2.copyFile = _a.copyFile, exports2.lstat = _a.lstat, exports2.mkdir = _a.mkdir, exports2.readdir = _a.readdir, exports2.readlink = _a.readlink, exports2.rename = _a.rename, exports2.rmdir = _a.rmdir, exports2.stat = _a.stat, exports2.symlink = _a.symlink, exports2.unlink = _a.unlink;
+    exports2.IS_WINDOWS = process.platform === "win32";
+    function exists(fsPath) {
+      return __awaiter(this, void 0, void 0, function* () {
+        try {
+          yield exports2.stat(fsPath);
+        } catch (err) {
+          if (err.code === "ENOENT") {
+            return false;
+          }
+          throw err;
+        }
+        return true;
+      });
+    }
+    exports2.exists = exists;
+    function isDirectory(fsPath, useStat = false) {
+      return __awaiter(this, void 0, void 0, function* () {
+        const stats = useStat ? yield exports2.stat(fsPath) : yield exports2.lstat(fsPath);
+        return stats.isDirectory();
+      });
+    }
+    exports2.isDirectory = isDirectory;
+    function isRooted(p) {
+      p = normalizeSeparators(p);
+      if (!p) {
+        throw new Error('isRooted() parameter "p" cannot be empty');
+      }
+      if (exports2.IS_WINDOWS) {
+        return p.startsWith("\\") || /^[A-Z]:/i.test(p);
+      }
+      return p.startsWith("/");
+    }
+    exports2.isRooted = isRooted;
+    function mkdirP(fsPath, maxDepth = 1e3, depth = 1) {
+      return __awaiter(this, void 0, void 0, function* () {
+        assert_1.ok(fsPath, "a path argument must be provided");
+        fsPath = path2.resolve(fsPath);
+        if (depth >= maxDepth)
+          return exports2.mkdir(fsPath);
+        try {
+          yield exports2.mkdir(fsPath);
+          return;
+        } catch (err) {
+          switch (err.code) {
+            case "ENOENT": {
+              yield mkdirP(path2.dirname(fsPath), maxDepth, depth + 1);
+              yield exports2.mkdir(fsPath);
+              return;
+            }
+            default: {
+              let stats;
+              try {
+                stats = yield exports2.stat(fsPath);
+              } catch (err2) {
+                throw err;
+              }
+              if (!stats.isDirectory())
+                throw err;
+            }
+          }
+        }
+      });
+    }
+    exports2.mkdirP = mkdirP;
+    function tryGetExecutablePath(filePath, extensions) {
+      return __awaiter(this, void 0, void 0, function* () {
+        let stats = void 0;
+        try {
+          stats = yield exports2.stat(filePath);
+        } catch (err) {
+          if (err.code !== "ENOENT") {
+            console.log(`Unexpected error attempting to determine if executable file exists '${filePath}': ${err}`);
+          }
+        }
+        if (stats && stats.isFile()) {
+          if (exports2.IS_WINDOWS) {
+            const upperExt = path2.extname(filePath).toUpperCase();
+            if (extensions.some((validExt) => validExt.toUpperCase() === upperExt)) {
+              return filePath;
+            }
+          } else {
+            if (isUnixExecutable(stats)) {
+              return filePath;
+            }
+          }
+        }
+        const originalFilePath = filePath;
+        for (const extension of extensions) {
+          filePath = originalFilePath + extension;
+          stats = void 0;
+          try {
+            stats = yield exports2.stat(filePath);
+          } catch (err) {
+            if (err.code !== "ENOENT") {
+              console.log(`Unexpected error attempting to determine if executable file exists '${filePath}': ${err}`);
+            }
+          }
+          if (stats && stats.isFile()) {
+            if (exports2.IS_WINDOWS) {
+              try {
+                const directory = path2.dirname(filePath);
+                const upperName = path2.basename(filePath).toUpperCase();
+                for (const actualName of yield exports2.readdir(directory)) {
+                  if (upperName === actualName.toUpperCase()) {
+                    filePath = path2.join(directory, actualName);
+                    break;
+                  }
+                }
+              } catch (err) {
+                console.log(`Unexpected error attempting to determine the actual case of the file '${filePath}': ${err}`);
+              }
+              return filePath;
+            } else {
+              if (isUnixExecutable(stats)) {
+                return filePath;
+              }
+            }
+          }
+        }
+        return "";
+      });
+    }
+    exports2.tryGetExecutablePath = tryGetExecutablePath;
+    function normalizeSeparators(p) {
+      p = p || "";
+      if (exports2.IS_WINDOWS) {
+        p = p.replace(/\//g, "\\");
+        return p.replace(/\\\\+/g, "\\");
+      }
+      return p.replace(/\/\/+/g, "/");
+    }
+    function isUnixExecutable(stats) {
+      return (stats.mode & 1) > 0 || (stats.mode & 8) > 0 && stats.gid === process.getgid() || (stats.mode & 64) > 0 && stats.uid === process.getuid();
+    }
+  }
+});
+
+// node_modules/@actions/io/lib/io.js
+var require_io2 = __commonJS({
+  "node_modules/@actions/io/lib/io.js"(exports2) {
+    "use strict";
+    var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve) {
+          resolve(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+      });
+    };
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    var childProcess = require("child_process");
+    var path2 = require("path");
+    var util_1 = require("util");
+    var ioUtil = require_io_util2();
+    var exec5 = util_1.promisify(childProcess.exec);
+    function cp(source, dest, options = {}) {
+      return __awaiter(this, void 0, void 0, function* () {
+        const { force, recursive } = readCopyOptions(options);
+        const destStat = (yield ioUtil.exists(dest)) ? yield ioUtil.stat(dest) : null;
+        if (destStat && destStat.isFile() && !force) {
+          return;
+        }
+        const newDest = destStat && destStat.isDirectory() ? path2.join(dest, path2.basename(source)) : dest;
+        if (!(yield ioUtil.exists(source))) {
+          throw new Error(`no such file or directory: ${source}`);
+        }
+        const sourceStat = yield ioUtil.stat(source);
+        if (sourceStat.isDirectory()) {
+          if (!recursive) {
+            throw new Error(`Failed to copy. ${source} is a directory, but tried to copy without recursive flag.`);
+          } else {
+            yield cpDirRecursive(source, newDest, 0, force);
+          }
+        } else {
+          if (path2.relative(source, newDest) === "") {
+            throw new Error(`'${newDest}' and '${source}' are the same file`);
+          }
+          yield copyFile(source, newDest, force);
+        }
+      });
+    }
+    exports2.cp = cp;
+    function mv(source, dest, options = {}) {
+      return __awaiter(this, void 0, void 0, function* () {
+        if (yield ioUtil.exists(dest)) {
+          let destExists = true;
+          if (yield ioUtil.isDirectory(dest)) {
+            dest = path2.join(dest, path2.basename(source));
+            destExists = yield ioUtil.exists(dest);
+          }
+          if (destExists) {
+            if (options.force == null || options.force) {
+              yield rmRF(dest);
+            } else {
+              throw new Error("Destination already exists");
+            }
+          }
+        }
+        yield mkdirP(path2.dirname(dest));
+        yield ioUtil.rename(source, dest);
+      });
+    }
+    exports2.mv = mv;
+    function rmRF(inputPath) {
+      return __awaiter(this, void 0, void 0, function* () {
+        if (ioUtil.IS_WINDOWS) {
+          try {
+            if (yield ioUtil.isDirectory(inputPath, true)) {
+              yield exec5(`rd /s /q "${inputPath}"`);
+            } else {
+              yield exec5(`del /f /a "${inputPath}"`);
+            }
+          } catch (err) {
+            if (err.code !== "ENOENT")
+              throw err;
+          }
+          try {
+            yield ioUtil.unlink(inputPath);
+          } catch (err) {
+            if (err.code !== "ENOENT")
+              throw err;
+          }
+        } else {
+          let isDir = false;
+          try {
+            isDir = yield ioUtil.isDirectory(inputPath);
+          } catch (err) {
+            if (err.code !== "ENOENT")
+              throw err;
+            return;
+          }
+          if (isDir) {
+            yield exec5(`rm -rf "${inputPath}"`);
+          } else {
+            yield ioUtil.unlink(inputPath);
+          }
+        }
+      });
+    }
+    exports2.rmRF = rmRF;
+    function mkdirP(fsPath) {
+      return __awaiter(this, void 0, void 0, function* () {
+        yield ioUtil.mkdirP(fsPath);
+      });
+    }
+    exports2.mkdirP = mkdirP;
+    function which2(tool, check) {
+      return __awaiter(this, void 0, void 0, function* () {
+        if (!tool) {
+          throw new Error("parameter 'tool' is required");
+        }
+        if (check) {
+          const result = yield which2(tool, false);
+          if (!result) {
+            if (ioUtil.IS_WINDOWS) {
+              throw new Error(`Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also verify the file has a valid extension for an executable file.`);
+            } else {
+              throw new Error(`Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also check the file mode to verify the file is executable.`);
+            }
+          }
+        }
+        try {
+          const extensions = [];
+          if (ioUtil.IS_WINDOWS && process.env.PATHEXT) {
+            for (const extension of process.env.PATHEXT.split(path2.delimiter)) {
+              if (extension) {
+                extensions.push(extension);
+              }
+            }
+          }
+          if (ioUtil.isRooted(tool)) {
+            const filePath = yield ioUtil.tryGetExecutablePath(tool, extensions);
+            if (filePath) {
+              return filePath;
+            }
+            return "";
+          }
+          if (tool.includes("/") || ioUtil.IS_WINDOWS && tool.includes("\\")) {
+            return "";
+          }
+          const directories = [];
+          if (process.env.PATH) {
+            for (const p of process.env.PATH.split(path2.delimiter)) {
+              if (p) {
+                directories.push(p);
+              }
+            }
+          }
+          for (const directory of directories) {
+            const filePath = yield ioUtil.tryGetExecutablePath(directory + path2.sep + tool, extensions);
+            if (filePath) {
+              return filePath;
+            }
+          }
+          return "";
+        } catch (err) {
+          throw new Error(`which failed with message ${err.message}`);
+        }
+      });
+    }
+    exports2.which = which2;
+    function readCopyOptions(options) {
+      const force = options.force == null ? true : options.force;
+      const recursive = Boolean(options.recursive);
+      return { force, recursive };
+    }
+    function cpDirRecursive(sourceDir, destDir, currentDepth, force) {
+      return __awaiter(this, void 0, void 0, function* () {
+        if (currentDepth >= 255)
+          return;
+        currentDepth++;
+        yield mkdirP(destDir);
+        const files = yield ioUtil.readdir(sourceDir);
+        for (const fileName of files) {
+          const srcFile = `${sourceDir}/${fileName}`;
+          const destFile = `${destDir}/${fileName}`;
+          const srcFileStat = yield ioUtil.lstat(srcFile);
+          if (srcFileStat.isDirectory()) {
+            yield cpDirRecursive(srcFile, destFile, currentDepth, force);
+          } else {
+            yield copyFile(srcFile, destFile, force);
+          }
+        }
+        yield ioUtil.chmod(destDir, (yield ioUtil.stat(sourceDir)).mode);
+      });
+    }
+    function copyFile(srcFile, destFile, force) {
+      return __awaiter(this, void 0, void 0, function* () {
+        if ((yield ioUtil.lstat(srcFile)).isSymbolicLink()) {
+          try {
+            yield ioUtil.lstat(destFile);
+            yield ioUtil.unlink(destFile);
+          } catch (e) {
+            if (e.code === "EPERM") {
+              yield ioUtil.chmod(destFile, "0666");
+              yield ioUtil.unlink(destFile);
+            }
+          }
+          const symlinkFull = yield ioUtil.readlink(srcFile);
+          yield ioUtil.symlink(symlinkFull, destFile, ioUtil.IS_WINDOWS ? "junction" : null);
+        } else if (!(yield ioUtil.exists(destFile)) || force) {
+          yield ioUtil.copyFile(srcFile, destFile);
+        }
+      });
+    }
+  }
 });
 
 // lib/plugin-test/main.ts
@@ -1221,7 +1688,7 @@ var exec3 = __toModule(require_exec());
 // lib/setup/index.ts
 var core = __toModule(require_core());
 var exec = __toModule(require_exec());
-var io = __toModule(require_io());
+var io = __toModule(require_io2());
 var os = __toModule(require("os"));
 var path = __toModule(require("path"));
 async function setupAsdf() {
@@ -1235,7 +1702,7 @@ async function setupAsdf() {
   core.addPath(`${asdfDir}/bin`);
   core.addPath(`${asdfDir}/shims`);
   core.info(`Cloning asdf into ASDF_DIR: ${asdfDir}`);
-  const branch = core.getInput("asdf_branch", {required: true});
+  const branch = core.getInput("asdf_branch", { required: true });
   await exec.exec("git", [
     "clone",
     "--depth",
@@ -1250,11 +1717,11 @@ async function setupAsdf() {
 // lib/plugin-test/index.ts
 async function pluginTest() {
   await setupAsdf();
-  const command = core2.getInput("command", {required: true});
-  const version = core2.getInput("version", {required: true});
-  const plugin = (core2.getInput("plugin", {required: false}) || process.env.GITHUB_REPOSITORY.split("/")[1]).replace("asdf-", "");
-  const giturl = core2.getInput("giturl", {required: false}) || `https://github.com/${process.env.GITHUB_REPOSITORY}`;
-  const gitref = core2.getInput("gitref", {required: false}) || process.env.GITHUB_SHA;
+  const command = core2.getInput("command", { required: true });
+  const version = core2.getInput("version", { required: true });
+  const plugin = (core2.getInput("plugin", { required: false }) || process.env.GITHUB_REPOSITORY.split("/")[1]).replace("asdf-", "");
+  const giturl = core2.getInput("giturl", { required: false }) || `https://github.com/${process.env.GITHUB_REPOSITORY}`;
+  const gitref = core2.getInput("gitref", { required: false }) || process.env.GITHUB_SHA;
   await exec3.exec("asdf", [
     "plugin-test",
     plugin,
@@ -1267,7 +1734,7 @@ async function pluginTest() {
   ]);
 }
 async function pluginTestAll() {
-  const githubToken = core2.getInput("github_token", {required: false});
+  const githubToken = core2.getInput("github_token", { required: false });
   core2.exportVariable("GITHUB_API_TOKEN", githubToken);
   core2.startGroup("Test plugin");
   await pluginTest();

--- a/plugin-test/main.js
+++ b/plugin-test/main.js
@@ -1,403 +1,424 @@
 var __create = Object.create;
 var __defProp = Object.defineProperty;
-var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
-var __getOwnPropNames = Object.getOwnPropertyNames;
 var __getProtoOf = Object.getPrototypeOf;
 var __hasOwnProp = Object.prototype.hasOwnProperty;
-var __markAsModule = (target) => __defProp(target, "__esModule", { value: true });
-var __commonJS = (cb, mod) => function __require() {
-  return mod || (0, cb[Object.keys(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __markAsModule = (target) => __defProp(target, "__esModule", {value: true});
+var __commonJS = (callback, module2) => () => {
+  if (!module2) {
+    module2 = {exports: {}};
+    callback(module2.exports, module2);
+  }
+  return module2.exports;
 };
-var __reExport = (target, module2, desc) => {
+var __exportStar = (target, module2, desc) => {
+  __markAsModule(target);
   if (module2 && typeof module2 === "object" || typeof module2 === "function") {
     for (let key of __getOwnPropNames(module2))
       if (!__hasOwnProp.call(target, key) && key !== "default")
-        __defProp(target, key, { get: () => module2[key], enumerable: !(desc = __getOwnPropDesc(module2, key)) || desc.enumerable });
+        __defProp(target, key, {get: () => module2[key], enumerable: !(desc = __getOwnPropDesc(module2, key)) || desc.enumerable});
   }
   return target;
 };
 var __toModule = (module2) => {
-  return __reExport(__markAsModule(__defProp(module2 != null ? __create(__getProtoOf(module2)) : {}, "default", module2 && module2.__esModule && "default" in module2 ? { get: () => module2.default, enumerable: true } : { value: module2, enumerable: true })), module2);
+  if (module2 && module2.__esModule)
+    return module2;
+  return __exportStar(__defProp(module2 != null ? __create(__getProtoOf(module2)) : {}, "default", {value: module2, enumerable: true}), module2);
 };
 
 // node_modules/@actions/core/lib/utils.js
-var require_utils = __commonJS({
-  "node_modules/@actions/core/lib/utils.js"(exports2) {
-    "use strict";
-    Object.defineProperty(exports2, "__esModule", { value: true });
-    function toCommandValue(input) {
-      if (input === null || input === void 0) {
-        return "";
-      } else if (typeof input === "string" || input instanceof String) {
-        return input;
-      }
-      return JSON.stringify(input);
+var require_utils = __commonJS((exports2) => {
+  "use strict";
+  Object.defineProperty(exports2, "__esModule", {value: true});
+  function toCommandValue(input) {
+    if (input === null || input === void 0) {
+      return "";
+    } else if (typeof input === "string" || input instanceof String) {
+      return input;
     }
-    exports2.toCommandValue = toCommandValue;
+    return JSON.stringify(input);
   }
+  exports2.toCommandValue = toCommandValue;
 });
 
 // node_modules/@actions/core/lib/command.js
-var require_command = __commonJS({
-  "node_modules/@actions/core/lib/command.js"(exports2) {
-    "use strict";
-    var __importStar = exports2 && exports2.__importStar || function(mod) {
-      if (mod && mod.__esModule)
-        return mod;
-      var result = {};
-      if (mod != null) {
-        for (var k in mod)
-          if (Object.hasOwnProperty.call(mod, k))
-            result[k] = mod[k];
-      }
-      result["default"] = mod;
-      return result;
-    };
-    Object.defineProperty(exports2, "__esModule", { value: true });
-    var os2 = __importStar(require("os"));
-    var utils_1 = require_utils();
-    function issueCommand(command, properties, message) {
-      const cmd = new Command(command, properties, message);
-      process.stdout.write(cmd.toString() + os2.EOL);
+var require_command = __commonJS((exports2) => {
+  "use strict";
+  var __importStar = exports2 && exports2.__importStar || function(mod) {
+    if (mod && mod.__esModule)
+      return mod;
+    var result = {};
+    if (mod != null) {
+      for (var k in mod)
+        if (Object.hasOwnProperty.call(mod, k))
+          result[k] = mod[k];
     }
-    exports2.issueCommand = issueCommand;
-    function issue(name, message = "") {
-      issueCommand(name, {}, message);
-    }
-    exports2.issue = issue;
-    var CMD_STRING = "::";
-    var Command = class {
-      constructor(command, properties, message) {
-        if (!command) {
-          command = "missing.command";
-        }
-        this.command = command;
-        this.properties = properties;
-        this.message = message;
+    result["default"] = mod;
+    return result;
+  };
+  Object.defineProperty(exports2, "__esModule", {value: true});
+  var os2 = __importStar(require("os"));
+  var utils_1 = require_utils();
+  function issueCommand(command, properties, message) {
+    const cmd = new Command(command, properties, message);
+    process.stdout.write(cmd.toString() + os2.EOL);
+  }
+  exports2.issueCommand = issueCommand;
+  function issue(name, message = "") {
+    issueCommand(name, {}, message);
+  }
+  exports2.issue = issue;
+  var CMD_STRING = "::";
+  var Command = class {
+    constructor(command, properties, message) {
+      if (!command) {
+        command = "missing.command";
       }
-      toString() {
-        let cmdStr = CMD_STRING + this.command;
-        if (this.properties && Object.keys(this.properties).length > 0) {
-          cmdStr += " ";
-          let first = true;
-          for (const key in this.properties) {
-            if (this.properties.hasOwnProperty(key)) {
-              const val = this.properties[key];
-              if (val) {
-                if (first) {
-                  first = false;
-                } else {
-                  cmdStr += ",";
-                }
-                cmdStr += `${key}=${escapeProperty(val)}`;
+      this.command = command;
+      this.properties = properties;
+      this.message = message;
+    }
+    toString() {
+      let cmdStr = CMD_STRING + this.command;
+      if (this.properties && Object.keys(this.properties).length > 0) {
+        cmdStr += " ";
+        let first = true;
+        for (const key in this.properties) {
+          if (this.properties.hasOwnProperty(key)) {
+            const val = this.properties[key];
+            if (val) {
+              if (first) {
+                first = false;
+              } else {
+                cmdStr += ",";
               }
+              cmdStr += `${key}=${escapeProperty(val)}`;
             }
           }
         }
-        cmdStr += `${CMD_STRING}${escapeData(this.message)}`;
-        return cmdStr;
       }
-    };
-    function escapeData(s) {
-      return utils_1.toCommandValue(s).replace(/%/g, "%25").replace(/\r/g, "%0D").replace(/\n/g, "%0A");
+      cmdStr += `${CMD_STRING}${escapeData(this.message)}`;
+      return cmdStr;
     }
-    function escapeProperty(s) {
-      return utils_1.toCommandValue(s).replace(/%/g, "%25").replace(/\r/g, "%0D").replace(/\n/g, "%0A").replace(/:/g, "%3A").replace(/,/g, "%2C");
-    }
+  };
+  function escapeData(s) {
+    return utils_1.toCommandValue(s).replace(/%/g, "%25").replace(/\r/g, "%0D").replace(/\n/g, "%0A");
+  }
+  function escapeProperty(s) {
+    return utils_1.toCommandValue(s).replace(/%/g, "%25").replace(/\r/g, "%0D").replace(/\n/g, "%0A").replace(/:/g, "%3A").replace(/,/g, "%2C");
   }
 });
 
 // node_modules/@actions/core/lib/file-command.js
-var require_file_command = __commonJS({
-  "node_modules/@actions/core/lib/file-command.js"(exports2) {
-    "use strict";
-    var __importStar = exports2 && exports2.__importStar || function(mod) {
-      if (mod && mod.__esModule)
-        return mod;
-      var result = {};
-      if (mod != null) {
-        for (var k in mod)
-          if (Object.hasOwnProperty.call(mod, k))
-            result[k] = mod[k];
-      }
-      result["default"] = mod;
-      return result;
-    };
-    Object.defineProperty(exports2, "__esModule", { value: true });
-    var fs = __importStar(require("fs"));
-    var os2 = __importStar(require("os"));
-    var utils_1 = require_utils();
-    function issueCommand(command, message) {
-      const filePath = process.env[`GITHUB_${command}`];
-      if (!filePath) {
-        throw new Error(`Unable to find environment variable for file command ${command}`);
-      }
-      if (!fs.existsSync(filePath)) {
-        throw new Error(`Missing file at path: ${filePath}`);
-      }
-      fs.appendFileSync(filePath, `${utils_1.toCommandValue(message)}${os2.EOL}`, {
-        encoding: "utf8"
-      });
+var require_file_command = __commonJS((exports2) => {
+  "use strict";
+  var __importStar = exports2 && exports2.__importStar || function(mod) {
+    if (mod && mod.__esModule)
+      return mod;
+    var result = {};
+    if (mod != null) {
+      for (var k in mod)
+        if (Object.hasOwnProperty.call(mod, k))
+          result[k] = mod[k];
     }
-    exports2.issueCommand = issueCommand;
+    result["default"] = mod;
+    return result;
+  };
+  Object.defineProperty(exports2, "__esModule", {value: true});
+  var fs = __importStar(require("fs"));
+  var os2 = __importStar(require("os"));
+  var utils_1 = require_utils();
+  function issueCommand(command, message) {
+    const filePath = process.env[`GITHUB_${command}`];
+    if (!filePath) {
+      throw new Error(`Unable to find environment variable for file command ${command}`);
+    }
+    if (!fs.existsSync(filePath)) {
+      throw new Error(`Missing file at path: ${filePath}`);
+    }
+    fs.appendFileSync(filePath, `${utils_1.toCommandValue(message)}${os2.EOL}`, {
+      encoding: "utf8"
+    });
   }
+  exports2.issueCommand = issueCommand;
 });
 
 // node_modules/@actions/core/lib/core.js
-var require_core = __commonJS({
-  "node_modules/@actions/core/lib/core.js"(exports2) {
-    "use strict";
-    var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
-      function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve) {
-          resolve(value);
-        });
-      }
-      return new (P || (P = Promise))(function(resolve, reject) {
-        function fulfilled(value) {
-          try {
-            step(generator.next(value));
-          } catch (e) {
-            reject(e);
-          }
-        }
-        function rejected(value) {
-          try {
-            step(generator["throw"](value));
-          } catch (e) {
-            reject(e);
-          }
-        }
-        function step(result) {
-          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
-        }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
+var require_core = __commonJS((exports2) => {
+  "use strict";
+  var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+    function adopt(value) {
+      return value instanceof P ? value : new P(function(resolve) {
+        resolve(value);
       });
-    };
-    var __importStar = exports2 && exports2.__importStar || function(mod) {
-      if (mod && mod.__esModule)
-        return mod;
-      var result = {};
-      if (mod != null) {
-        for (var k in mod)
-          if (Object.hasOwnProperty.call(mod, k))
-            result[k] = mod[k];
-      }
-      result["default"] = mod;
-      return result;
-    };
-    Object.defineProperty(exports2, "__esModule", { value: true });
-    var command_1 = require_command();
-    var file_command_1 = require_file_command();
-    var utils_1 = require_utils();
-    var os2 = __importStar(require("os"));
-    var path2 = __importStar(require("path"));
-    var ExitCode;
-    (function(ExitCode2) {
-      ExitCode2[ExitCode2["Success"] = 0] = "Success";
-      ExitCode2[ExitCode2["Failure"] = 1] = "Failure";
-    })(ExitCode = exports2.ExitCode || (exports2.ExitCode = {}));
-    function exportVariable3(name, val) {
-      const convertedVal = utils_1.toCommandValue(val);
-      process.env[name] = convertedVal;
-      const filePath = process.env["GITHUB_ENV"] || "";
-      if (filePath) {
-        const delimiter = "_GitHubActionsFileCommandDelimeter_";
-        const commandValue = `${name}<<${delimiter}${os2.EOL}${convertedVal}${os2.EOL}${delimiter}`;
-        file_command_1.issueCommand("ENV", commandValue);
-      } else {
-        command_1.issueCommand("set-env", { name }, convertedVal);
-      }
     }
-    exports2.exportVariable = exportVariable3;
-    function setSecret(secret) {
-      command_1.issueCommand("add-mask", {}, secret);
-    }
-    exports2.setSecret = setSecret;
-    function addPath2(inputPath) {
-      const filePath = process.env["GITHUB_PATH"] || "";
-      if (filePath) {
-        file_command_1.issueCommand("PATH", inputPath);
-      } else {
-        command_1.issueCommand("add-path", {}, inputPath);
-      }
-      process.env["PATH"] = `${inputPath}${path2.delimiter}${process.env["PATH"]}`;
-    }
-    exports2.addPath = addPath2;
-    function getInput3(name, options) {
-      const val = process.env[`INPUT_${name.replace(/ /g, "_").toUpperCase()}`] || "";
-      if (options && options.required && !val) {
-        throw new Error(`Input required and not supplied: ${name}`);
-      }
-      return val.trim();
-    }
-    exports2.getInput = getInput3;
-    function setOutput(name, value) {
-      command_1.issueCommand("set-output", { name }, value);
-    }
-    exports2.setOutput = setOutput;
-    function setCommandEcho(enabled) {
-      command_1.issue("echo", enabled ? "on" : "off");
-    }
-    exports2.setCommandEcho = setCommandEcho;
-    function setFailed2(message) {
-      process.exitCode = ExitCode.Failure;
-      error(message);
-    }
-    exports2.setFailed = setFailed2;
-    function isDebug() {
-      return process.env["RUNNER_DEBUG"] === "1";
-    }
-    exports2.isDebug = isDebug;
-    function debug(message) {
-      command_1.issueCommand("debug", {}, message);
-    }
-    exports2.debug = debug;
-    function error(message) {
-      command_1.issue("error", message instanceof Error ? message.toString() : message);
-    }
-    exports2.error = error;
-    function warning(message) {
-      command_1.issue("warning", message instanceof Error ? message.toString() : message);
-    }
-    exports2.warning = warning;
-    function info2(message) {
-      process.stdout.write(message + os2.EOL);
-    }
-    exports2.info = info2;
-    function startGroup2(name) {
-      command_1.issue("group", name);
-    }
-    exports2.startGroup = startGroup2;
-    function endGroup2() {
-      command_1.issue("endgroup");
-    }
-    exports2.endGroup = endGroup2;
-    function group(name, fn) {
-      return __awaiter(this, void 0, void 0, function* () {
-        startGroup2(name);
-        let result;
+    return new (P || (P = Promise))(function(resolve, reject) {
+      function fulfilled(value) {
         try {
-          result = yield fn();
-        } finally {
-          endGroup2();
+          step(generator.next(value));
+        } catch (e) {
+          reject(e);
         }
-        return result;
-      });
+      }
+      function rejected(value) {
+        try {
+          step(generator["throw"](value));
+        } catch (e) {
+          reject(e);
+        }
+      }
+      function step(result) {
+        result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+      }
+      step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+  };
+  var __importStar = exports2 && exports2.__importStar || function(mod) {
+    if (mod && mod.__esModule)
+      return mod;
+    var result = {};
+    if (mod != null) {
+      for (var k in mod)
+        if (Object.hasOwnProperty.call(mod, k))
+          result[k] = mod[k];
     }
-    exports2.group = group;
-    function saveState(name, value) {
-      command_1.issueCommand("save-state", { name }, value);
+    result["default"] = mod;
+    return result;
+  };
+  Object.defineProperty(exports2, "__esModule", {value: true});
+  var command_1 = require_command();
+  var file_command_1 = require_file_command();
+  var utils_1 = require_utils();
+  var os2 = __importStar(require("os"));
+  var path2 = __importStar(require("path"));
+  var ExitCode;
+  (function(ExitCode2) {
+    ExitCode2[ExitCode2["Success"] = 0] = "Success";
+    ExitCode2[ExitCode2["Failure"] = 1] = "Failure";
+  })(ExitCode = exports2.ExitCode || (exports2.ExitCode = {}));
+  function exportVariable3(name, val) {
+    const convertedVal = utils_1.toCommandValue(val);
+    process.env[name] = convertedVal;
+    const filePath = process.env["GITHUB_ENV"] || "";
+    if (filePath) {
+      const delimiter = "_GitHubActionsFileCommandDelimeter_";
+      const commandValue = `${name}<<${delimiter}${os2.EOL}${convertedVal}${os2.EOL}${delimiter}`;
+      file_command_1.issueCommand("ENV", commandValue);
+    } else {
+      command_1.issueCommand("set-env", {name}, convertedVal);
     }
-    exports2.saveState = saveState;
-    function getState(name) {
-      return process.env[`STATE_${name}`] || "";
-    }
-    exports2.getState = getState;
   }
+  exports2.exportVariable = exportVariable3;
+  function setSecret(secret) {
+    command_1.issueCommand("add-mask", {}, secret);
+  }
+  exports2.setSecret = setSecret;
+  function addPath2(inputPath) {
+    const filePath = process.env["GITHUB_PATH"] || "";
+    if (filePath) {
+      file_command_1.issueCommand("PATH", inputPath);
+    } else {
+      command_1.issueCommand("add-path", {}, inputPath);
+    }
+    process.env["PATH"] = `${inputPath}${path2.delimiter}${process.env["PATH"]}`;
+  }
+  exports2.addPath = addPath2;
+  function getInput3(name, options) {
+    const val = process.env[`INPUT_${name.replace(/ /g, "_").toUpperCase()}`] || "";
+    if (options && options.required && !val) {
+      throw new Error(`Input required and not supplied: ${name}`);
+    }
+    return val.trim();
+  }
+  exports2.getInput = getInput3;
+  function setOutput(name, value) {
+    command_1.issueCommand("set-output", {name}, value);
+  }
+  exports2.setOutput = setOutput;
+  function setCommandEcho(enabled) {
+    command_1.issue("echo", enabled ? "on" : "off");
+  }
+  exports2.setCommandEcho = setCommandEcho;
+  function setFailed2(message) {
+    process.exitCode = ExitCode.Failure;
+    error(message);
+  }
+  exports2.setFailed = setFailed2;
+  function isDebug() {
+    return process.env["RUNNER_DEBUG"] === "1";
+  }
+  exports2.isDebug = isDebug;
+  function debug(message) {
+    command_1.issueCommand("debug", {}, message);
+  }
+  exports2.debug = debug;
+  function error(message) {
+    command_1.issue("error", message instanceof Error ? message.toString() : message);
+  }
+  exports2.error = error;
+  function warning(message) {
+    command_1.issue("warning", message instanceof Error ? message.toString() : message);
+  }
+  exports2.warning = warning;
+  function info2(message) {
+    process.stdout.write(message + os2.EOL);
+  }
+  exports2.info = info2;
+  function startGroup2(name) {
+    command_1.issue("group", name);
+  }
+  exports2.startGroup = startGroup2;
+  function endGroup2() {
+    command_1.issue("endgroup");
+  }
+  exports2.endGroup = endGroup2;
+  function group(name, fn) {
+    return __awaiter(this, void 0, void 0, function* () {
+      startGroup2(name);
+      let result;
+      try {
+        result = yield fn();
+      } finally {
+        endGroup2();
+      }
+      return result;
+    });
+  }
+  exports2.group = group;
+  function saveState(name, value) {
+    command_1.issueCommand("save-state", {name}, value);
+  }
+  exports2.saveState = saveState;
+  function getState(name) {
+    return process.env[`STATE_${name}`] || "";
+  }
+  exports2.getState = getState;
 });
 
 // node_modules/@actions/exec/node_modules/@actions/io/lib/io-util.js
-var require_io_util = __commonJS({
-  "node_modules/@actions/exec/node_modules/@actions/io/lib/io-util.js"(exports2) {
-    "use strict";
-    var __createBinding = exports2 && exports2.__createBinding || (Object.create ? function(o, m, k, k2) {
-      if (k2 === void 0)
-        k2 = k;
-      Object.defineProperty(o, k2, { enumerable: true, get: function() {
-        return m[k];
-      } });
-    } : function(o, m, k, k2) {
-      if (k2 === void 0)
-        k2 = k;
-      o[k2] = m[k];
-    });
-    var __setModuleDefault = exports2 && exports2.__setModuleDefault || (Object.create ? function(o, v) {
-      Object.defineProperty(o, "default", { enumerable: true, value: v });
-    } : function(o, v) {
-      o["default"] = v;
-    });
-    var __importStar = exports2 && exports2.__importStar || function(mod) {
-      if (mod && mod.__esModule)
-        return mod;
-      var result = {};
-      if (mod != null) {
-        for (var k in mod)
-          if (k !== "default" && Object.hasOwnProperty.call(mod, k))
-            __createBinding(result, mod, k);
-      }
-      __setModuleDefault(result, mod);
-      return result;
-    };
-    var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
-      function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve) {
-          resolve(value);
-        });
-      }
-      return new (P || (P = Promise))(function(resolve, reject) {
-        function fulfilled(value) {
-          try {
-            step(generator.next(value));
-          } catch (e) {
-            reject(e);
-          }
-        }
-        function rejected(value) {
-          try {
-            step(generator["throw"](value));
-          } catch (e) {
-            reject(e);
-          }
-        }
-        function step(result) {
-          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
-        }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
+var require_io_util = __commonJS((exports2) => {
+  "use strict";
+  var __createBinding = exports2 && exports2.__createBinding || (Object.create ? function(o, m, k, k2) {
+    if (k2 === void 0)
+      k2 = k;
+    Object.defineProperty(o, k2, {enumerable: true, get: function() {
+      return m[k];
+    }});
+  } : function(o, m, k, k2) {
+    if (k2 === void 0)
+      k2 = k;
+    o[k2] = m[k];
+  });
+  var __setModuleDefault = exports2 && exports2.__setModuleDefault || (Object.create ? function(o, v) {
+    Object.defineProperty(o, "default", {enumerable: true, value: v});
+  } : function(o, v) {
+    o["default"] = v;
+  });
+  var __importStar = exports2 && exports2.__importStar || function(mod) {
+    if (mod && mod.__esModule)
+      return mod;
+    var result = {};
+    if (mod != null) {
+      for (var k in mod)
+        if (k !== "default" && Object.hasOwnProperty.call(mod, k))
+          __createBinding(result, mod, k);
+    }
+    __setModuleDefault(result, mod);
+    return result;
+  };
+  var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+    function adopt(value) {
+      return value instanceof P ? value : new P(function(resolve) {
+        resolve(value);
       });
-    };
-    var _a;
-    Object.defineProperty(exports2, "__esModule", { value: true });
-    exports2.getCmdPath = exports2.tryGetExecutablePath = exports2.isRooted = exports2.isDirectory = exports2.exists = exports2.IS_WINDOWS = exports2.unlink = exports2.symlink = exports2.stat = exports2.rmdir = exports2.rename = exports2.readlink = exports2.readdir = exports2.mkdir = exports2.lstat = exports2.copyFile = exports2.chmod = void 0;
-    var fs = __importStar(require("fs"));
-    var path2 = __importStar(require("path"));
-    _a = fs.promises, exports2.chmod = _a.chmod, exports2.copyFile = _a.copyFile, exports2.lstat = _a.lstat, exports2.mkdir = _a.mkdir, exports2.readdir = _a.readdir, exports2.readlink = _a.readlink, exports2.rename = _a.rename, exports2.rmdir = _a.rmdir, exports2.stat = _a.stat, exports2.symlink = _a.symlink, exports2.unlink = _a.unlink;
-    exports2.IS_WINDOWS = process.platform === "win32";
-    function exists(fsPath) {
-      return __awaiter(this, void 0, void 0, function* () {
+    }
+    return new (P || (P = Promise))(function(resolve, reject) {
+      function fulfilled(value) {
         try {
-          yield exports2.stat(fsPath);
-        } catch (err) {
-          if (err.code === "ENOENT") {
-            return false;
-          }
-          throw err;
+          step(generator.next(value));
+        } catch (e) {
+          reject(e);
         }
-        return true;
-      });
-    }
-    exports2.exists = exists;
-    function isDirectory(fsPath, useStat = false) {
-      return __awaiter(this, void 0, void 0, function* () {
-        const stats = useStat ? yield exports2.stat(fsPath) : yield exports2.lstat(fsPath);
-        return stats.isDirectory();
-      });
-    }
-    exports2.isDirectory = isDirectory;
-    function isRooted(p) {
-      p = normalizeSeparators(p);
-      if (!p) {
-        throw new Error('isRooted() parameter "p" cannot be empty');
       }
-      if (exports2.IS_WINDOWS) {
-        return p.startsWith("\\") || /^[A-Z]:/i.test(p);
+      function rejected(value) {
+        try {
+          step(generator["throw"](value));
+        } catch (e) {
+          reject(e);
+        }
       }
-      return p.startsWith("/");
+      function step(result) {
+        result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+      }
+      step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+  };
+  var _a;
+  Object.defineProperty(exports2, "__esModule", {value: true});
+  exports2.getCmdPath = exports2.tryGetExecutablePath = exports2.isRooted = exports2.isDirectory = exports2.exists = exports2.IS_WINDOWS = exports2.unlink = exports2.symlink = exports2.stat = exports2.rmdir = exports2.rename = exports2.readlink = exports2.readdir = exports2.mkdir = exports2.lstat = exports2.copyFile = exports2.chmod = void 0;
+  var fs = __importStar(require("fs"));
+  var path2 = __importStar(require("path"));
+  _a = fs.promises, exports2.chmod = _a.chmod, exports2.copyFile = _a.copyFile, exports2.lstat = _a.lstat, exports2.mkdir = _a.mkdir, exports2.readdir = _a.readdir, exports2.readlink = _a.readlink, exports2.rename = _a.rename, exports2.rmdir = _a.rmdir, exports2.stat = _a.stat, exports2.symlink = _a.symlink, exports2.unlink = _a.unlink;
+  exports2.IS_WINDOWS = process.platform === "win32";
+  function exists(fsPath) {
+    return __awaiter(this, void 0, void 0, function* () {
+      try {
+        yield exports2.stat(fsPath);
+      } catch (err) {
+        if (err.code === "ENOENT") {
+          return false;
+        }
+        throw err;
+      }
+      return true;
+    });
+  }
+  exports2.exists = exists;
+  function isDirectory(fsPath, useStat = false) {
+    return __awaiter(this, void 0, void 0, function* () {
+      const stats = useStat ? yield exports2.stat(fsPath) : yield exports2.lstat(fsPath);
+      return stats.isDirectory();
+    });
+  }
+  exports2.isDirectory = isDirectory;
+  function isRooted(p) {
+    p = normalizeSeparators(p);
+    if (!p) {
+      throw new Error('isRooted() parameter "p" cannot be empty');
     }
-    exports2.isRooted = isRooted;
-    function tryGetExecutablePath(filePath, extensions) {
-      return __awaiter(this, void 0, void 0, function* () {
-        let stats = void 0;
+    if (exports2.IS_WINDOWS) {
+      return p.startsWith("\\") || /^[A-Z]:/i.test(p);
+    }
+    return p.startsWith("/");
+  }
+  exports2.isRooted = isRooted;
+  function tryGetExecutablePath(filePath, extensions) {
+    return __awaiter(this, void 0, void 0, function* () {
+      let stats = void 0;
+      try {
+        stats = yield exports2.stat(filePath);
+      } catch (err) {
+        if (err.code !== "ENOENT") {
+          console.log(`Unexpected error attempting to determine if executable file exists '${filePath}': ${err}`);
+        }
+      }
+      if (stats && stats.isFile()) {
+        if (exports2.IS_WINDOWS) {
+          const upperExt = path2.extname(filePath).toUpperCase();
+          if (extensions.some((validExt) => validExt.toUpperCase() === upperExt)) {
+            return filePath;
+          }
+        } else {
+          if (isUnixExecutable(stats)) {
+            return filePath;
+          }
+        }
+      }
+      const originalFilePath = filePath;
+      for (const extension of extensions) {
+        filePath = originalFilePath + extension;
+        stats = void 0;
         try {
           stats = yield exports2.stat(filePath);
         } catch (err) {
@@ -407,272 +428,1161 @@ var require_io_util = __commonJS({
         }
         if (stats && stats.isFile()) {
           if (exports2.IS_WINDOWS) {
-            const upperExt = path2.extname(filePath).toUpperCase();
-            if (extensions.some((validExt) => validExt.toUpperCase() === upperExt)) {
-              return filePath;
+            try {
+              const directory = path2.dirname(filePath);
+              const upperName = path2.basename(filePath).toUpperCase();
+              for (const actualName of yield exports2.readdir(directory)) {
+                if (upperName === actualName.toUpperCase()) {
+                  filePath = path2.join(directory, actualName);
+                  break;
+                }
+              }
+            } catch (err) {
+              console.log(`Unexpected error attempting to determine the actual case of the file '${filePath}': ${err}`);
             }
+            return filePath;
           } else {
             if (isUnixExecutable(stats)) {
               return filePath;
             }
           }
         }
-        const originalFilePath = filePath;
-        for (const extension of extensions) {
-          filePath = originalFilePath + extension;
-          stats = void 0;
-          try {
-            stats = yield exports2.stat(filePath);
-          } catch (err) {
-            if (err.code !== "ENOENT") {
-              console.log(`Unexpected error attempting to determine if executable file exists '${filePath}': ${err}`);
-            }
-          }
-          if (stats && stats.isFile()) {
-            if (exports2.IS_WINDOWS) {
-              try {
-                const directory = path2.dirname(filePath);
-                const upperName = path2.basename(filePath).toUpperCase();
-                for (const actualName of yield exports2.readdir(directory)) {
-                  if (upperName === actualName.toUpperCase()) {
-                    filePath = path2.join(directory, actualName);
-                    break;
-                  }
-                }
-              } catch (err) {
-                console.log(`Unexpected error attempting to determine the actual case of the file '${filePath}': ${err}`);
-              }
-              return filePath;
-            } else {
-              if (isUnixExecutable(stats)) {
-                return filePath;
-              }
-            }
-          }
-        }
-        return "";
-      });
-    }
-    exports2.tryGetExecutablePath = tryGetExecutablePath;
-    function normalizeSeparators(p) {
-      p = p || "";
-      if (exports2.IS_WINDOWS) {
-        p = p.replace(/\//g, "\\");
-        return p.replace(/\\\\+/g, "\\");
       }
-      return p.replace(/\/\/+/g, "/");
-    }
-    function isUnixExecutable(stats) {
-      return (stats.mode & 1) > 0 || (stats.mode & 8) > 0 && stats.gid === process.getgid() || (stats.mode & 64) > 0 && stats.uid === process.getuid();
-    }
-    function getCmdPath() {
-      var _a2;
-      return (_a2 = process.env["COMSPEC"]) !== null && _a2 !== void 0 ? _a2 : `cmd.exe`;
-    }
-    exports2.getCmdPath = getCmdPath;
+      return "";
+    });
   }
+  exports2.tryGetExecutablePath = tryGetExecutablePath;
+  function normalizeSeparators(p) {
+    p = p || "";
+    if (exports2.IS_WINDOWS) {
+      p = p.replace(/\//g, "\\");
+      return p.replace(/\\\\+/g, "\\");
+    }
+    return p.replace(/\/\/+/g, "/");
+  }
+  function isUnixExecutable(stats) {
+    return (stats.mode & 1) > 0 || (stats.mode & 8) > 0 && stats.gid === process.getgid() || (stats.mode & 64) > 0 && stats.uid === process.getuid();
+  }
+  function getCmdPath() {
+    var _a2;
+    return (_a2 = process.env["COMSPEC"]) !== null && _a2 !== void 0 ? _a2 : `cmd.exe`;
+  }
+  exports2.getCmdPath = getCmdPath;
 });
 
 // node_modules/@actions/exec/node_modules/@actions/io/lib/io.js
-var require_io = __commonJS({
-  "node_modules/@actions/exec/node_modules/@actions/io/lib/io.js"(exports2) {
-    "use strict";
-    var __createBinding = exports2 && exports2.__createBinding || (Object.create ? function(o, m, k, k2) {
-      if (k2 === void 0)
-        k2 = k;
-      Object.defineProperty(o, k2, { enumerable: true, get: function() {
-        return m[k];
-      } });
-    } : function(o, m, k, k2) {
-      if (k2 === void 0)
-        k2 = k;
-      o[k2] = m[k];
-    });
-    var __setModuleDefault = exports2 && exports2.__setModuleDefault || (Object.create ? function(o, v) {
-      Object.defineProperty(o, "default", { enumerable: true, value: v });
-    } : function(o, v) {
-      o["default"] = v;
-    });
-    var __importStar = exports2 && exports2.__importStar || function(mod) {
-      if (mod && mod.__esModule)
-        return mod;
-      var result = {};
-      if (mod != null) {
-        for (var k in mod)
-          if (k !== "default" && Object.hasOwnProperty.call(mod, k))
-            __createBinding(result, mod, k);
-      }
-      __setModuleDefault(result, mod);
-      return result;
-    };
-    var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
-      function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve) {
-          resolve(value);
-        });
-      }
-      return new (P || (P = Promise))(function(resolve, reject) {
-        function fulfilled(value) {
-          try {
-            step(generator.next(value));
-          } catch (e) {
-            reject(e);
-          }
-        }
-        function rejected(value) {
-          try {
-            step(generator["throw"](value));
-          } catch (e) {
-            reject(e);
-          }
-        }
-        function step(result) {
-          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
-        }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
+var require_io = __commonJS((exports2) => {
+  "use strict";
+  var __createBinding = exports2 && exports2.__createBinding || (Object.create ? function(o, m, k, k2) {
+    if (k2 === void 0)
+      k2 = k;
+    Object.defineProperty(o, k2, {enumerable: true, get: function() {
+      return m[k];
+    }});
+  } : function(o, m, k, k2) {
+    if (k2 === void 0)
+      k2 = k;
+    o[k2] = m[k];
+  });
+  var __setModuleDefault = exports2 && exports2.__setModuleDefault || (Object.create ? function(o, v) {
+    Object.defineProperty(o, "default", {enumerable: true, value: v});
+  } : function(o, v) {
+    o["default"] = v;
+  });
+  var __importStar = exports2 && exports2.__importStar || function(mod) {
+    if (mod && mod.__esModule)
+      return mod;
+    var result = {};
+    if (mod != null) {
+      for (var k in mod)
+        if (k !== "default" && Object.hasOwnProperty.call(mod, k))
+          __createBinding(result, mod, k);
+    }
+    __setModuleDefault(result, mod);
+    return result;
+  };
+  var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+    function adopt(value) {
+      return value instanceof P ? value : new P(function(resolve) {
+        resolve(value);
       });
-    };
-    Object.defineProperty(exports2, "__esModule", { value: true });
-    exports2.findInPath = exports2.which = exports2.mkdirP = exports2.rmRF = exports2.mv = exports2.cp = void 0;
-    var assert_1 = require("assert");
-    var childProcess = __importStar(require("child_process"));
-    var path2 = __importStar(require("path"));
-    var util_1 = require("util");
-    var ioUtil = __importStar(require_io_util());
-    var exec5 = util_1.promisify(childProcess.exec);
-    var execFile = util_1.promisify(childProcess.execFile);
-    function cp(source, dest, options = {}) {
-      return __awaiter(this, void 0, void 0, function* () {
-        const { force, recursive, copySourceDirectory } = readCopyOptions(options);
-        const destStat = (yield ioUtil.exists(dest)) ? yield ioUtil.stat(dest) : null;
-        if (destStat && destStat.isFile() && !force) {
+    }
+    return new (P || (P = Promise))(function(resolve, reject) {
+      function fulfilled(value) {
+        try {
+          step(generator.next(value));
+        } catch (e) {
+          reject(e);
+        }
+      }
+      function rejected(value) {
+        try {
+          step(generator["throw"](value));
+        } catch (e) {
+          reject(e);
+        }
+      }
+      function step(result) {
+        result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+      }
+      step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+  };
+  Object.defineProperty(exports2, "__esModule", {value: true});
+  exports2.findInPath = exports2.which = exports2.mkdirP = exports2.rmRF = exports2.mv = exports2.cp = void 0;
+  var assert_1 = require("assert");
+  var childProcess = __importStar(require("child_process"));
+  var path2 = __importStar(require("path"));
+  var util_1 = require("util");
+  var ioUtil = __importStar(require_io_util());
+  var exec5 = util_1.promisify(childProcess.exec);
+  var execFile = util_1.promisify(childProcess.execFile);
+  function cp(source, dest, options = {}) {
+    return __awaiter(this, void 0, void 0, function* () {
+      const {force, recursive, copySourceDirectory} = readCopyOptions(options);
+      const destStat = (yield ioUtil.exists(dest)) ? yield ioUtil.stat(dest) : null;
+      if (destStat && destStat.isFile() && !force) {
+        return;
+      }
+      const newDest = destStat && destStat.isDirectory() && copySourceDirectory ? path2.join(dest, path2.basename(source)) : dest;
+      if (!(yield ioUtil.exists(source))) {
+        throw new Error(`no such file or directory: ${source}`);
+      }
+      const sourceStat = yield ioUtil.stat(source);
+      if (sourceStat.isDirectory()) {
+        if (!recursive) {
+          throw new Error(`Failed to copy. ${source} is a directory, but tried to copy without recursive flag.`);
+        } else {
+          yield cpDirRecursive(source, newDest, 0, force);
+        }
+      } else {
+        if (path2.relative(source, newDest) === "") {
+          throw new Error(`'${newDest}' and '${source}' are the same file`);
+        }
+        yield copyFile(source, newDest, force);
+      }
+    });
+  }
+  exports2.cp = cp;
+  function mv(source, dest, options = {}) {
+    return __awaiter(this, void 0, void 0, function* () {
+      if (yield ioUtil.exists(dest)) {
+        let destExists = true;
+        if (yield ioUtil.isDirectory(dest)) {
+          dest = path2.join(dest, path2.basename(source));
+          destExists = yield ioUtil.exists(dest);
+        }
+        if (destExists) {
+          if (options.force == null || options.force) {
+            yield rmRF(dest);
+          } else {
+            throw new Error("Destination already exists");
+          }
+        }
+      }
+      yield mkdirP(path2.dirname(dest));
+      yield ioUtil.rename(source, dest);
+    });
+  }
+  exports2.mv = mv;
+  function rmRF(inputPath) {
+    return __awaiter(this, void 0, void 0, function* () {
+      if (ioUtil.IS_WINDOWS) {
+        if (/[*"<>|]/.test(inputPath)) {
+          throw new Error('File path must not contain `*`, `"`, `<`, `>` or `|` on Windows');
+        }
+        try {
+          const cmdPath = ioUtil.getCmdPath();
+          if (yield ioUtil.isDirectory(inputPath, true)) {
+            yield exec5(`${cmdPath} /s /c "rd /s /q "%inputPath%""`, {
+              env: {inputPath}
+            });
+          } else {
+            yield exec5(`${cmdPath} /s /c "del /f /a "%inputPath%""`, {
+              env: {inputPath}
+            });
+          }
+        } catch (err) {
+          if (err.code !== "ENOENT")
+            throw err;
+        }
+        try {
+          yield ioUtil.unlink(inputPath);
+        } catch (err) {
+          if (err.code !== "ENOENT")
+            throw err;
+        }
+      } else {
+        let isDir = false;
+        try {
+          isDir = yield ioUtil.isDirectory(inputPath);
+        } catch (err) {
+          if (err.code !== "ENOENT")
+            throw err;
           return;
         }
-        const newDest = destStat && destStat.isDirectory() && copySourceDirectory ? path2.join(dest, path2.basename(source)) : dest;
-        if (!(yield ioUtil.exists(source))) {
-          throw new Error(`no such file or directory: ${source}`);
+        if (isDir) {
+          yield execFile(`rm`, [`-rf`, `${inputPath}`]);
+        } else {
+          yield ioUtil.unlink(inputPath);
         }
-        const sourceStat = yield ioUtil.stat(source);
-        if (sourceStat.isDirectory()) {
-          if (!recursive) {
-            throw new Error(`Failed to copy. ${source} is a directory, but tried to copy without recursive flag.`);
+      }
+    });
+  }
+  exports2.rmRF = rmRF;
+  function mkdirP(fsPath) {
+    return __awaiter(this, void 0, void 0, function* () {
+      assert_1.ok(fsPath, "a path argument must be provided");
+      yield ioUtil.mkdir(fsPath, {recursive: true});
+    });
+  }
+  exports2.mkdirP = mkdirP;
+  function which2(tool, check) {
+    return __awaiter(this, void 0, void 0, function* () {
+      if (!tool) {
+        throw new Error("parameter 'tool' is required");
+      }
+      if (check) {
+        const result = yield which2(tool, false);
+        if (!result) {
+          if (ioUtil.IS_WINDOWS) {
+            throw new Error(`Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also verify the file has a valid extension for an executable file.`);
           } else {
-            yield cpDirRecursive(source, newDest, 0, force);
-          }
-        } else {
-          if (path2.relative(source, newDest) === "") {
-            throw new Error(`'${newDest}' and '${source}' are the same file`);
-          }
-          yield copyFile(source, newDest, force);
-        }
-      });
-    }
-    exports2.cp = cp;
-    function mv(source, dest, options = {}) {
-      return __awaiter(this, void 0, void 0, function* () {
-        if (yield ioUtil.exists(dest)) {
-          let destExists = true;
-          if (yield ioUtil.isDirectory(dest)) {
-            dest = path2.join(dest, path2.basename(source));
-            destExists = yield ioUtil.exists(dest);
-          }
-          if (destExists) {
-            if (options.force == null || options.force) {
-              yield rmRF(dest);
-            } else {
-              throw new Error("Destination already exists");
-            }
+            throw new Error(`Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also check the file mode to verify the file is executable.`);
           }
         }
-        yield mkdirP(path2.dirname(dest));
-        yield ioUtil.rename(source, dest);
+        return result;
+      }
+      const matches = yield findInPath(tool);
+      if (matches && matches.length > 0) {
+        return matches[0];
+      }
+      return "";
+    });
+  }
+  exports2.which = which2;
+  function findInPath(tool) {
+    return __awaiter(this, void 0, void 0, function* () {
+      if (!tool) {
+        throw new Error("parameter 'tool' is required");
+      }
+      const extensions = [];
+      if (ioUtil.IS_WINDOWS && process.env["PATHEXT"]) {
+        for (const extension of process.env["PATHEXT"].split(path2.delimiter)) {
+          if (extension) {
+            extensions.push(extension);
+          }
+        }
+      }
+      if (ioUtil.isRooted(tool)) {
+        const filePath = yield ioUtil.tryGetExecutablePath(tool, extensions);
+        if (filePath) {
+          return [filePath];
+        }
+        return [];
+      }
+      if (tool.includes(path2.sep)) {
+        return [];
+      }
+      const directories = [];
+      if (process.env.PATH) {
+        for (const p of process.env.PATH.split(path2.delimiter)) {
+          if (p) {
+            directories.push(p);
+          }
+        }
+      }
+      const matches = [];
+      for (const directory of directories) {
+        const filePath = yield ioUtil.tryGetExecutablePath(path2.join(directory, tool), extensions);
+        if (filePath) {
+          matches.push(filePath);
+        }
+      }
+      return matches;
+    });
+  }
+  exports2.findInPath = findInPath;
+  function readCopyOptions(options) {
+    const force = options.force == null ? true : options.force;
+    const recursive = Boolean(options.recursive);
+    const copySourceDirectory = options.copySourceDirectory == null ? true : Boolean(options.copySourceDirectory);
+    return {force, recursive, copySourceDirectory};
+  }
+  function cpDirRecursive(sourceDir, destDir, currentDepth, force) {
+    return __awaiter(this, void 0, void 0, function* () {
+      if (currentDepth >= 255)
+        return;
+      currentDepth++;
+      yield mkdirP(destDir);
+      const files = yield ioUtil.readdir(sourceDir);
+      for (const fileName of files) {
+        const srcFile = `${sourceDir}/${fileName}`;
+        const destFile = `${destDir}/${fileName}`;
+        const srcFileStat = yield ioUtil.lstat(srcFile);
+        if (srcFileStat.isDirectory()) {
+          yield cpDirRecursive(srcFile, destFile, currentDepth, force);
+        } else {
+          yield copyFile(srcFile, destFile, force);
+        }
+      }
+      yield ioUtil.chmod(destDir, (yield ioUtil.stat(sourceDir)).mode);
+    });
+  }
+  function copyFile(srcFile, destFile, force) {
+    return __awaiter(this, void 0, void 0, function* () {
+      if ((yield ioUtil.lstat(srcFile)).isSymbolicLink()) {
+        try {
+          yield ioUtil.lstat(destFile);
+          yield ioUtil.unlink(destFile);
+        } catch (e) {
+          if (e.code === "EPERM") {
+            yield ioUtil.chmod(destFile, "0666");
+            yield ioUtil.unlink(destFile);
+          }
+        }
+        const symlinkFull = yield ioUtil.readlink(srcFile);
+        yield ioUtil.symlink(symlinkFull, destFile, ioUtil.IS_WINDOWS ? "junction" : null);
+      } else if (!(yield ioUtil.exists(destFile)) || force) {
+        yield ioUtil.copyFile(srcFile, destFile);
+      }
+    });
+  }
+});
+
+// node_modules/@actions/exec/lib/toolrunner.js
+var require_toolrunner = __commonJS((exports2) => {
+  "use strict";
+  var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+    function adopt(value) {
+      return value instanceof P ? value : new P(function(resolve) {
+        resolve(value);
       });
     }
-    exports2.mv = mv;
-    function rmRF(inputPath) {
-      return __awaiter(this, void 0, void 0, function* () {
-        if (ioUtil.IS_WINDOWS) {
-          if (/[*"<>|]/.test(inputPath)) {
-            throw new Error('File path must not contain `*`, `"`, `<`, `>` or `|` on Windows');
+    return new (P || (P = Promise))(function(resolve, reject) {
+      function fulfilled(value) {
+        try {
+          step(generator.next(value));
+        } catch (e) {
+          reject(e);
+        }
+      }
+      function rejected(value) {
+        try {
+          step(generator["throw"](value));
+        } catch (e) {
+          reject(e);
+        }
+      }
+      function step(result) {
+        result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+      }
+      step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+  };
+  var __importStar = exports2 && exports2.__importStar || function(mod) {
+    if (mod && mod.__esModule)
+      return mod;
+    var result = {};
+    if (mod != null) {
+      for (var k in mod)
+        if (Object.hasOwnProperty.call(mod, k))
+          result[k] = mod[k];
+    }
+    result["default"] = mod;
+    return result;
+  };
+  Object.defineProperty(exports2, "__esModule", {value: true});
+  var os2 = __importStar(require("os"));
+  var events = __importStar(require("events"));
+  var child = __importStar(require("child_process"));
+  var path2 = __importStar(require("path"));
+  var io2 = __importStar(require_io());
+  var ioUtil = __importStar(require_io_util());
+  var IS_WINDOWS = process.platform === "win32";
+  var ToolRunner = class extends events.EventEmitter {
+    constructor(toolPath, args, options) {
+      super();
+      if (!toolPath) {
+        throw new Error("Parameter 'toolPath' cannot be null or empty.");
+      }
+      this.toolPath = toolPath;
+      this.args = args || [];
+      this.options = options || {};
+    }
+    _debug(message) {
+      if (this.options.listeners && this.options.listeners.debug) {
+        this.options.listeners.debug(message);
+      }
+    }
+    _getCommandString(options, noPrefix) {
+      const toolPath = this._getSpawnFileName();
+      const args = this._getSpawnArgs(options);
+      let cmd = noPrefix ? "" : "[command]";
+      if (IS_WINDOWS) {
+        if (this._isCmdFile()) {
+          cmd += toolPath;
+          for (const a of args) {
+            cmd += ` ${a}`;
           }
-          try {
-            const cmdPath = ioUtil.getCmdPath();
-            if (yield ioUtil.isDirectory(inputPath, true)) {
-              yield exec5(`${cmdPath} /s /c "rd /s /q "%inputPath%""`, {
-                env: { inputPath }
-              });
-            } else {
-              yield exec5(`${cmdPath} /s /c "del /f /a "%inputPath%""`, {
-                env: { inputPath }
-              });
-            }
-          } catch (err) {
-            if (err.code !== "ENOENT")
-              throw err;
-          }
-          try {
-            yield ioUtil.unlink(inputPath);
-          } catch (err) {
-            if (err.code !== "ENOENT")
-              throw err;
+        } else if (options.windowsVerbatimArguments) {
+          cmd += `"${toolPath}"`;
+          for (const a of args) {
+            cmd += ` ${a}`;
           }
         } else {
-          let isDir = false;
-          try {
-            isDir = yield ioUtil.isDirectory(inputPath);
-          } catch (err) {
-            if (err.code !== "ENOENT")
-              throw err;
+          cmd += this._windowsQuoteCmdArg(toolPath);
+          for (const a of args) {
+            cmd += ` ${this._windowsQuoteCmdArg(a)}`;
+          }
+        }
+      } else {
+        cmd += toolPath;
+        for (const a of args) {
+          cmd += ` ${a}`;
+        }
+      }
+      return cmd;
+    }
+    _processLineBuffer(data, strBuffer, onLine) {
+      try {
+        let s = strBuffer + data.toString();
+        let n = s.indexOf(os2.EOL);
+        while (n > -1) {
+          const line = s.substring(0, n);
+          onLine(line);
+          s = s.substring(n + os2.EOL.length);
+          n = s.indexOf(os2.EOL);
+        }
+        strBuffer = s;
+      } catch (err) {
+        this._debug(`error processing line. Failed with error ${err}`);
+      }
+    }
+    _getSpawnFileName() {
+      if (IS_WINDOWS) {
+        if (this._isCmdFile()) {
+          return process.env["COMSPEC"] || "cmd.exe";
+        }
+      }
+      return this.toolPath;
+    }
+    _getSpawnArgs(options) {
+      if (IS_WINDOWS) {
+        if (this._isCmdFile()) {
+          let argline = `/D /S /C "${this._windowsQuoteCmdArg(this.toolPath)}`;
+          for (const a of this.args) {
+            argline += " ";
+            argline += options.windowsVerbatimArguments ? a : this._windowsQuoteCmdArg(a);
+          }
+          argline += '"';
+          return [argline];
+        }
+      }
+      return this.args;
+    }
+    _endsWith(str, end) {
+      return str.endsWith(end);
+    }
+    _isCmdFile() {
+      const upperToolPath = this.toolPath.toUpperCase();
+      return this._endsWith(upperToolPath, ".CMD") || this._endsWith(upperToolPath, ".BAT");
+    }
+    _windowsQuoteCmdArg(arg) {
+      if (!this._isCmdFile()) {
+        return this._uvQuoteCmdArg(arg);
+      }
+      if (!arg) {
+        return '""';
+      }
+      const cmdSpecialChars = [
+        " ",
+        "	",
+        "&",
+        "(",
+        ")",
+        "[",
+        "]",
+        "{",
+        "}",
+        "^",
+        "=",
+        ";",
+        "!",
+        "'",
+        "+",
+        ",",
+        "`",
+        "~",
+        "|",
+        "<",
+        ">",
+        '"'
+      ];
+      let needsQuotes = false;
+      for (const char of arg) {
+        if (cmdSpecialChars.some((x) => x === char)) {
+          needsQuotes = true;
+          break;
+        }
+      }
+      if (!needsQuotes) {
+        return arg;
+      }
+      let reverse = '"';
+      let quoteHit = true;
+      for (let i = arg.length; i > 0; i--) {
+        reverse += arg[i - 1];
+        if (quoteHit && arg[i - 1] === "\\") {
+          reverse += "\\";
+        } else if (arg[i - 1] === '"') {
+          quoteHit = true;
+          reverse += '"';
+        } else {
+          quoteHit = false;
+        }
+      }
+      reverse += '"';
+      return reverse.split("").reverse().join("");
+    }
+    _uvQuoteCmdArg(arg) {
+      if (!arg) {
+        return '""';
+      }
+      if (!arg.includes(" ") && !arg.includes("	") && !arg.includes('"')) {
+        return arg;
+      }
+      if (!arg.includes('"') && !arg.includes("\\")) {
+        return `"${arg}"`;
+      }
+      let reverse = '"';
+      let quoteHit = true;
+      for (let i = arg.length; i > 0; i--) {
+        reverse += arg[i - 1];
+        if (quoteHit && arg[i - 1] === "\\") {
+          reverse += "\\";
+        } else if (arg[i - 1] === '"') {
+          quoteHit = true;
+          reverse += "\\";
+        } else {
+          quoteHit = false;
+        }
+      }
+      reverse += '"';
+      return reverse.split("").reverse().join("");
+    }
+    _cloneExecOptions(options) {
+      options = options || {};
+      const result = {
+        cwd: options.cwd || process.cwd(),
+        env: options.env || process.env,
+        silent: options.silent || false,
+        windowsVerbatimArguments: options.windowsVerbatimArguments || false,
+        failOnStdErr: options.failOnStdErr || false,
+        ignoreReturnCode: options.ignoreReturnCode || false,
+        delay: options.delay || 1e4
+      };
+      result.outStream = options.outStream || process.stdout;
+      result.errStream = options.errStream || process.stderr;
+      return result;
+    }
+    _getSpawnOptions(options, toolPath) {
+      options = options || {};
+      const result = {};
+      result.cwd = options.cwd;
+      result.env = options.env;
+      result["windowsVerbatimArguments"] = options.windowsVerbatimArguments || this._isCmdFile();
+      if (options.windowsVerbatimArguments) {
+        result.argv0 = `"${toolPath}"`;
+      }
+      return result;
+    }
+    exec() {
+      return __awaiter(this, void 0, void 0, function* () {
+        if (!ioUtil.isRooted(this.toolPath) && (this.toolPath.includes("/") || IS_WINDOWS && this.toolPath.includes("\\"))) {
+          this.toolPath = path2.resolve(process.cwd(), this.options.cwd || process.cwd(), this.toolPath);
+        }
+        this.toolPath = yield io2.which(this.toolPath, true);
+        return new Promise((resolve, reject) => {
+          this._debug(`exec tool: ${this.toolPath}`);
+          this._debug("arguments:");
+          for (const arg of this.args) {
+            this._debug(`   ${arg}`);
+          }
+          const optionsNonNull = this._cloneExecOptions(this.options);
+          if (!optionsNonNull.silent && optionsNonNull.outStream) {
+            optionsNonNull.outStream.write(this._getCommandString(optionsNonNull) + os2.EOL);
+          }
+          const state = new ExecState(optionsNonNull, this.toolPath);
+          state.on("debug", (message) => {
+            this._debug(message);
+          });
+          const fileName = this._getSpawnFileName();
+          const cp = child.spawn(fileName, this._getSpawnArgs(optionsNonNull), this._getSpawnOptions(this.options, fileName));
+          const stdbuffer = "";
+          if (cp.stdout) {
+            cp.stdout.on("data", (data) => {
+              if (this.options.listeners && this.options.listeners.stdout) {
+                this.options.listeners.stdout(data);
+              }
+              if (!optionsNonNull.silent && optionsNonNull.outStream) {
+                optionsNonNull.outStream.write(data);
+              }
+              this._processLineBuffer(data, stdbuffer, (line) => {
+                if (this.options.listeners && this.options.listeners.stdline) {
+                  this.options.listeners.stdline(line);
+                }
+              });
+            });
+          }
+          const errbuffer = "";
+          if (cp.stderr) {
+            cp.stderr.on("data", (data) => {
+              state.processStderr = true;
+              if (this.options.listeners && this.options.listeners.stderr) {
+                this.options.listeners.stderr(data);
+              }
+              if (!optionsNonNull.silent && optionsNonNull.errStream && optionsNonNull.outStream) {
+                const s = optionsNonNull.failOnStdErr ? optionsNonNull.errStream : optionsNonNull.outStream;
+                s.write(data);
+              }
+              this._processLineBuffer(data, errbuffer, (line) => {
+                if (this.options.listeners && this.options.listeners.errline) {
+                  this.options.listeners.errline(line);
+                }
+              });
+            });
+          }
+          cp.on("error", (err) => {
+            state.processError = err.message;
+            state.processExited = true;
+            state.processClosed = true;
+            state.CheckComplete();
+          });
+          cp.on("exit", (code) => {
+            state.processExitCode = code;
+            state.processExited = true;
+            this._debug(`Exit code ${code} received from tool '${this.toolPath}'`);
+            state.CheckComplete();
+          });
+          cp.on("close", (code) => {
+            state.processExitCode = code;
+            state.processExited = true;
+            state.processClosed = true;
+            this._debug(`STDIO streams have closed for tool '${this.toolPath}'`);
+            state.CheckComplete();
+          });
+          state.on("done", (error, exitCode) => {
+            if (stdbuffer.length > 0) {
+              this.emit("stdline", stdbuffer);
+            }
+            if (errbuffer.length > 0) {
+              this.emit("errline", errbuffer);
+            }
+            cp.removeAllListeners();
+            if (error) {
+              reject(error);
+            } else {
+              resolve(exitCode);
+            }
+          });
+          if (this.options.input) {
+            if (!cp.stdin) {
+              throw new Error("child process missing stdin");
+            }
+            cp.stdin.end(this.options.input);
+          }
+        });
+      });
+    }
+  };
+  exports2.ToolRunner = ToolRunner;
+  function argStringToArray(argString) {
+    const args = [];
+    let inQuotes = false;
+    let escaped = false;
+    let arg = "";
+    function append(c) {
+      if (escaped && c !== '"') {
+        arg += "\\";
+      }
+      arg += c;
+      escaped = false;
+    }
+    for (let i = 0; i < argString.length; i++) {
+      const c = argString.charAt(i);
+      if (c === '"') {
+        if (!escaped) {
+          inQuotes = !inQuotes;
+        } else {
+          append(c);
+        }
+        continue;
+      }
+      if (c === "\\" && escaped) {
+        append(c);
+        continue;
+      }
+      if (c === "\\" && inQuotes) {
+        escaped = true;
+        continue;
+      }
+      if (c === " " && !inQuotes) {
+        if (arg.length > 0) {
+          args.push(arg);
+          arg = "";
+        }
+        continue;
+      }
+      append(c);
+    }
+    if (arg.length > 0) {
+      args.push(arg.trim());
+    }
+    return args;
+  }
+  exports2.argStringToArray = argStringToArray;
+  var ExecState = class extends events.EventEmitter {
+    constructor(options, toolPath) {
+      super();
+      this.processClosed = false;
+      this.processError = "";
+      this.processExitCode = 0;
+      this.processExited = false;
+      this.processStderr = false;
+      this.delay = 1e4;
+      this.done = false;
+      this.timeout = null;
+      if (!toolPath) {
+        throw new Error("toolPath must not be empty");
+      }
+      this.options = options;
+      this.toolPath = toolPath;
+      if (options.delay) {
+        this.delay = options.delay;
+      }
+    }
+    CheckComplete() {
+      if (this.done) {
+        return;
+      }
+      if (this.processClosed) {
+        this._setResult();
+      } else if (this.processExited) {
+        this.timeout = setTimeout(ExecState.HandleTimeout, this.delay, this);
+      }
+    }
+    _debug(message) {
+      this.emit("debug", message);
+    }
+    _setResult() {
+      let error;
+      if (this.processExited) {
+        if (this.processError) {
+          error = new Error(`There was an error when attempting to execute the process '${this.toolPath}'. This may indicate the process failed to start. Error: ${this.processError}`);
+        } else if (this.processExitCode !== 0 && !this.options.ignoreReturnCode) {
+          error = new Error(`The process '${this.toolPath}' failed with exit code ${this.processExitCode}`);
+        } else if (this.processStderr && this.options.failOnStdErr) {
+          error = new Error(`The process '${this.toolPath}' failed because one or more lines were written to the STDERR stream`);
+        }
+      }
+      if (this.timeout) {
+        clearTimeout(this.timeout);
+        this.timeout = null;
+      }
+      this.done = true;
+      this.emit("done", error, this.processExitCode);
+    }
+    static HandleTimeout(state) {
+      if (state.done) {
+        return;
+      }
+      if (!state.processClosed && state.processExited) {
+        const message = `The STDIO streams did not close within ${state.delay / 1e3} seconds of the exit event from process '${state.toolPath}'. This may indicate a child process inherited the STDIO streams and has not yet exited.`;
+        state._debug(message);
+      }
+      state._setResult();
+    }
+  };
+});
+
+// node_modules/@actions/exec/lib/exec.js
+var require_exec = __commonJS((exports2) => {
+  "use strict";
+  var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+    function adopt(value) {
+      return value instanceof P ? value : new P(function(resolve) {
+        resolve(value);
+      });
+    }
+    return new (P || (P = Promise))(function(resolve, reject) {
+      function fulfilled(value) {
+        try {
+          step(generator.next(value));
+        } catch (e) {
+          reject(e);
+        }
+      }
+      function rejected(value) {
+        try {
+          step(generator["throw"](value));
+        } catch (e) {
+          reject(e);
+        }
+      }
+      function step(result) {
+        result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+      }
+      step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+  };
+  var __importStar = exports2 && exports2.__importStar || function(mod) {
+    if (mod && mod.__esModule)
+      return mod;
+    var result = {};
+    if (mod != null) {
+      for (var k in mod)
+        if (Object.hasOwnProperty.call(mod, k))
+          result[k] = mod[k];
+    }
+    result["default"] = mod;
+    return result;
+  };
+  Object.defineProperty(exports2, "__esModule", {value: true});
+  var tr = __importStar(require_toolrunner());
+  function exec5(commandLine, args, options) {
+    return __awaiter(this, void 0, void 0, function* () {
+      const commandArgs = tr.argStringToArray(commandLine);
+      if (commandArgs.length === 0) {
+        throw new Error(`Parameter 'commandLine' cannot be null or empty.`);
+      }
+      const toolPath = commandArgs[0];
+      args = commandArgs.slice(1).concat(args || []);
+      const runner = new tr.ToolRunner(toolPath, args, options);
+      return runner.exec();
+    });
+  }
+  exports2.exec = exec5;
+});
+
+// node_modules/@actions/io/lib/io-util.js
+var require_io_util2 = __commonJS((exports2) => {
+  "use strict";
+  var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+    function adopt(value) {
+      return value instanceof P ? value : new P(function(resolve) {
+        resolve(value);
+      });
+    }
+    return new (P || (P = Promise))(function(resolve, reject) {
+      function fulfilled(value) {
+        try {
+          step(generator.next(value));
+        } catch (e) {
+          reject(e);
+        }
+      }
+      function rejected(value) {
+        try {
+          step(generator["throw"](value));
+        } catch (e) {
+          reject(e);
+        }
+      }
+      function step(result) {
+        result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+      }
+      step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+  };
+  var _a;
+  Object.defineProperty(exports2, "__esModule", {value: true});
+  var assert_1 = require("assert");
+  var fs = require("fs");
+  var path2 = require("path");
+  _a = fs.promises, exports2.chmod = _a.chmod, exports2.copyFile = _a.copyFile, exports2.lstat = _a.lstat, exports2.mkdir = _a.mkdir, exports2.readdir = _a.readdir, exports2.readlink = _a.readlink, exports2.rename = _a.rename, exports2.rmdir = _a.rmdir, exports2.stat = _a.stat, exports2.symlink = _a.symlink, exports2.unlink = _a.unlink;
+  exports2.IS_WINDOWS = process.platform === "win32";
+  function exists(fsPath) {
+    return __awaiter(this, void 0, void 0, function* () {
+      try {
+        yield exports2.stat(fsPath);
+      } catch (err) {
+        if (err.code === "ENOENT") {
+          return false;
+        }
+        throw err;
+      }
+      return true;
+    });
+  }
+  exports2.exists = exists;
+  function isDirectory(fsPath, useStat = false) {
+    return __awaiter(this, void 0, void 0, function* () {
+      const stats = useStat ? yield exports2.stat(fsPath) : yield exports2.lstat(fsPath);
+      return stats.isDirectory();
+    });
+  }
+  exports2.isDirectory = isDirectory;
+  function isRooted(p) {
+    p = normalizeSeparators(p);
+    if (!p) {
+      throw new Error('isRooted() parameter "p" cannot be empty');
+    }
+    if (exports2.IS_WINDOWS) {
+      return p.startsWith("\\") || /^[A-Z]:/i.test(p);
+    }
+    return p.startsWith("/");
+  }
+  exports2.isRooted = isRooted;
+  function mkdirP(fsPath, maxDepth = 1e3, depth = 1) {
+    return __awaiter(this, void 0, void 0, function* () {
+      assert_1.ok(fsPath, "a path argument must be provided");
+      fsPath = path2.resolve(fsPath);
+      if (depth >= maxDepth)
+        return exports2.mkdir(fsPath);
+      try {
+        yield exports2.mkdir(fsPath);
+        return;
+      } catch (err) {
+        switch (err.code) {
+          case "ENOENT": {
+            yield mkdirP(path2.dirname(fsPath), maxDepth, depth + 1);
+            yield exports2.mkdir(fsPath);
             return;
           }
-          if (isDir) {
-            yield execFile(`rm`, [`-rf`, `${inputPath}`]);
-          } else {
-            yield ioUtil.unlink(inputPath);
+          default: {
+            let stats;
+            try {
+              stats = yield exports2.stat(fsPath);
+            } catch (err2) {
+              throw err;
+            }
+            if (!stats.isDirectory())
+              throw err;
           }
         }
-      });
-    }
-    exports2.rmRF = rmRF;
-    function mkdirP(fsPath) {
-      return __awaiter(this, void 0, void 0, function* () {
-        assert_1.ok(fsPath, "a path argument must be provided");
-        yield ioUtil.mkdir(fsPath, { recursive: true });
-      });
-    }
-    exports2.mkdirP = mkdirP;
-    function which2(tool, check) {
-      return __awaiter(this, void 0, void 0, function* () {
-        if (!tool) {
-          throw new Error("parameter 'tool' is required");
+      }
+    });
+  }
+  exports2.mkdirP = mkdirP;
+  function tryGetExecutablePath(filePath, extensions) {
+    return __awaiter(this, void 0, void 0, function* () {
+      let stats = void 0;
+      try {
+        stats = yield exports2.stat(filePath);
+      } catch (err) {
+        if (err.code !== "ENOENT") {
+          console.log(`Unexpected error attempting to determine if executable file exists '${filePath}': ${err}`);
         }
-        if (check) {
-          const result = yield which2(tool, false);
-          if (!result) {
-            if (ioUtil.IS_WINDOWS) {
-              throw new Error(`Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also verify the file has a valid extension for an executable file.`);
-            } else {
-              throw new Error(`Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also check the file mode to verify the file is executable.`);
+      }
+      if (stats && stats.isFile()) {
+        if (exports2.IS_WINDOWS) {
+          const upperExt = path2.extname(filePath).toUpperCase();
+          if (extensions.some((validExt) => validExt.toUpperCase() === upperExt)) {
+            return filePath;
+          }
+        } else {
+          if (isUnixExecutable(stats)) {
+            return filePath;
+          }
+        }
+      }
+      const originalFilePath = filePath;
+      for (const extension of extensions) {
+        filePath = originalFilePath + extension;
+        stats = void 0;
+        try {
+          stats = yield exports2.stat(filePath);
+        } catch (err) {
+          if (err.code !== "ENOENT") {
+            console.log(`Unexpected error attempting to determine if executable file exists '${filePath}': ${err}`);
+          }
+        }
+        if (stats && stats.isFile()) {
+          if (exports2.IS_WINDOWS) {
+            try {
+              const directory = path2.dirname(filePath);
+              const upperName = path2.basename(filePath).toUpperCase();
+              for (const actualName of yield exports2.readdir(directory)) {
+                if (upperName === actualName.toUpperCase()) {
+                  filePath = path2.join(directory, actualName);
+                  break;
+                }
+              }
+            } catch (err) {
+              console.log(`Unexpected error attempting to determine the actual case of the file '${filePath}': ${err}`);
+            }
+            return filePath;
+          } else {
+            if (isUnixExecutable(stats)) {
+              return filePath;
             }
           }
-          return result;
         }
-        const matches = yield findInPath(tool);
-        if (matches && matches.length > 0) {
-          return matches[0];
-        }
-        return "";
+      }
+      return "";
+    });
+  }
+  exports2.tryGetExecutablePath = tryGetExecutablePath;
+  function normalizeSeparators(p) {
+    p = p || "";
+    if (exports2.IS_WINDOWS) {
+      p = p.replace(/\//g, "\\");
+      return p.replace(/\\\\+/g, "\\");
+    }
+    return p.replace(/\/\/+/g, "/");
+  }
+  function isUnixExecutable(stats) {
+    return (stats.mode & 1) > 0 || (stats.mode & 8) > 0 && stats.gid === process.getgid() || (stats.mode & 64) > 0 && stats.uid === process.getuid();
+  }
+});
+
+// node_modules/@actions/io/lib/io.js
+var require_io2 = __commonJS((exports2) => {
+  "use strict";
+  var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+    function adopt(value) {
+      return value instanceof P ? value : new P(function(resolve) {
+        resolve(value);
       });
     }
-    exports2.which = which2;
-    function findInPath(tool) {
-      return __awaiter(this, void 0, void 0, function* () {
-        if (!tool) {
-          throw new Error("parameter 'tool' is required");
+    return new (P || (P = Promise))(function(resolve, reject) {
+      function fulfilled(value) {
+        try {
+          step(generator.next(value));
+        } catch (e) {
+          reject(e);
         }
+      }
+      function rejected(value) {
+        try {
+          step(generator["throw"](value));
+        } catch (e) {
+          reject(e);
+        }
+      }
+      function step(result) {
+        result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+      }
+      step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+  };
+  Object.defineProperty(exports2, "__esModule", {value: true});
+  var childProcess = require("child_process");
+  var path2 = require("path");
+  var util_1 = require("util");
+  var ioUtil = require_io_util2();
+  var exec5 = util_1.promisify(childProcess.exec);
+  function cp(source, dest, options = {}) {
+    return __awaiter(this, void 0, void 0, function* () {
+      const {force, recursive} = readCopyOptions(options);
+      const destStat = (yield ioUtil.exists(dest)) ? yield ioUtil.stat(dest) : null;
+      if (destStat && destStat.isFile() && !force) {
+        return;
+      }
+      const newDest = destStat && destStat.isDirectory() ? path2.join(dest, path2.basename(source)) : dest;
+      if (!(yield ioUtil.exists(source))) {
+        throw new Error(`no such file or directory: ${source}`);
+      }
+      const sourceStat = yield ioUtil.stat(source);
+      if (sourceStat.isDirectory()) {
+        if (!recursive) {
+          throw new Error(`Failed to copy. ${source} is a directory, but tried to copy without recursive flag.`);
+        } else {
+          yield cpDirRecursive(source, newDest, 0, force);
+        }
+      } else {
+        if (path2.relative(source, newDest) === "") {
+          throw new Error(`'${newDest}' and '${source}' are the same file`);
+        }
+        yield copyFile(source, newDest, force);
+      }
+    });
+  }
+  exports2.cp = cp;
+  function mv(source, dest, options = {}) {
+    return __awaiter(this, void 0, void 0, function* () {
+      if (yield ioUtil.exists(dest)) {
+        let destExists = true;
+        if (yield ioUtil.isDirectory(dest)) {
+          dest = path2.join(dest, path2.basename(source));
+          destExists = yield ioUtil.exists(dest);
+        }
+        if (destExists) {
+          if (options.force == null || options.force) {
+            yield rmRF(dest);
+          } else {
+            throw new Error("Destination already exists");
+          }
+        }
+      }
+      yield mkdirP(path2.dirname(dest));
+      yield ioUtil.rename(source, dest);
+    });
+  }
+  exports2.mv = mv;
+  function rmRF(inputPath) {
+    return __awaiter(this, void 0, void 0, function* () {
+      if (ioUtil.IS_WINDOWS) {
+        try {
+          if (yield ioUtil.isDirectory(inputPath, true)) {
+            yield exec5(`rd /s /q "${inputPath}"`);
+          } else {
+            yield exec5(`del /f /a "${inputPath}"`);
+          }
+        } catch (err) {
+          if (err.code !== "ENOENT")
+            throw err;
+        }
+        try {
+          yield ioUtil.unlink(inputPath);
+        } catch (err) {
+          if (err.code !== "ENOENT")
+            throw err;
+        }
+      } else {
+        let isDir = false;
+        try {
+          isDir = yield ioUtil.isDirectory(inputPath);
+        } catch (err) {
+          if (err.code !== "ENOENT")
+            throw err;
+          return;
+        }
+        if (isDir) {
+          yield exec5(`rm -rf "${inputPath}"`);
+        } else {
+          yield ioUtil.unlink(inputPath);
+        }
+      }
+    });
+  }
+  exports2.rmRF = rmRF;
+  function mkdirP(fsPath) {
+    return __awaiter(this, void 0, void 0, function* () {
+      yield ioUtil.mkdirP(fsPath);
+    });
+  }
+  exports2.mkdirP = mkdirP;
+  function which2(tool, check) {
+    return __awaiter(this, void 0, void 0, function* () {
+      if (!tool) {
+        throw new Error("parameter 'tool' is required");
+      }
+      if (check) {
+        const result = yield which2(tool, false);
+        if (!result) {
+          if (ioUtil.IS_WINDOWS) {
+            throw new Error(`Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also verify the file has a valid extension for an executable file.`);
+          } else {
+            throw new Error(`Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also check the file mode to verify the file is executable.`);
+          }
+        }
+      }
+      try {
         const extensions = [];
-        if (ioUtil.IS_WINDOWS && process.env["PATHEXT"]) {
-          for (const extension of process.env["PATHEXT"].split(path2.delimiter)) {
+        if (ioUtil.IS_WINDOWS && process.env.PATHEXT) {
+          for (const extension of process.env.PATHEXT.split(path2.delimiter)) {
             if (extension) {
               extensions.push(extension);
             }
@@ -681,12 +1591,12 @@ var require_io = __commonJS({
         if (ioUtil.isRooted(tool)) {
           const filePath = yield ioUtil.tryGetExecutablePath(tool, extensions);
           if (filePath) {
-            return [filePath];
+            return filePath;
           }
-          return [];
+          return "";
         }
-        if (tool.includes(path2.sep)) {
-          return [];
+        if (tool.includes("/") || ioUtil.IS_WINDOWS && tool.includes("\\")) {
+          return "";
         }
         const directories = [];
         if (process.env.PATH) {
@@ -696,985 +1606,62 @@ var require_io = __commonJS({
             }
           }
         }
-        const matches = [];
         for (const directory of directories) {
-          const filePath = yield ioUtil.tryGetExecutablePath(path2.join(directory, tool), extensions);
+          const filePath = yield ioUtil.tryGetExecutablePath(directory + path2.sep + tool, extensions);
           if (filePath) {
-            matches.push(filePath);
-          }
-        }
-        return matches;
-      });
-    }
-    exports2.findInPath = findInPath;
-    function readCopyOptions(options) {
-      const force = options.force == null ? true : options.force;
-      const recursive = Boolean(options.recursive);
-      const copySourceDirectory = options.copySourceDirectory == null ? true : Boolean(options.copySourceDirectory);
-      return { force, recursive, copySourceDirectory };
-    }
-    function cpDirRecursive(sourceDir, destDir, currentDepth, force) {
-      return __awaiter(this, void 0, void 0, function* () {
-        if (currentDepth >= 255)
-          return;
-        currentDepth++;
-        yield mkdirP(destDir);
-        const files = yield ioUtil.readdir(sourceDir);
-        for (const fileName of files) {
-          const srcFile = `${sourceDir}/${fileName}`;
-          const destFile = `${destDir}/${fileName}`;
-          const srcFileStat = yield ioUtil.lstat(srcFile);
-          if (srcFileStat.isDirectory()) {
-            yield cpDirRecursive(srcFile, destFile, currentDepth, force);
-          } else {
-            yield copyFile(srcFile, destFile, force);
-          }
-        }
-        yield ioUtil.chmod(destDir, (yield ioUtil.stat(sourceDir)).mode);
-      });
-    }
-    function copyFile(srcFile, destFile, force) {
-      return __awaiter(this, void 0, void 0, function* () {
-        if ((yield ioUtil.lstat(srcFile)).isSymbolicLink()) {
-          try {
-            yield ioUtil.lstat(destFile);
-            yield ioUtil.unlink(destFile);
-          } catch (e) {
-            if (e.code === "EPERM") {
-              yield ioUtil.chmod(destFile, "0666");
-              yield ioUtil.unlink(destFile);
-            }
-          }
-          const symlinkFull = yield ioUtil.readlink(srcFile);
-          yield ioUtil.symlink(symlinkFull, destFile, ioUtil.IS_WINDOWS ? "junction" : null);
-        } else if (!(yield ioUtil.exists(destFile)) || force) {
-          yield ioUtil.copyFile(srcFile, destFile);
-        }
-      });
-    }
-  }
-});
-
-// node_modules/@actions/exec/lib/toolrunner.js
-var require_toolrunner = __commonJS({
-  "node_modules/@actions/exec/lib/toolrunner.js"(exports2) {
-    "use strict";
-    var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
-      function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve) {
-          resolve(value);
-        });
-      }
-      return new (P || (P = Promise))(function(resolve, reject) {
-        function fulfilled(value) {
-          try {
-            step(generator.next(value));
-          } catch (e) {
-            reject(e);
-          }
-        }
-        function rejected(value) {
-          try {
-            step(generator["throw"](value));
-          } catch (e) {
-            reject(e);
-          }
-        }
-        function step(result) {
-          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
-        }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-      });
-    };
-    var __importStar = exports2 && exports2.__importStar || function(mod) {
-      if (mod && mod.__esModule)
-        return mod;
-      var result = {};
-      if (mod != null) {
-        for (var k in mod)
-          if (Object.hasOwnProperty.call(mod, k))
-            result[k] = mod[k];
-      }
-      result["default"] = mod;
-      return result;
-    };
-    Object.defineProperty(exports2, "__esModule", { value: true });
-    var os2 = __importStar(require("os"));
-    var events = __importStar(require("events"));
-    var child = __importStar(require("child_process"));
-    var path2 = __importStar(require("path"));
-    var io2 = __importStar(require_io());
-    var ioUtil = __importStar(require_io_util());
-    var IS_WINDOWS = process.platform === "win32";
-    var ToolRunner = class extends events.EventEmitter {
-      constructor(toolPath, args, options) {
-        super();
-        if (!toolPath) {
-          throw new Error("Parameter 'toolPath' cannot be null or empty.");
-        }
-        this.toolPath = toolPath;
-        this.args = args || [];
-        this.options = options || {};
-      }
-      _debug(message) {
-        if (this.options.listeners && this.options.listeners.debug) {
-          this.options.listeners.debug(message);
-        }
-      }
-      _getCommandString(options, noPrefix) {
-        const toolPath = this._getSpawnFileName();
-        const args = this._getSpawnArgs(options);
-        let cmd = noPrefix ? "" : "[command]";
-        if (IS_WINDOWS) {
-          if (this._isCmdFile()) {
-            cmd += toolPath;
-            for (const a of args) {
-              cmd += ` ${a}`;
-            }
-          } else if (options.windowsVerbatimArguments) {
-            cmd += `"${toolPath}"`;
-            for (const a of args) {
-              cmd += ` ${a}`;
-            }
-          } else {
-            cmd += this._windowsQuoteCmdArg(toolPath);
-            for (const a of args) {
-              cmd += ` ${this._windowsQuoteCmdArg(a)}`;
-            }
-          }
-        } else {
-          cmd += toolPath;
-          for (const a of args) {
-            cmd += ` ${a}`;
-          }
-        }
-        return cmd;
-      }
-      _processLineBuffer(data, strBuffer, onLine) {
-        try {
-          let s = strBuffer + data.toString();
-          let n = s.indexOf(os2.EOL);
-          while (n > -1) {
-            const line = s.substring(0, n);
-            onLine(line);
-            s = s.substring(n + os2.EOL.length);
-            n = s.indexOf(os2.EOL);
-          }
-          strBuffer = s;
-        } catch (err) {
-          this._debug(`error processing line. Failed with error ${err}`);
-        }
-      }
-      _getSpawnFileName() {
-        if (IS_WINDOWS) {
-          if (this._isCmdFile()) {
-            return process.env["COMSPEC"] || "cmd.exe";
-          }
-        }
-        return this.toolPath;
-      }
-      _getSpawnArgs(options) {
-        if (IS_WINDOWS) {
-          if (this._isCmdFile()) {
-            let argline = `/D /S /C "${this._windowsQuoteCmdArg(this.toolPath)}`;
-            for (const a of this.args) {
-              argline += " ";
-              argline += options.windowsVerbatimArguments ? a : this._windowsQuoteCmdArg(a);
-            }
-            argline += '"';
-            return [argline];
-          }
-        }
-        return this.args;
-      }
-      _endsWith(str, end) {
-        return str.endsWith(end);
-      }
-      _isCmdFile() {
-        const upperToolPath = this.toolPath.toUpperCase();
-        return this._endsWith(upperToolPath, ".CMD") || this._endsWith(upperToolPath, ".BAT");
-      }
-      _windowsQuoteCmdArg(arg) {
-        if (!this._isCmdFile()) {
-          return this._uvQuoteCmdArg(arg);
-        }
-        if (!arg) {
-          return '""';
-        }
-        const cmdSpecialChars = [
-          " ",
-          "	",
-          "&",
-          "(",
-          ")",
-          "[",
-          "]",
-          "{",
-          "}",
-          "^",
-          "=",
-          ";",
-          "!",
-          "'",
-          "+",
-          ",",
-          "`",
-          "~",
-          "|",
-          "<",
-          ">",
-          '"'
-        ];
-        let needsQuotes = false;
-        for (const char of arg) {
-          if (cmdSpecialChars.some((x) => x === char)) {
-            needsQuotes = true;
-            break;
-          }
-        }
-        if (!needsQuotes) {
-          return arg;
-        }
-        let reverse = '"';
-        let quoteHit = true;
-        for (let i = arg.length; i > 0; i--) {
-          reverse += arg[i - 1];
-          if (quoteHit && arg[i - 1] === "\\") {
-            reverse += "\\";
-          } else if (arg[i - 1] === '"') {
-            quoteHit = true;
-            reverse += '"';
-          } else {
-            quoteHit = false;
-          }
-        }
-        reverse += '"';
-        return reverse.split("").reverse().join("");
-      }
-      _uvQuoteCmdArg(arg) {
-        if (!arg) {
-          return '""';
-        }
-        if (!arg.includes(" ") && !arg.includes("	") && !arg.includes('"')) {
-          return arg;
-        }
-        if (!arg.includes('"') && !arg.includes("\\")) {
-          return `"${arg}"`;
-        }
-        let reverse = '"';
-        let quoteHit = true;
-        for (let i = arg.length; i > 0; i--) {
-          reverse += arg[i - 1];
-          if (quoteHit && arg[i - 1] === "\\") {
-            reverse += "\\";
-          } else if (arg[i - 1] === '"') {
-            quoteHit = true;
-            reverse += "\\";
-          } else {
-            quoteHit = false;
-          }
-        }
-        reverse += '"';
-        return reverse.split("").reverse().join("");
-      }
-      _cloneExecOptions(options) {
-        options = options || {};
-        const result = {
-          cwd: options.cwd || process.cwd(),
-          env: options.env || process.env,
-          silent: options.silent || false,
-          windowsVerbatimArguments: options.windowsVerbatimArguments || false,
-          failOnStdErr: options.failOnStdErr || false,
-          ignoreReturnCode: options.ignoreReturnCode || false,
-          delay: options.delay || 1e4
-        };
-        result.outStream = options.outStream || process.stdout;
-        result.errStream = options.errStream || process.stderr;
-        return result;
-      }
-      _getSpawnOptions(options, toolPath) {
-        options = options || {};
-        const result = {};
-        result.cwd = options.cwd;
-        result.env = options.env;
-        result["windowsVerbatimArguments"] = options.windowsVerbatimArguments || this._isCmdFile();
-        if (options.windowsVerbatimArguments) {
-          result.argv0 = `"${toolPath}"`;
-        }
-        return result;
-      }
-      exec() {
-        return __awaiter(this, void 0, void 0, function* () {
-          if (!ioUtil.isRooted(this.toolPath) && (this.toolPath.includes("/") || IS_WINDOWS && this.toolPath.includes("\\"))) {
-            this.toolPath = path2.resolve(process.cwd(), this.options.cwd || process.cwd(), this.toolPath);
-          }
-          this.toolPath = yield io2.which(this.toolPath, true);
-          return new Promise((resolve, reject) => {
-            this._debug(`exec tool: ${this.toolPath}`);
-            this._debug("arguments:");
-            for (const arg of this.args) {
-              this._debug(`   ${arg}`);
-            }
-            const optionsNonNull = this._cloneExecOptions(this.options);
-            if (!optionsNonNull.silent && optionsNonNull.outStream) {
-              optionsNonNull.outStream.write(this._getCommandString(optionsNonNull) + os2.EOL);
-            }
-            const state = new ExecState(optionsNonNull, this.toolPath);
-            state.on("debug", (message) => {
-              this._debug(message);
-            });
-            const fileName = this._getSpawnFileName();
-            const cp = child.spawn(fileName, this._getSpawnArgs(optionsNonNull), this._getSpawnOptions(this.options, fileName));
-            const stdbuffer = "";
-            if (cp.stdout) {
-              cp.stdout.on("data", (data) => {
-                if (this.options.listeners && this.options.listeners.stdout) {
-                  this.options.listeners.stdout(data);
-                }
-                if (!optionsNonNull.silent && optionsNonNull.outStream) {
-                  optionsNonNull.outStream.write(data);
-                }
-                this._processLineBuffer(data, stdbuffer, (line) => {
-                  if (this.options.listeners && this.options.listeners.stdline) {
-                    this.options.listeners.stdline(line);
-                  }
-                });
-              });
-            }
-            const errbuffer = "";
-            if (cp.stderr) {
-              cp.stderr.on("data", (data) => {
-                state.processStderr = true;
-                if (this.options.listeners && this.options.listeners.stderr) {
-                  this.options.listeners.stderr(data);
-                }
-                if (!optionsNonNull.silent && optionsNonNull.errStream && optionsNonNull.outStream) {
-                  const s = optionsNonNull.failOnStdErr ? optionsNonNull.errStream : optionsNonNull.outStream;
-                  s.write(data);
-                }
-                this._processLineBuffer(data, errbuffer, (line) => {
-                  if (this.options.listeners && this.options.listeners.errline) {
-                    this.options.listeners.errline(line);
-                  }
-                });
-              });
-            }
-            cp.on("error", (err) => {
-              state.processError = err.message;
-              state.processExited = true;
-              state.processClosed = true;
-              state.CheckComplete();
-            });
-            cp.on("exit", (code) => {
-              state.processExitCode = code;
-              state.processExited = true;
-              this._debug(`Exit code ${code} received from tool '${this.toolPath}'`);
-              state.CheckComplete();
-            });
-            cp.on("close", (code) => {
-              state.processExitCode = code;
-              state.processExited = true;
-              state.processClosed = true;
-              this._debug(`STDIO streams have closed for tool '${this.toolPath}'`);
-              state.CheckComplete();
-            });
-            state.on("done", (error, exitCode) => {
-              if (stdbuffer.length > 0) {
-                this.emit("stdline", stdbuffer);
-              }
-              if (errbuffer.length > 0) {
-                this.emit("errline", errbuffer);
-              }
-              cp.removeAllListeners();
-              if (error) {
-                reject(error);
-              } else {
-                resolve(exitCode);
-              }
-            });
-            if (this.options.input) {
-              if (!cp.stdin) {
-                throw new Error("child process missing stdin");
-              }
-              cp.stdin.end(this.options.input);
-            }
-          });
-        });
-      }
-    };
-    exports2.ToolRunner = ToolRunner;
-    function argStringToArray(argString) {
-      const args = [];
-      let inQuotes = false;
-      let escaped = false;
-      let arg = "";
-      function append(c) {
-        if (escaped && c !== '"') {
-          arg += "\\";
-        }
-        arg += c;
-        escaped = false;
-      }
-      for (let i = 0; i < argString.length; i++) {
-        const c = argString.charAt(i);
-        if (c === '"') {
-          if (!escaped) {
-            inQuotes = !inQuotes;
-          } else {
-            append(c);
-          }
-          continue;
-        }
-        if (c === "\\" && escaped) {
-          append(c);
-          continue;
-        }
-        if (c === "\\" && inQuotes) {
-          escaped = true;
-          continue;
-        }
-        if (c === " " && !inQuotes) {
-          if (arg.length > 0) {
-            args.push(arg);
-            arg = "";
-          }
-          continue;
-        }
-        append(c);
-      }
-      if (arg.length > 0) {
-        args.push(arg.trim());
-      }
-      return args;
-    }
-    exports2.argStringToArray = argStringToArray;
-    var ExecState = class extends events.EventEmitter {
-      constructor(options, toolPath) {
-        super();
-        this.processClosed = false;
-        this.processError = "";
-        this.processExitCode = 0;
-        this.processExited = false;
-        this.processStderr = false;
-        this.delay = 1e4;
-        this.done = false;
-        this.timeout = null;
-        if (!toolPath) {
-          throw new Error("toolPath must not be empty");
-        }
-        this.options = options;
-        this.toolPath = toolPath;
-        if (options.delay) {
-          this.delay = options.delay;
-        }
-      }
-      CheckComplete() {
-        if (this.done) {
-          return;
-        }
-        if (this.processClosed) {
-          this._setResult();
-        } else if (this.processExited) {
-          this.timeout = setTimeout(ExecState.HandleTimeout, this.delay, this);
-        }
-      }
-      _debug(message) {
-        this.emit("debug", message);
-      }
-      _setResult() {
-        let error;
-        if (this.processExited) {
-          if (this.processError) {
-            error = new Error(`There was an error when attempting to execute the process '${this.toolPath}'. This may indicate the process failed to start. Error: ${this.processError}`);
-          } else if (this.processExitCode !== 0 && !this.options.ignoreReturnCode) {
-            error = new Error(`The process '${this.toolPath}' failed with exit code ${this.processExitCode}`);
-          } else if (this.processStderr && this.options.failOnStdErr) {
-            error = new Error(`The process '${this.toolPath}' failed because one or more lines were written to the STDERR stream`);
-          }
-        }
-        if (this.timeout) {
-          clearTimeout(this.timeout);
-          this.timeout = null;
-        }
-        this.done = true;
-        this.emit("done", error, this.processExitCode);
-      }
-      static HandleTimeout(state) {
-        if (state.done) {
-          return;
-        }
-        if (!state.processClosed && state.processExited) {
-          const message = `The STDIO streams did not close within ${state.delay / 1e3} seconds of the exit event from process '${state.toolPath}'. This may indicate a child process inherited the STDIO streams and has not yet exited.`;
-          state._debug(message);
-        }
-        state._setResult();
-      }
-    };
-  }
-});
-
-// node_modules/@actions/exec/lib/exec.js
-var require_exec = __commonJS({
-  "node_modules/@actions/exec/lib/exec.js"(exports2) {
-    "use strict";
-    var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
-      function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve) {
-          resolve(value);
-        });
-      }
-      return new (P || (P = Promise))(function(resolve, reject) {
-        function fulfilled(value) {
-          try {
-            step(generator.next(value));
-          } catch (e) {
-            reject(e);
-          }
-        }
-        function rejected(value) {
-          try {
-            step(generator["throw"](value));
-          } catch (e) {
-            reject(e);
-          }
-        }
-        function step(result) {
-          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
-        }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-      });
-    };
-    var __importStar = exports2 && exports2.__importStar || function(mod) {
-      if (mod && mod.__esModule)
-        return mod;
-      var result = {};
-      if (mod != null) {
-        for (var k in mod)
-          if (Object.hasOwnProperty.call(mod, k))
-            result[k] = mod[k];
-      }
-      result["default"] = mod;
-      return result;
-    };
-    Object.defineProperty(exports2, "__esModule", { value: true });
-    var tr = __importStar(require_toolrunner());
-    function exec5(commandLine, args, options) {
-      return __awaiter(this, void 0, void 0, function* () {
-        const commandArgs = tr.argStringToArray(commandLine);
-        if (commandArgs.length === 0) {
-          throw new Error(`Parameter 'commandLine' cannot be null or empty.`);
-        }
-        const toolPath = commandArgs[0];
-        args = commandArgs.slice(1).concat(args || []);
-        const runner = new tr.ToolRunner(toolPath, args, options);
-        return runner.exec();
-      });
-    }
-    exports2.exec = exec5;
-  }
-});
-
-// node_modules/@actions/io/lib/io-util.js
-var require_io_util2 = __commonJS({
-  "node_modules/@actions/io/lib/io-util.js"(exports2) {
-    "use strict";
-    var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
-      function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve) {
-          resolve(value);
-        });
-      }
-      return new (P || (P = Promise))(function(resolve, reject) {
-        function fulfilled(value) {
-          try {
-            step(generator.next(value));
-          } catch (e) {
-            reject(e);
-          }
-        }
-        function rejected(value) {
-          try {
-            step(generator["throw"](value));
-          } catch (e) {
-            reject(e);
-          }
-        }
-        function step(result) {
-          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
-        }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-      });
-    };
-    var _a;
-    Object.defineProperty(exports2, "__esModule", { value: true });
-    var assert_1 = require("assert");
-    var fs = require("fs");
-    var path2 = require("path");
-    _a = fs.promises, exports2.chmod = _a.chmod, exports2.copyFile = _a.copyFile, exports2.lstat = _a.lstat, exports2.mkdir = _a.mkdir, exports2.readdir = _a.readdir, exports2.readlink = _a.readlink, exports2.rename = _a.rename, exports2.rmdir = _a.rmdir, exports2.stat = _a.stat, exports2.symlink = _a.symlink, exports2.unlink = _a.unlink;
-    exports2.IS_WINDOWS = process.platform === "win32";
-    function exists(fsPath) {
-      return __awaiter(this, void 0, void 0, function* () {
-        try {
-          yield exports2.stat(fsPath);
-        } catch (err) {
-          if (err.code === "ENOENT") {
-            return false;
-          }
-          throw err;
-        }
-        return true;
-      });
-    }
-    exports2.exists = exists;
-    function isDirectory(fsPath, useStat = false) {
-      return __awaiter(this, void 0, void 0, function* () {
-        const stats = useStat ? yield exports2.stat(fsPath) : yield exports2.lstat(fsPath);
-        return stats.isDirectory();
-      });
-    }
-    exports2.isDirectory = isDirectory;
-    function isRooted(p) {
-      p = normalizeSeparators(p);
-      if (!p) {
-        throw new Error('isRooted() parameter "p" cannot be empty');
-      }
-      if (exports2.IS_WINDOWS) {
-        return p.startsWith("\\") || /^[A-Z]:/i.test(p);
-      }
-      return p.startsWith("/");
-    }
-    exports2.isRooted = isRooted;
-    function mkdirP(fsPath, maxDepth = 1e3, depth = 1) {
-      return __awaiter(this, void 0, void 0, function* () {
-        assert_1.ok(fsPath, "a path argument must be provided");
-        fsPath = path2.resolve(fsPath);
-        if (depth >= maxDepth)
-          return exports2.mkdir(fsPath);
-        try {
-          yield exports2.mkdir(fsPath);
-          return;
-        } catch (err) {
-          switch (err.code) {
-            case "ENOENT": {
-              yield mkdirP(path2.dirname(fsPath), maxDepth, depth + 1);
-              yield exports2.mkdir(fsPath);
-              return;
-            }
-            default: {
-              let stats;
-              try {
-                stats = yield exports2.stat(fsPath);
-              } catch (err2) {
-                throw err;
-              }
-              if (!stats.isDirectory())
-                throw err;
-            }
-          }
-        }
-      });
-    }
-    exports2.mkdirP = mkdirP;
-    function tryGetExecutablePath(filePath, extensions) {
-      return __awaiter(this, void 0, void 0, function* () {
-        let stats = void 0;
-        try {
-          stats = yield exports2.stat(filePath);
-        } catch (err) {
-          if (err.code !== "ENOENT") {
-            console.log(`Unexpected error attempting to determine if executable file exists '${filePath}': ${err}`);
-          }
-        }
-        if (stats && stats.isFile()) {
-          if (exports2.IS_WINDOWS) {
-            const upperExt = path2.extname(filePath).toUpperCase();
-            if (extensions.some((validExt) => validExt.toUpperCase() === upperExt)) {
-              return filePath;
-            }
-          } else {
-            if (isUnixExecutable(stats)) {
-              return filePath;
-            }
-          }
-        }
-        const originalFilePath = filePath;
-        for (const extension of extensions) {
-          filePath = originalFilePath + extension;
-          stats = void 0;
-          try {
-            stats = yield exports2.stat(filePath);
-          } catch (err) {
-            if (err.code !== "ENOENT") {
-              console.log(`Unexpected error attempting to determine if executable file exists '${filePath}': ${err}`);
-            }
-          }
-          if (stats && stats.isFile()) {
-            if (exports2.IS_WINDOWS) {
-              try {
-                const directory = path2.dirname(filePath);
-                const upperName = path2.basename(filePath).toUpperCase();
-                for (const actualName of yield exports2.readdir(directory)) {
-                  if (upperName === actualName.toUpperCase()) {
-                    filePath = path2.join(directory, actualName);
-                    break;
-                  }
-                }
-              } catch (err) {
-                console.log(`Unexpected error attempting to determine the actual case of the file '${filePath}': ${err}`);
-              }
-              return filePath;
-            } else {
-              if (isUnixExecutable(stats)) {
-                return filePath;
-              }
-            }
+            return filePath;
           }
         }
         return "";
-      });
-    }
-    exports2.tryGetExecutablePath = tryGetExecutablePath;
-    function normalizeSeparators(p) {
-      p = p || "";
-      if (exports2.IS_WINDOWS) {
-        p = p.replace(/\//g, "\\");
-        return p.replace(/\\\\+/g, "\\");
+      } catch (err) {
+        throw new Error(`which failed with message ${err.message}`);
       }
-      return p.replace(/\/\/+/g, "/");
-    }
-    function isUnixExecutable(stats) {
-      return (stats.mode & 1) > 0 || (stats.mode & 8) > 0 && stats.gid === process.getgid() || (stats.mode & 64) > 0 && stats.uid === process.getuid();
-    }
+    });
   }
-});
-
-// node_modules/@actions/io/lib/io.js
-var require_io2 = __commonJS({
-  "node_modules/@actions/io/lib/io.js"(exports2) {
-    "use strict";
-    var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
-      function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve) {
-          resolve(value);
-        });
+  exports2.which = which2;
+  function readCopyOptions(options) {
+    const force = options.force == null ? true : options.force;
+    const recursive = Boolean(options.recursive);
+    return {force, recursive};
+  }
+  function cpDirRecursive(sourceDir, destDir, currentDepth, force) {
+    return __awaiter(this, void 0, void 0, function* () {
+      if (currentDepth >= 255)
+        return;
+      currentDepth++;
+      yield mkdirP(destDir);
+      const files = yield ioUtil.readdir(sourceDir);
+      for (const fileName of files) {
+        const srcFile = `${sourceDir}/${fileName}`;
+        const destFile = `${destDir}/${fileName}`;
+        const srcFileStat = yield ioUtil.lstat(srcFile);
+        if (srcFileStat.isDirectory()) {
+          yield cpDirRecursive(srcFile, destFile, currentDepth, force);
+        } else {
+          yield copyFile(srcFile, destFile, force);
+        }
       }
-      return new (P || (P = Promise))(function(resolve, reject) {
-        function fulfilled(value) {
-          try {
-            step(generator.next(value));
-          } catch (e) {
-            reject(e);
-          }
-        }
-        function rejected(value) {
-          try {
-            step(generator["throw"](value));
-          } catch (e) {
-            reject(e);
-          }
-        }
-        function step(result) {
-          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
-        }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-      });
-    };
-    Object.defineProperty(exports2, "__esModule", { value: true });
-    var childProcess = require("child_process");
-    var path2 = require("path");
-    var util_1 = require("util");
-    var ioUtil = require_io_util2();
-    var exec5 = util_1.promisify(childProcess.exec);
-    function cp(source, dest, options = {}) {
-      return __awaiter(this, void 0, void 0, function* () {
-        const { force, recursive } = readCopyOptions(options);
-        const destStat = (yield ioUtil.exists(dest)) ? yield ioUtil.stat(dest) : null;
-        if (destStat && destStat.isFile() && !force) {
-          return;
-        }
-        const newDest = destStat && destStat.isDirectory() ? path2.join(dest, path2.basename(source)) : dest;
-        if (!(yield ioUtil.exists(source))) {
-          throw new Error(`no such file or directory: ${source}`);
-        }
-        const sourceStat = yield ioUtil.stat(source);
-        if (sourceStat.isDirectory()) {
-          if (!recursive) {
-            throw new Error(`Failed to copy. ${source} is a directory, but tried to copy without recursive flag.`);
-          } else {
-            yield cpDirRecursive(source, newDest, 0, force);
-          }
-        } else {
-          if (path2.relative(source, newDest) === "") {
-            throw new Error(`'${newDest}' and '${source}' are the same file`);
-          }
-          yield copyFile(source, newDest, force);
-        }
-      });
-    }
-    exports2.cp = cp;
-    function mv(source, dest, options = {}) {
-      return __awaiter(this, void 0, void 0, function* () {
-        if (yield ioUtil.exists(dest)) {
-          let destExists = true;
-          if (yield ioUtil.isDirectory(dest)) {
-            dest = path2.join(dest, path2.basename(source));
-            destExists = yield ioUtil.exists(dest);
-          }
-          if (destExists) {
-            if (options.force == null || options.force) {
-              yield rmRF(dest);
-            } else {
-              throw new Error("Destination already exists");
-            }
-          }
-        }
-        yield mkdirP(path2.dirname(dest));
-        yield ioUtil.rename(source, dest);
-      });
-    }
-    exports2.mv = mv;
-    function rmRF(inputPath) {
-      return __awaiter(this, void 0, void 0, function* () {
-        if (ioUtil.IS_WINDOWS) {
-          try {
-            if (yield ioUtil.isDirectory(inputPath, true)) {
-              yield exec5(`rd /s /q "${inputPath}"`);
-            } else {
-              yield exec5(`del /f /a "${inputPath}"`);
-            }
-          } catch (err) {
-            if (err.code !== "ENOENT")
-              throw err;
-          }
-          try {
-            yield ioUtil.unlink(inputPath);
-          } catch (err) {
-            if (err.code !== "ENOENT")
-              throw err;
-          }
-        } else {
-          let isDir = false;
-          try {
-            isDir = yield ioUtil.isDirectory(inputPath);
-          } catch (err) {
-            if (err.code !== "ENOENT")
-              throw err;
-            return;
-          }
-          if (isDir) {
-            yield exec5(`rm -rf "${inputPath}"`);
-          } else {
-            yield ioUtil.unlink(inputPath);
-          }
-        }
-      });
-    }
-    exports2.rmRF = rmRF;
-    function mkdirP(fsPath) {
-      return __awaiter(this, void 0, void 0, function* () {
-        yield ioUtil.mkdirP(fsPath);
-      });
-    }
-    exports2.mkdirP = mkdirP;
-    function which2(tool, check) {
-      return __awaiter(this, void 0, void 0, function* () {
-        if (!tool) {
-          throw new Error("parameter 'tool' is required");
-        }
-        if (check) {
-          const result = yield which2(tool, false);
-          if (!result) {
-            if (ioUtil.IS_WINDOWS) {
-              throw new Error(`Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also verify the file has a valid extension for an executable file.`);
-            } else {
-              throw new Error(`Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also check the file mode to verify the file is executable.`);
-            }
-          }
-        }
+      yield ioUtil.chmod(destDir, (yield ioUtil.stat(sourceDir)).mode);
+    });
+  }
+  function copyFile(srcFile, destFile, force) {
+    return __awaiter(this, void 0, void 0, function* () {
+      if ((yield ioUtil.lstat(srcFile)).isSymbolicLink()) {
         try {
-          const extensions = [];
-          if (ioUtil.IS_WINDOWS && process.env.PATHEXT) {
-            for (const extension of process.env.PATHEXT.split(path2.delimiter)) {
-              if (extension) {
-                extensions.push(extension);
-              }
-            }
-          }
-          if (ioUtil.isRooted(tool)) {
-            const filePath = yield ioUtil.tryGetExecutablePath(tool, extensions);
-            if (filePath) {
-              return filePath;
-            }
-            return "";
-          }
-          if (tool.includes("/") || ioUtil.IS_WINDOWS && tool.includes("\\")) {
-            return "";
-          }
-          const directories = [];
-          if (process.env.PATH) {
-            for (const p of process.env.PATH.split(path2.delimiter)) {
-              if (p) {
-                directories.push(p);
-              }
-            }
-          }
-          for (const directory of directories) {
-            const filePath = yield ioUtil.tryGetExecutablePath(directory + path2.sep + tool, extensions);
-            if (filePath) {
-              return filePath;
-            }
-          }
-          return "";
-        } catch (err) {
-          throw new Error(`which failed with message ${err.message}`);
-        }
-      });
-    }
-    exports2.which = which2;
-    function readCopyOptions(options) {
-      const force = options.force == null ? true : options.force;
-      const recursive = Boolean(options.recursive);
-      return { force, recursive };
-    }
-    function cpDirRecursive(sourceDir, destDir, currentDepth, force) {
-      return __awaiter(this, void 0, void 0, function* () {
-        if (currentDepth >= 255)
-          return;
-        currentDepth++;
-        yield mkdirP(destDir);
-        const files = yield ioUtil.readdir(sourceDir);
-        for (const fileName of files) {
-          const srcFile = `${sourceDir}/${fileName}`;
-          const destFile = `${destDir}/${fileName}`;
-          const srcFileStat = yield ioUtil.lstat(srcFile);
-          if (srcFileStat.isDirectory()) {
-            yield cpDirRecursive(srcFile, destFile, currentDepth, force);
-          } else {
-            yield copyFile(srcFile, destFile, force);
-          }
-        }
-        yield ioUtil.chmod(destDir, (yield ioUtil.stat(sourceDir)).mode);
-      });
-    }
-    function copyFile(srcFile, destFile, force) {
-      return __awaiter(this, void 0, void 0, function* () {
-        if ((yield ioUtil.lstat(srcFile)).isSymbolicLink()) {
-          try {
-            yield ioUtil.lstat(destFile);
+          yield ioUtil.lstat(destFile);
+          yield ioUtil.unlink(destFile);
+        } catch (e) {
+          if (e.code === "EPERM") {
+            yield ioUtil.chmod(destFile, "0666");
             yield ioUtil.unlink(destFile);
-          } catch (e) {
-            if (e.code === "EPERM") {
-              yield ioUtil.chmod(destFile, "0666");
-              yield ioUtil.unlink(destFile);
-            }
           }
-          const symlinkFull = yield ioUtil.readlink(srcFile);
-          yield ioUtil.symlink(symlinkFull, destFile, ioUtil.IS_WINDOWS ? "junction" : null);
-        } else if (!(yield ioUtil.exists(destFile)) || force) {
-          yield ioUtil.copyFile(srcFile, destFile);
         }
-      });
-    }
+        const symlinkFull = yield ioUtil.readlink(srcFile);
+        yield ioUtil.symlink(symlinkFull, destFile, ioUtil.IS_WINDOWS ? "junction" : null);
+      } else if (!(yield ioUtil.exists(destFile)) || force) {
+        yield ioUtil.copyFile(srcFile, destFile);
+      }
+    });
   }
 });
 
@@ -1702,7 +1689,7 @@ async function setupAsdf() {
   core.addPath(`${asdfDir}/bin`);
   core.addPath(`${asdfDir}/shims`);
   core.info(`Cloning asdf into ASDF_DIR: ${asdfDir}`);
-  const branch = core.getInput("asdf_branch", { required: true });
+  const branch = core.getInput("asdf_branch", {required: true});
   await exec.exec("git", [
     "clone",
     "--depth",
@@ -1717,11 +1704,11 @@ async function setupAsdf() {
 // lib/plugin-test/index.ts
 async function pluginTest() {
   await setupAsdf();
-  const command = core2.getInput("command", { required: true });
-  const version = core2.getInput("version", { required: true });
-  const plugin = (core2.getInput("plugin", { required: false }) || process.env.GITHUB_REPOSITORY.split("/")[1]).replace("asdf-", "");
-  const giturl = core2.getInput("giturl", { required: false }) || `https://github.com/${process.env.GITHUB_REPOSITORY}`;
-  const gitref = core2.getInput("gitref", { required: false }) || process.env.GITHUB_SHA;
+  const command = core2.getInput("command", {required: true});
+  const version = core2.getInput("version", {required: true});
+  const plugin = (core2.getInput("plugin", {required: false}) || process.env.GITHUB_REPOSITORY.split("/")[1]).replace("asdf-", "");
+  const giturl = core2.getInput("giturl", {required: false}) || `https://github.com/${process.env.GITHUB_REPOSITORY}`;
+  const gitref = core2.getInput("gitref", {required: false}) || process.env.GITHUB_SHA;
   await exec3.exec("asdf", [
     "plugin-test",
     plugin,
@@ -1734,7 +1721,7 @@ async function pluginTest() {
   ]);
 }
 async function pluginTestAll() {
-  const githubToken = core2.getInput("github_token", { required: false });
+  const githubToken = core2.getInput("github_token", {required: false});
   core2.exportVariable("GITHUB_API_TOKEN", githubToken);
   core2.startGroup("Test plugin");
   await pluginTest();

--- a/plugins-add/main.js
+++ b/plugins-add/main.js
@@ -1,427 +1,403 @@
 var __create = Object.create;
 var __defProp = Object.defineProperty;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __getOwnPropNames = Object.getOwnPropertyNames;
 var __getProtoOf = Object.getPrototypeOf;
 var __hasOwnProp = Object.prototype.hasOwnProperty;
-var __getOwnPropNames = Object.getOwnPropertyNames;
-var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
-var __markAsModule = (target) => __defProp(target, "__esModule", {value: true});
-var __commonJS = (callback, module2) => () => {
-  if (!module2) {
-    module2 = {exports: {}};
-    callback(module2.exports, module2);
-  }
-  return module2.exports;
+var __markAsModule = (target) => __defProp(target, "__esModule", { value: true });
+var __commonJS = (cb, mod) => function __require() {
+  return mod || (0, cb[Object.keys(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports;
 };
-var __exportStar = (target, module2, desc) => {
-  __markAsModule(target);
+var __reExport = (target, module2, desc) => {
   if (module2 && typeof module2 === "object" || typeof module2 === "function") {
     for (let key of __getOwnPropNames(module2))
       if (!__hasOwnProp.call(target, key) && key !== "default")
-        __defProp(target, key, {get: () => module2[key], enumerable: !(desc = __getOwnPropDesc(module2, key)) || desc.enumerable});
+        __defProp(target, key, { get: () => module2[key], enumerable: !(desc = __getOwnPropDesc(module2, key)) || desc.enumerable });
   }
   return target;
 };
 var __toModule = (module2) => {
-  if (module2 && module2.__esModule)
-    return module2;
-  return __exportStar(__defProp(module2 != null ? __create(__getProtoOf(module2)) : {}, "default", {value: module2, enumerable: true}), module2);
+  return __reExport(__markAsModule(__defProp(module2 != null ? __create(__getProtoOf(module2)) : {}, "default", module2 && module2.__esModule && "default" in module2 ? { get: () => module2.default, enumerable: true } : { value: module2, enumerable: true })), module2);
 };
 
 // node_modules/@actions/core/lib/utils.js
-var require_utils = __commonJS((exports2) => {
-  "use strict";
-  Object.defineProperty(exports2, "__esModule", {value: true});
-  function toCommandValue(input) {
-    if (input === null || input === void 0) {
-      return "";
-    } else if (typeof input === "string" || input instanceof String) {
-      return input;
+var require_utils = __commonJS({
+  "node_modules/@actions/core/lib/utils.js"(exports2) {
+    "use strict";
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    function toCommandValue(input) {
+      if (input === null || input === void 0) {
+        return "";
+      } else if (typeof input === "string" || input instanceof String) {
+        return input;
+      }
+      return JSON.stringify(input);
     }
-    return JSON.stringify(input);
+    exports2.toCommandValue = toCommandValue;
   }
-  exports2.toCommandValue = toCommandValue;
 });
 
 // node_modules/@actions/core/lib/command.js
-var require_command = __commonJS((exports2) => {
-  "use strict";
-  var __importStar = exports2 && exports2.__importStar || function(mod) {
-    if (mod && mod.__esModule)
-      return mod;
-    var result = {};
-    if (mod != null) {
-      for (var k in mod)
-        if (Object.hasOwnProperty.call(mod, k))
-          result[k] = mod[k];
-    }
-    result["default"] = mod;
-    return result;
-  };
-  Object.defineProperty(exports2, "__esModule", {value: true});
-  var os2 = __importStar(require("os"));
-  var utils_1 = require_utils();
-  function issueCommand(command, properties, message) {
-    const cmd = new Command(command, properties, message);
-    process.stdout.write(cmd.toString() + os2.EOL);
-  }
-  exports2.issueCommand = issueCommand;
-  function issue(name, message = "") {
-    issueCommand(name, {}, message);
-  }
-  exports2.issue = issue;
-  var CMD_STRING = "::";
-  var Command = class {
-    constructor(command, properties, message) {
-      if (!command) {
-        command = "missing.command";
+var require_command = __commonJS({
+  "node_modules/@actions/core/lib/command.js"(exports2) {
+    "use strict";
+    var __importStar = exports2 && exports2.__importStar || function(mod) {
+      if (mod && mod.__esModule)
+        return mod;
+      var result = {};
+      if (mod != null) {
+        for (var k in mod)
+          if (Object.hasOwnProperty.call(mod, k))
+            result[k] = mod[k];
       }
-      this.command = command;
-      this.properties = properties;
-      this.message = message;
+      result["default"] = mod;
+      return result;
+    };
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    var os2 = __importStar(require("os"));
+    var utils_1 = require_utils();
+    function issueCommand(command, properties, message) {
+      const cmd = new Command(command, properties, message);
+      process.stdout.write(cmd.toString() + os2.EOL);
     }
-    toString() {
-      let cmdStr = CMD_STRING + this.command;
-      if (this.properties && Object.keys(this.properties).length > 0) {
-        cmdStr += " ";
-        let first = true;
-        for (const key in this.properties) {
-          if (this.properties.hasOwnProperty(key)) {
-            const val = this.properties[key];
-            if (val) {
-              if (first) {
-                first = false;
-              } else {
-                cmdStr += ",";
+    exports2.issueCommand = issueCommand;
+    function issue(name, message = "") {
+      issueCommand(name, {}, message);
+    }
+    exports2.issue = issue;
+    var CMD_STRING = "::";
+    var Command = class {
+      constructor(command, properties, message) {
+        if (!command) {
+          command = "missing.command";
+        }
+        this.command = command;
+        this.properties = properties;
+        this.message = message;
+      }
+      toString() {
+        let cmdStr = CMD_STRING + this.command;
+        if (this.properties && Object.keys(this.properties).length > 0) {
+          cmdStr += " ";
+          let first = true;
+          for (const key in this.properties) {
+            if (this.properties.hasOwnProperty(key)) {
+              const val = this.properties[key];
+              if (val) {
+                if (first) {
+                  first = false;
+                } else {
+                  cmdStr += ",";
+                }
+                cmdStr += `${key}=${escapeProperty(val)}`;
               }
-              cmdStr += `${key}=${escapeProperty(val)}`;
             }
           }
         }
+        cmdStr += `${CMD_STRING}${escapeData(this.message)}`;
+        return cmdStr;
       }
-      cmdStr += `${CMD_STRING}${escapeData(this.message)}`;
-      return cmdStr;
+    };
+    function escapeData(s) {
+      return utils_1.toCommandValue(s).replace(/%/g, "%25").replace(/\r/g, "%0D").replace(/\n/g, "%0A");
     }
-  };
-  function escapeData(s) {
-    return utils_1.toCommandValue(s).replace(/%/g, "%25").replace(/\r/g, "%0D").replace(/\n/g, "%0A");
-  }
-  function escapeProperty(s) {
-    return utils_1.toCommandValue(s).replace(/%/g, "%25").replace(/\r/g, "%0D").replace(/\n/g, "%0A").replace(/:/g, "%3A").replace(/,/g, "%2C");
+    function escapeProperty(s) {
+      return utils_1.toCommandValue(s).replace(/%/g, "%25").replace(/\r/g, "%0D").replace(/\n/g, "%0A").replace(/:/g, "%3A").replace(/,/g, "%2C");
+    }
   }
 });
 
 // node_modules/@actions/core/lib/file-command.js
-var require_file_command = __commonJS((exports2) => {
-  "use strict";
-  var __importStar = exports2 && exports2.__importStar || function(mod) {
-    if (mod && mod.__esModule)
-      return mod;
-    var result = {};
-    if (mod != null) {
-      for (var k in mod)
-        if (Object.hasOwnProperty.call(mod, k))
-          result[k] = mod[k];
+var require_file_command = __commonJS({
+  "node_modules/@actions/core/lib/file-command.js"(exports2) {
+    "use strict";
+    var __importStar = exports2 && exports2.__importStar || function(mod) {
+      if (mod && mod.__esModule)
+        return mod;
+      var result = {};
+      if (mod != null) {
+        for (var k in mod)
+          if (Object.hasOwnProperty.call(mod, k))
+            result[k] = mod[k];
+      }
+      result["default"] = mod;
+      return result;
+    };
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    var fs2 = __importStar(require("fs"));
+    var os2 = __importStar(require("os"));
+    var utils_1 = require_utils();
+    function issueCommand(command, message) {
+      const filePath = process.env[`GITHUB_${command}`];
+      if (!filePath) {
+        throw new Error(`Unable to find environment variable for file command ${command}`);
+      }
+      if (!fs2.existsSync(filePath)) {
+        throw new Error(`Missing file at path: ${filePath}`);
+      }
+      fs2.appendFileSync(filePath, `${utils_1.toCommandValue(message)}${os2.EOL}`, {
+        encoding: "utf8"
+      });
     }
-    result["default"] = mod;
-    return result;
-  };
-  Object.defineProperty(exports2, "__esModule", {value: true});
-  var fs2 = __importStar(require("fs"));
-  var os2 = __importStar(require("os"));
-  var utils_1 = require_utils();
-  function issueCommand(command, message) {
-    const filePath = process.env[`GITHUB_${command}`];
-    if (!filePath) {
-      throw new Error(`Unable to find environment variable for file command ${command}`);
-    }
-    if (!fs2.existsSync(filePath)) {
-      throw new Error(`Missing file at path: ${filePath}`);
-    }
-    fs2.appendFileSync(filePath, `${utils_1.toCommandValue(message)}${os2.EOL}`, {
-      encoding: "utf8"
-    });
+    exports2.issueCommand = issueCommand;
   }
-  exports2.issueCommand = issueCommand;
 });
 
 // node_modules/@actions/core/lib/core.js
-var require_core = __commonJS((exports2) => {
-  "use strict";
-  var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
-    function adopt(value) {
-      return value instanceof P ? value : new P(function(resolve) {
-        resolve(value);
+var require_core = __commonJS({
+  "node_modules/@actions/core/lib/core.js"(exports2) {
+    "use strict";
+    var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve) {
+          resolve(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+      });
+    };
+    var __importStar = exports2 && exports2.__importStar || function(mod) {
+      if (mod && mod.__esModule)
+        return mod;
+      var result = {};
+      if (mod != null) {
+        for (var k in mod)
+          if (Object.hasOwnProperty.call(mod, k))
+            result[k] = mod[k];
+      }
+      result["default"] = mod;
+      return result;
+    };
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    var command_1 = require_command();
+    var file_command_1 = require_file_command();
+    var utils_1 = require_utils();
+    var os2 = __importStar(require("os"));
+    var path2 = __importStar(require("path"));
+    var ExitCode;
+    (function(ExitCode2) {
+      ExitCode2[ExitCode2["Success"] = 0] = "Success";
+      ExitCode2[ExitCode2["Failure"] = 1] = "Failure";
+    })(ExitCode = exports2.ExitCode || (exports2.ExitCode = {}));
+    function exportVariable2(name, val) {
+      const convertedVal = utils_1.toCommandValue(val);
+      process.env[name] = convertedVal;
+      const filePath = process.env["GITHUB_ENV"] || "";
+      if (filePath) {
+        const delimiter = "_GitHubActionsFileCommandDelimeter_";
+        const commandValue = `${name}<<${delimiter}${os2.EOL}${convertedVal}${os2.EOL}${delimiter}`;
+        file_command_1.issueCommand("ENV", commandValue);
+      } else {
+        command_1.issueCommand("set-env", { name }, convertedVal);
+      }
+    }
+    exports2.exportVariable = exportVariable2;
+    function setSecret(secret) {
+      command_1.issueCommand("add-mask", {}, secret);
+    }
+    exports2.setSecret = setSecret;
+    function addPath2(inputPath) {
+      const filePath = process.env["GITHUB_PATH"] || "";
+      if (filePath) {
+        file_command_1.issueCommand("PATH", inputPath);
+      } else {
+        command_1.issueCommand("add-path", {}, inputPath);
+      }
+      process.env["PATH"] = `${inputPath}${path2.delimiter}${process.env["PATH"]}`;
+    }
+    exports2.addPath = addPath2;
+    function getInput3(name, options) {
+      const val = process.env[`INPUT_${name.replace(/ /g, "_").toUpperCase()}`] || "";
+      if (options && options.required && !val) {
+        throw new Error(`Input required and not supplied: ${name}`);
+      }
+      return val.trim();
+    }
+    exports2.getInput = getInput3;
+    function setOutput(name, value) {
+      command_1.issueCommand("set-output", { name }, value);
+    }
+    exports2.setOutput = setOutput;
+    function setCommandEcho(enabled) {
+      command_1.issue("echo", enabled ? "on" : "off");
+    }
+    exports2.setCommandEcho = setCommandEcho;
+    function setFailed2(message) {
+      process.exitCode = ExitCode.Failure;
+      error(message);
+    }
+    exports2.setFailed = setFailed2;
+    function isDebug() {
+      return process.env["RUNNER_DEBUG"] === "1";
+    }
+    exports2.isDebug = isDebug;
+    function debug(message) {
+      command_1.issueCommand("debug", {}, message);
+    }
+    exports2.debug = debug;
+    function error(message) {
+      command_1.issue("error", message instanceof Error ? message.toString() : message);
+    }
+    exports2.error = error;
+    function warning(message) {
+      command_1.issue("warning", message instanceof Error ? message.toString() : message);
+    }
+    exports2.warning = warning;
+    function info3(message) {
+      process.stdout.write(message + os2.EOL);
+    }
+    exports2.info = info3;
+    function startGroup(name) {
+      command_1.issue("group", name);
+    }
+    exports2.startGroup = startGroup;
+    function endGroup() {
+      command_1.issue("endgroup");
+    }
+    exports2.endGroup = endGroup;
+    function group(name, fn) {
+      return __awaiter(this, void 0, void 0, function* () {
+        startGroup(name);
+        let result;
+        try {
+          result = yield fn();
+        } finally {
+          endGroup();
+        }
+        return result;
       });
     }
-    return new (P || (P = Promise))(function(resolve, reject) {
-      function fulfilled(value) {
-        try {
-          step(generator.next(value));
-        } catch (e) {
-          reject(e);
-        }
-      }
-      function rejected(value) {
-        try {
-          step(generator["throw"](value));
-        } catch (e) {
-          reject(e);
-        }
-      }
-      function step(result) {
-        result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
-      }
-      step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-  };
-  var __importStar = exports2 && exports2.__importStar || function(mod) {
-    if (mod && mod.__esModule)
-      return mod;
-    var result = {};
-    if (mod != null) {
-      for (var k in mod)
-        if (Object.hasOwnProperty.call(mod, k))
-          result[k] = mod[k];
+    exports2.group = group;
+    function saveState(name, value) {
+      command_1.issueCommand("save-state", { name }, value);
     }
-    result["default"] = mod;
-    return result;
-  };
-  Object.defineProperty(exports2, "__esModule", {value: true});
-  var command_1 = require_command();
-  var file_command_1 = require_file_command();
-  var utils_1 = require_utils();
-  var os2 = __importStar(require("os"));
-  var path2 = __importStar(require("path"));
-  var ExitCode;
-  (function(ExitCode2) {
-    ExitCode2[ExitCode2["Success"] = 0] = "Success";
-    ExitCode2[ExitCode2["Failure"] = 1] = "Failure";
-  })(ExitCode = exports2.ExitCode || (exports2.ExitCode = {}));
-  function exportVariable2(name, val) {
-    const convertedVal = utils_1.toCommandValue(val);
-    process.env[name] = convertedVal;
-    const filePath = process.env["GITHUB_ENV"] || "";
-    if (filePath) {
-      const delimiter = "_GitHubActionsFileCommandDelimeter_";
-      const commandValue = `${name}<<${delimiter}${os2.EOL}${convertedVal}${os2.EOL}${delimiter}`;
-      file_command_1.issueCommand("ENV", commandValue);
-    } else {
-      command_1.issueCommand("set-env", {name}, convertedVal);
+    exports2.saveState = saveState;
+    function getState(name) {
+      return process.env[`STATE_${name}`] || "";
     }
+    exports2.getState = getState;
   }
-  exports2.exportVariable = exportVariable2;
-  function setSecret(secret) {
-    command_1.issueCommand("add-mask", {}, secret);
-  }
-  exports2.setSecret = setSecret;
-  function addPath2(inputPath) {
-    const filePath = process.env["GITHUB_PATH"] || "";
-    if (filePath) {
-      file_command_1.issueCommand("PATH", inputPath);
-    } else {
-      command_1.issueCommand("add-path", {}, inputPath);
-    }
-    process.env["PATH"] = `${inputPath}${path2.delimiter}${process.env["PATH"]}`;
-  }
-  exports2.addPath = addPath2;
-  function getInput3(name, options) {
-    const val = process.env[`INPUT_${name.replace(/ /g, "_").toUpperCase()}`] || "";
-    if (options && options.required && !val) {
-      throw new Error(`Input required and not supplied: ${name}`);
-    }
-    return val.trim();
-  }
-  exports2.getInput = getInput3;
-  function setOutput(name, value) {
-    command_1.issueCommand("set-output", {name}, value);
-  }
-  exports2.setOutput = setOutput;
-  function setCommandEcho(enabled) {
-    command_1.issue("echo", enabled ? "on" : "off");
-  }
-  exports2.setCommandEcho = setCommandEcho;
-  function setFailed2(message) {
-    process.exitCode = ExitCode.Failure;
-    error(message);
-  }
-  exports2.setFailed = setFailed2;
-  function isDebug() {
-    return process.env["RUNNER_DEBUG"] === "1";
-  }
-  exports2.isDebug = isDebug;
-  function debug(message) {
-    command_1.issueCommand("debug", {}, message);
-  }
-  exports2.debug = debug;
-  function error(message) {
-    command_1.issue("error", message instanceof Error ? message.toString() : message);
-  }
-  exports2.error = error;
-  function warning(message) {
-    command_1.issue("warning", message instanceof Error ? message.toString() : message);
-  }
-  exports2.warning = warning;
-  function info3(message) {
-    process.stdout.write(message + os2.EOL);
-  }
-  exports2.info = info3;
-  function startGroup(name) {
-    command_1.issue("group", name);
-  }
-  exports2.startGroup = startGroup;
-  function endGroup() {
-    command_1.issue("endgroup");
-  }
-  exports2.endGroup = endGroup;
-  function group(name, fn) {
-    return __awaiter(this, void 0, void 0, function* () {
-      startGroup(name);
-      let result;
-      try {
-        result = yield fn();
-      } finally {
-        endGroup();
-      }
-      return result;
-    });
-  }
-  exports2.group = group;
-  function saveState(name, value) {
-    command_1.issueCommand("save-state", {name}, value);
-  }
-  exports2.saveState = saveState;
-  function getState(name) {
-    return process.env[`STATE_${name}`] || "";
-  }
-  exports2.getState = getState;
 });
 
-// node_modules/@actions/io/lib/io-util.js
-var require_io_util = __commonJS((exports2) => {
-  "use strict";
-  var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
-    function adopt(value) {
-      return value instanceof P ? value : new P(function(resolve) {
-        resolve(value);
+// node_modules/@actions/exec/node_modules/@actions/io/lib/io-util.js
+var require_io_util = __commonJS({
+  "node_modules/@actions/exec/node_modules/@actions/io/lib/io-util.js"(exports2) {
+    "use strict";
+    var __createBinding = exports2 && exports2.__createBinding || (Object.create ? function(o, m, k, k2) {
+      if (k2 === void 0)
+        k2 = k;
+      Object.defineProperty(o, k2, { enumerable: true, get: function() {
+        return m[k];
+      } });
+    } : function(o, m, k, k2) {
+      if (k2 === void 0)
+        k2 = k;
+      o[k2] = m[k];
+    });
+    var __setModuleDefault = exports2 && exports2.__setModuleDefault || (Object.create ? function(o, v) {
+      Object.defineProperty(o, "default", { enumerable: true, value: v });
+    } : function(o, v) {
+      o["default"] = v;
+    });
+    var __importStar = exports2 && exports2.__importStar || function(mod) {
+      if (mod && mod.__esModule)
+        return mod;
+      var result = {};
+      if (mod != null) {
+        for (var k in mod)
+          if (k !== "default" && Object.hasOwnProperty.call(mod, k))
+            __createBinding(result, mod, k);
+      }
+      __setModuleDefault(result, mod);
+      return result;
+    };
+    var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve) {
+          resolve(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+      });
+    };
+    var _a;
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    exports2.getCmdPath = exports2.tryGetExecutablePath = exports2.isRooted = exports2.isDirectory = exports2.exists = exports2.IS_WINDOWS = exports2.unlink = exports2.symlink = exports2.stat = exports2.rmdir = exports2.rename = exports2.readlink = exports2.readdir = exports2.mkdir = exports2.lstat = exports2.copyFile = exports2.chmod = void 0;
+    var fs2 = __importStar(require("fs"));
+    var path2 = __importStar(require("path"));
+    _a = fs2.promises, exports2.chmod = _a.chmod, exports2.copyFile = _a.copyFile, exports2.lstat = _a.lstat, exports2.mkdir = _a.mkdir, exports2.readdir = _a.readdir, exports2.readlink = _a.readlink, exports2.rename = _a.rename, exports2.rmdir = _a.rmdir, exports2.stat = _a.stat, exports2.symlink = _a.symlink, exports2.unlink = _a.unlink;
+    exports2.IS_WINDOWS = process.platform === "win32";
+    function exists(fsPath) {
+      return __awaiter(this, void 0, void 0, function* () {
+        try {
+          yield exports2.stat(fsPath);
+        } catch (err) {
+          if (err.code === "ENOENT") {
+            return false;
+          }
+          throw err;
+        }
+        return true;
       });
     }
-    return new (P || (P = Promise))(function(resolve, reject) {
-      function fulfilled(value) {
-        try {
-          step(generator.next(value));
-        } catch (e) {
-          reject(e);
-        }
-      }
-      function rejected(value) {
-        try {
-          step(generator["throw"](value));
-        } catch (e) {
-          reject(e);
-        }
-      }
-      function step(result) {
-        result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
-      }
-      step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-  };
-  var _a;
-  Object.defineProperty(exports2, "__esModule", {value: true});
-  var assert_1 = require("assert");
-  var fs2 = require("fs");
-  var path2 = require("path");
-  _a = fs2.promises, exports2.chmod = _a.chmod, exports2.copyFile = _a.copyFile, exports2.lstat = _a.lstat, exports2.mkdir = _a.mkdir, exports2.readdir = _a.readdir, exports2.readlink = _a.readlink, exports2.rename = _a.rename, exports2.rmdir = _a.rmdir, exports2.stat = _a.stat, exports2.symlink = _a.symlink, exports2.unlink = _a.unlink;
-  exports2.IS_WINDOWS = process.platform === "win32";
-  function exists(fsPath) {
-    return __awaiter(this, void 0, void 0, function* () {
-      try {
-        yield exports2.stat(fsPath);
-      } catch (err) {
-        if (err.code === "ENOENT") {
-          return false;
-        }
-        throw err;
-      }
-      return true;
-    });
-  }
-  exports2.exists = exists;
-  function isDirectory(fsPath, useStat = false) {
-    return __awaiter(this, void 0, void 0, function* () {
-      const stats = useStat ? yield exports2.stat(fsPath) : yield exports2.lstat(fsPath);
-      return stats.isDirectory();
-    });
-  }
-  exports2.isDirectory = isDirectory;
-  function isRooted(p) {
-    p = normalizeSeparators(p);
-    if (!p) {
-      throw new Error('isRooted() parameter "p" cannot be empty');
+    exports2.exists = exists;
+    function isDirectory(fsPath, useStat = false) {
+      return __awaiter(this, void 0, void 0, function* () {
+        const stats = useStat ? yield exports2.stat(fsPath) : yield exports2.lstat(fsPath);
+        return stats.isDirectory();
+      });
     }
-    if (exports2.IS_WINDOWS) {
-      return p.startsWith("\\") || /^[A-Z]:/i.test(p);
+    exports2.isDirectory = isDirectory;
+    function isRooted(p) {
+      p = normalizeSeparators(p);
+      if (!p) {
+        throw new Error('isRooted() parameter "p" cannot be empty');
+      }
+      if (exports2.IS_WINDOWS) {
+        return p.startsWith("\\") || /^[A-Z]:/i.test(p);
+      }
+      return p.startsWith("/");
     }
-    return p.startsWith("/");
-  }
-  exports2.isRooted = isRooted;
-  function mkdirP(fsPath, maxDepth = 1e3, depth = 1) {
-    return __awaiter(this, void 0, void 0, function* () {
-      assert_1.ok(fsPath, "a path argument must be provided");
-      fsPath = path2.resolve(fsPath);
-      if (depth >= maxDepth)
-        return exports2.mkdir(fsPath);
-      try {
-        yield exports2.mkdir(fsPath);
-        return;
-      } catch (err) {
-        switch (err.code) {
-          case "ENOENT": {
-            yield mkdirP(path2.dirname(fsPath), maxDepth, depth + 1);
-            yield exports2.mkdir(fsPath);
-            return;
-          }
-          default: {
-            let stats;
-            try {
-              stats = yield exports2.stat(fsPath);
-            } catch (err2) {
-              throw err;
-            }
-            if (!stats.isDirectory())
-              throw err;
-          }
-        }
-      }
-    });
-  }
-  exports2.mkdirP = mkdirP;
-  function tryGetExecutablePath(filePath, extensions) {
-    return __awaiter(this, void 0, void 0, function* () {
-      let stats = void 0;
-      try {
-        stats = yield exports2.stat(filePath);
-      } catch (err) {
-        if (err.code !== "ENOENT") {
-          console.log(`Unexpected error attempting to determine if executable file exists '${filePath}': ${err}`);
-        }
-      }
-      if (stats && stats.isFile()) {
-        if (exports2.IS_WINDOWS) {
-          const upperExt = path2.extname(filePath).toUpperCase();
-          if (extensions.some((validExt) => validExt.toUpperCase() === upperExt)) {
-            return filePath;
-          }
-        } else {
-          if (isUnixExecutable(stats)) {
-            return filePath;
-          }
-        }
-      }
-      const originalFilePath = filePath;
-      for (const extension of extensions) {
-        filePath = originalFilePath + extension;
-        stats = void 0;
+    exports2.isRooted = isRooted;
+    function tryGetExecutablePath(filePath, extensions) {
+      return __awaiter(this, void 0, void 0, function* () {
+        let stats = void 0;
         try {
           stats = yield exports2.stat(filePath);
         } catch (err) {
@@ -431,189 +407,272 @@ var require_io_util = __commonJS((exports2) => {
         }
         if (stats && stats.isFile()) {
           if (exports2.IS_WINDOWS) {
-            try {
-              const directory = path2.dirname(filePath);
-              const upperName = path2.basename(filePath).toUpperCase();
-              for (const actualName of yield exports2.readdir(directory)) {
-                if (upperName === actualName.toUpperCase()) {
-                  filePath = path2.join(directory, actualName);
-                  break;
-                }
-              }
-            } catch (err) {
-              console.log(`Unexpected error attempting to determine the actual case of the file '${filePath}': ${err}`);
+            const upperExt = path2.extname(filePath).toUpperCase();
+            if (extensions.some((validExt) => validExt.toUpperCase() === upperExt)) {
+              return filePath;
             }
-            return filePath;
           } else {
             if (isUnixExecutable(stats)) {
               return filePath;
             }
           }
         }
-      }
-      return "";
-    });
-  }
-  exports2.tryGetExecutablePath = tryGetExecutablePath;
-  function normalizeSeparators(p) {
-    p = p || "";
-    if (exports2.IS_WINDOWS) {
-      p = p.replace(/\//g, "\\");
-      return p.replace(/\\\\+/g, "\\");
+        const originalFilePath = filePath;
+        for (const extension of extensions) {
+          filePath = originalFilePath + extension;
+          stats = void 0;
+          try {
+            stats = yield exports2.stat(filePath);
+          } catch (err) {
+            if (err.code !== "ENOENT") {
+              console.log(`Unexpected error attempting to determine if executable file exists '${filePath}': ${err}`);
+            }
+          }
+          if (stats && stats.isFile()) {
+            if (exports2.IS_WINDOWS) {
+              try {
+                const directory = path2.dirname(filePath);
+                const upperName = path2.basename(filePath).toUpperCase();
+                for (const actualName of yield exports2.readdir(directory)) {
+                  if (upperName === actualName.toUpperCase()) {
+                    filePath = path2.join(directory, actualName);
+                    break;
+                  }
+                }
+              } catch (err) {
+                console.log(`Unexpected error attempting to determine the actual case of the file '${filePath}': ${err}`);
+              }
+              return filePath;
+            } else {
+              if (isUnixExecutable(stats)) {
+                return filePath;
+              }
+            }
+          }
+        }
+        return "";
+      });
     }
-    return p.replace(/\/\/+/g, "/");
-  }
-  function isUnixExecutable(stats) {
-    return (stats.mode & 1) > 0 || (stats.mode & 8) > 0 && stats.gid === process.getgid() || (stats.mode & 64) > 0 && stats.uid === process.getuid();
+    exports2.tryGetExecutablePath = tryGetExecutablePath;
+    function normalizeSeparators(p) {
+      p = p || "";
+      if (exports2.IS_WINDOWS) {
+        p = p.replace(/\//g, "\\");
+        return p.replace(/\\\\+/g, "\\");
+      }
+      return p.replace(/\/\/+/g, "/");
+    }
+    function isUnixExecutable(stats) {
+      return (stats.mode & 1) > 0 || (stats.mode & 8) > 0 && stats.gid === process.getgid() || (stats.mode & 64) > 0 && stats.uid === process.getuid();
+    }
+    function getCmdPath() {
+      var _a2;
+      return (_a2 = process.env["COMSPEC"]) !== null && _a2 !== void 0 ? _a2 : `cmd.exe`;
+    }
+    exports2.getCmdPath = getCmdPath;
   }
 });
 
-// node_modules/@actions/io/lib/io.js
-var require_io = __commonJS((exports2) => {
-  "use strict";
-  var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
-    function adopt(value) {
-      return value instanceof P ? value : new P(function(resolve) {
-        resolve(value);
+// node_modules/@actions/exec/node_modules/@actions/io/lib/io.js
+var require_io = __commonJS({
+  "node_modules/@actions/exec/node_modules/@actions/io/lib/io.js"(exports2) {
+    "use strict";
+    var __createBinding = exports2 && exports2.__createBinding || (Object.create ? function(o, m, k, k2) {
+      if (k2 === void 0)
+        k2 = k;
+      Object.defineProperty(o, k2, { enumerable: true, get: function() {
+        return m[k];
+      } });
+    } : function(o, m, k, k2) {
+      if (k2 === void 0)
+        k2 = k;
+      o[k2] = m[k];
+    });
+    var __setModuleDefault = exports2 && exports2.__setModuleDefault || (Object.create ? function(o, v) {
+      Object.defineProperty(o, "default", { enumerable: true, value: v });
+    } : function(o, v) {
+      o["default"] = v;
+    });
+    var __importStar = exports2 && exports2.__importStar || function(mod) {
+      if (mod && mod.__esModule)
+        return mod;
+      var result = {};
+      if (mod != null) {
+        for (var k in mod)
+          if (k !== "default" && Object.hasOwnProperty.call(mod, k))
+            __createBinding(result, mod, k);
+      }
+      __setModuleDefault(result, mod);
+      return result;
+    };
+    var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve) {
+          resolve(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
-    }
-    return new (P || (P = Promise))(function(resolve, reject) {
-      function fulfilled(value) {
-        try {
-          step(generator.next(value));
-        } catch (e) {
-          reject(e);
-        }
-      }
-      function rejected(value) {
-        try {
-          step(generator["throw"](value));
-        } catch (e) {
-          reject(e);
-        }
-      }
-      function step(result) {
-        result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
-      }
-      step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-  };
-  Object.defineProperty(exports2, "__esModule", {value: true});
-  var childProcess = require("child_process");
-  var path2 = require("path");
-  var util_1 = require("util");
-  var ioUtil = require_io_util();
-  var exec5 = util_1.promisify(childProcess.exec);
-  function cp(source, dest, options = {}) {
-    return __awaiter(this, void 0, void 0, function* () {
-      const {force, recursive} = readCopyOptions(options);
-      const destStat = (yield ioUtil.exists(dest)) ? yield ioUtil.stat(dest) : null;
-      if (destStat && destStat.isFile() && !force) {
-        return;
-      }
-      const newDest = destStat && destStat.isDirectory() ? path2.join(dest, path2.basename(source)) : dest;
-      if (!(yield ioUtil.exists(source))) {
-        throw new Error(`no such file or directory: ${source}`);
-      }
-      const sourceStat = yield ioUtil.stat(source);
-      if (sourceStat.isDirectory()) {
-        if (!recursive) {
-          throw new Error(`Failed to copy. ${source} is a directory, but tried to copy without recursive flag.`);
-        } else {
-          yield cpDirRecursive(source, newDest, 0, force);
-        }
-      } else {
-        if (path2.relative(source, newDest) === "") {
-          throw new Error(`'${newDest}' and '${source}' are the same file`);
-        }
-        yield copyFile(source, newDest, force);
-      }
-    });
-  }
-  exports2.cp = cp;
-  function mv(source, dest, options = {}) {
-    return __awaiter(this, void 0, void 0, function* () {
-      if (yield ioUtil.exists(dest)) {
-        let destExists = true;
-        if (yield ioUtil.isDirectory(dest)) {
-          dest = path2.join(dest, path2.basename(source));
-          destExists = yield ioUtil.exists(dest);
-        }
-        if (destExists) {
-          if (options.force == null || options.force) {
-            yield rmRF(dest);
-          } else {
-            throw new Error("Destination already exists");
-          }
-        }
-      }
-      yield mkdirP(path2.dirname(dest));
-      yield ioUtil.rename(source, dest);
-    });
-  }
-  exports2.mv = mv;
-  function rmRF(inputPath) {
-    return __awaiter(this, void 0, void 0, function* () {
-      if (ioUtil.IS_WINDOWS) {
-        try {
-          if (yield ioUtil.isDirectory(inputPath, true)) {
-            yield exec5(`rd /s /q "${inputPath}"`);
-          } else {
-            yield exec5(`del /f /a "${inputPath}"`);
-          }
-        } catch (err) {
-          if (err.code !== "ENOENT")
-            throw err;
-        }
-        try {
-          yield ioUtil.unlink(inputPath);
-        } catch (err) {
-          if (err.code !== "ENOENT")
-            throw err;
-        }
-      } else {
-        let isDir = false;
-        try {
-          isDir = yield ioUtil.isDirectory(inputPath);
-        } catch (err) {
-          if (err.code !== "ENOENT")
-            throw err;
+    };
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    exports2.findInPath = exports2.which = exports2.mkdirP = exports2.rmRF = exports2.mv = exports2.cp = void 0;
+    var assert_1 = require("assert");
+    var childProcess = __importStar(require("child_process"));
+    var path2 = __importStar(require("path"));
+    var util_1 = require("util");
+    var ioUtil = __importStar(require_io_util());
+    var exec5 = util_1.promisify(childProcess.exec);
+    var execFile = util_1.promisify(childProcess.execFile);
+    function cp(source, dest, options = {}) {
+      return __awaiter(this, void 0, void 0, function* () {
+        const { force, recursive, copySourceDirectory } = readCopyOptions(options);
+        const destStat = (yield ioUtil.exists(dest)) ? yield ioUtil.stat(dest) : null;
+        if (destStat && destStat.isFile() && !force) {
           return;
         }
-        if (isDir) {
-          yield exec5(`rm -rf "${inputPath}"`);
-        } else {
-          yield ioUtil.unlink(inputPath);
+        const newDest = destStat && destStat.isDirectory() && copySourceDirectory ? path2.join(dest, path2.basename(source)) : dest;
+        if (!(yield ioUtil.exists(source))) {
+          throw new Error(`no such file or directory: ${source}`);
         }
-      }
-    });
-  }
-  exports2.rmRF = rmRF;
-  function mkdirP(fsPath) {
-    return __awaiter(this, void 0, void 0, function* () {
-      yield ioUtil.mkdirP(fsPath);
-    });
-  }
-  exports2.mkdirP = mkdirP;
-  function which2(tool, check) {
-    return __awaiter(this, void 0, void 0, function* () {
-      if (!tool) {
-        throw new Error("parameter 'tool' is required");
-      }
-      if (check) {
-        const result = yield which2(tool, false);
-        if (!result) {
-          if (ioUtil.IS_WINDOWS) {
-            throw new Error(`Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also verify the file has a valid extension for an executable file.`);
+        const sourceStat = yield ioUtil.stat(source);
+        if (sourceStat.isDirectory()) {
+          if (!recursive) {
+            throw new Error(`Failed to copy. ${source} is a directory, but tried to copy without recursive flag.`);
           } else {
-            throw new Error(`Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also check the file mode to verify the file is executable.`);
+            yield cpDirRecursive(source, newDest, 0, force);
+          }
+        } else {
+          if (path2.relative(source, newDest) === "") {
+            throw new Error(`'${newDest}' and '${source}' are the same file`);
+          }
+          yield copyFile(source, newDest, force);
+        }
+      });
+    }
+    exports2.cp = cp;
+    function mv(source, dest, options = {}) {
+      return __awaiter(this, void 0, void 0, function* () {
+        if (yield ioUtil.exists(dest)) {
+          let destExists = true;
+          if (yield ioUtil.isDirectory(dest)) {
+            dest = path2.join(dest, path2.basename(source));
+            destExists = yield ioUtil.exists(dest);
+          }
+          if (destExists) {
+            if (options.force == null || options.force) {
+              yield rmRF(dest);
+            } else {
+              throw new Error("Destination already exists");
+            }
           }
         }
-      }
-      try {
+        yield mkdirP(path2.dirname(dest));
+        yield ioUtil.rename(source, dest);
+      });
+    }
+    exports2.mv = mv;
+    function rmRF(inputPath) {
+      return __awaiter(this, void 0, void 0, function* () {
+        if (ioUtil.IS_WINDOWS) {
+          if (/[*"<>|]/.test(inputPath)) {
+            throw new Error('File path must not contain `*`, `"`, `<`, `>` or `|` on Windows');
+          }
+          try {
+            const cmdPath = ioUtil.getCmdPath();
+            if (yield ioUtil.isDirectory(inputPath, true)) {
+              yield exec5(`${cmdPath} /s /c "rd /s /q "%inputPath%""`, {
+                env: { inputPath }
+              });
+            } else {
+              yield exec5(`${cmdPath} /s /c "del /f /a "%inputPath%""`, {
+                env: { inputPath }
+              });
+            }
+          } catch (err) {
+            if (err.code !== "ENOENT")
+              throw err;
+          }
+          try {
+            yield ioUtil.unlink(inputPath);
+          } catch (err) {
+            if (err.code !== "ENOENT")
+              throw err;
+          }
+        } else {
+          let isDir = false;
+          try {
+            isDir = yield ioUtil.isDirectory(inputPath);
+          } catch (err) {
+            if (err.code !== "ENOENT")
+              throw err;
+            return;
+          }
+          if (isDir) {
+            yield execFile(`rm`, [`-rf`, `${inputPath}`]);
+          } else {
+            yield ioUtil.unlink(inputPath);
+          }
+        }
+      });
+    }
+    exports2.rmRF = rmRF;
+    function mkdirP(fsPath) {
+      return __awaiter(this, void 0, void 0, function* () {
+        assert_1.ok(fsPath, "a path argument must be provided");
+        yield ioUtil.mkdir(fsPath, { recursive: true });
+      });
+    }
+    exports2.mkdirP = mkdirP;
+    function which2(tool, check) {
+      return __awaiter(this, void 0, void 0, function* () {
+        if (!tool) {
+          throw new Error("parameter 'tool' is required");
+        }
+        if (check) {
+          const result = yield which2(tool, false);
+          if (!result) {
+            if (ioUtil.IS_WINDOWS) {
+              throw new Error(`Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also verify the file has a valid extension for an executable file.`);
+            } else {
+              throw new Error(`Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also check the file mode to verify the file is executable.`);
+            }
+          }
+          return result;
+        }
+        const matches = yield findInPath(tool);
+        if (matches && matches.length > 0) {
+          return matches[0];
+        }
+        return "";
+      });
+    }
+    exports2.which = which2;
+    function findInPath(tool) {
+      return __awaiter(this, void 0, void 0, function* () {
+        if (!tool) {
+          throw new Error("parameter 'tool' is required");
+        }
         const extensions = [];
-        if (ioUtil.IS_WINDOWS && process.env.PATHEXT) {
-          for (const extension of process.env.PATHEXT.split(path2.delimiter)) {
+        if (ioUtil.IS_WINDOWS && process.env["PATHEXT"]) {
+          for (const extension of process.env["PATHEXT"].split(path2.delimiter)) {
             if (extension) {
               extensions.push(extension);
             }
@@ -622,12 +681,12 @@ var require_io = __commonJS((exports2) => {
         if (ioUtil.isRooted(tool)) {
           const filePath = yield ioUtil.tryGetExecutablePath(tool, extensions);
           if (filePath) {
-            return filePath;
+            return [filePath];
           }
-          return "";
+          return [];
         }
-        if (tool.includes("/") || ioUtil.IS_WINDOWS && tool.includes("\\")) {
-          return "";
+        if (tool.includes(path2.sep)) {
+          return [];
         }
         const directories = [];
         if (process.env.PATH) {
@@ -637,578 +696,986 @@ var require_io = __commonJS((exports2) => {
             }
           }
         }
+        const matches = [];
         for (const directory of directories) {
-          const filePath = yield ioUtil.tryGetExecutablePath(directory + path2.sep + tool, extensions);
+          const filePath = yield ioUtil.tryGetExecutablePath(path2.join(directory, tool), extensions);
           if (filePath) {
-            return filePath;
+            matches.push(filePath);
           }
         }
-        return "";
-      } catch (err) {
-        throw new Error(`which failed with message ${err.message}`);
-      }
-    });
-  }
-  exports2.which = which2;
-  function readCopyOptions(options) {
-    const force = options.force == null ? true : options.force;
-    const recursive = Boolean(options.recursive);
-    return {force, recursive};
-  }
-  function cpDirRecursive(sourceDir, destDir, currentDepth, force) {
-    return __awaiter(this, void 0, void 0, function* () {
-      if (currentDepth >= 255)
-        return;
-      currentDepth++;
-      yield mkdirP(destDir);
-      const files = yield ioUtil.readdir(sourceDir);
-      for (const fileName of files) {
-        const srcFile = `${sourceDir}/${fileName}`;
-        const destFile = `${destDir}/${fileName}`;
-        const srcFileStat = yield ioUtil.lstat(srcFile);
-        if (srcFileStat.isDirectory()) {
-          yield cpDirRecursive(srcFile, destFile, currentDepth, force);
-        } else {
-          yield copyFile(srcFile, destFile, force);
+        return matches;
+      });
+    }
+    exports2.findInPath = findInPath;
+    function readCopyOptions(options) {
+      const force = options.force == null ? true : options.force;
+      const recursive = Boolean(options.recursive);
+      const copySourceDirectory = options.copySourceDirectory == null ? true : Boolean(options.copySourceDirectory);
+      return { force, recursive, copySourceDirectory };
+    }
+    function cpDirRecursive(sourceDir, destDir, currentDepth, force) {
+      return __awaiter(this, void 0, void 0, function* () {
+        if (currentDepth >= 255)
+          return;
+        currentDepth++;
+        yield mkdirP(destDir);
+        const files = yield ioUtil.readdir(sourceDir);
+        for (const fileName of files) {
+          const srcFile = `${sourceDir}/${fileName}`;
+          const destFile = `${destDir}/${fileName}`;
+          const srcFileStat = yield ioUtil.lstat(srcFile);
+          if (srcFileStat.isDirectory()) {
+            yield cpDirRecursive(srcFile, destFile, currentDepth, force);
+          } else {
+            yield copyFile(srcFile, destFile, force);
+          }
         }
-      }
-      yield ioUtil.chmod(destDir, (yield ioUtil.stat(sourceDir)).mode);
-    });
-  }
-  function copyFile(srcFile, destFile, force) {
-    return __awaiter(this, void 0, void 0, function* () {
-      if ((yield ioUtil.lstat(srcFile)).isSymbolicLink()) {
-        try {
-          yield ioUtil.lstat(destFile);
-          yield ioUtil.unlink(destFile);
-        } catch (e) {
-          if (e.code === "EPERM") {
-            yield ioUtil.chmod(destFile, "0666");
+        yield ioUtil.chmod(destDir, (yield ioUtil.stat(sourceDir)).mode);
+      });
+    }
+    function copyFile(srcFile, destFile, force) {
+      return __awaiter(this, void 0, void 0, function* () {
+        if ((yield ioUtil.lstat(srcFile)).isSymbolicLink()) {
+          try {
+            yield ioUtil.lstat(destFile);
             yield ioUtil.unlink(destFile);
+          } catch (e) {
+            if (e.code === "EPERM") {
+              yield ioUtil.chmod(destFile, "0666");
+              yield ioUtil.unlink(destFile);
+            }
           }
+          const symlinkFull = yield ioUtil.readlink(srcFile);
+          yield ioUtil.symlink(symlinkFull, destFile, ioUtil.IS_WINDOWS ? "junction" : null);
+        } else if (!(yield ioUtil.exists(destFile)) || force) {
+          yield ioUtil.copyFile(srcFile, destFile);
         }
-        const symlinkFull = yield ioUtil.readlink(srcFile);
-        yield ioUtil.symlink(symlinkFull, destFile, ioUtil.IS_WINDOWS ? "junction" : null);
-      } else if (!(yield ioUtil.exists(destFile)) || force) {
-        yield ioUtil.copyFile(srcFile, destFile);
-      }
-    });
+      });
+    }
   }
 });
 
 // node_modules/@actions/exec/lib/toolrunner.js
-var require_toolrunner = __commonJS((exports2) => {
-  "use strict";
-  var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
-    function adopt(value) {
-      return value instanceof P ? value : new P(function(resolve) {
-        resolve(value);
+var require_toolrunner = __commonJS({
+  "node_modules/@actions/exec/lib/toolrunner.js"(exports2) {
+    "use strict";
+    var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve) {
+          resolve(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
-    }
-    return new (P || (P = Promise))(function(resolve, reject) {
-      function fulfilled(value) {
-        try {
-          step(generator.next(value));
-        } catch (e) {
-          reject(e);
+    };
+    var __importStar = exports2 && exports2.__importStar || function(mod) {
+      if (mod && mod.__esModule)
+        return mod;
+      var result = {};
+      if (mod != null) {
+        for (var k in mod)
+          if (Object.hasOwnProperty.call(mod, k))
+            result[k] = mod[k];
+      }
+      result["default"] = mod;
+      return result;
+    };
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    var os2 = __importStar(require("os"));
+    var events = __importStar(require("events"));
+    var child = __importStar(require("child_process"));
+    var path2 = __importStar(require("path"));
+    var io2 = __importStar(require_io());
+    var ioUtil = __importStar(require_io_util());
+    var IS_WINDOWS = process.platform === "win32";
+    var ToolRunner = class extends events.EventEmitter {
+      constructor(toolPath, args, options) {
+        super();
+        if (!toolPath) {
+          throw new Error("Parameter 'toolPath' cannot be null or empty.");
+        }
+        this.toolPath = toolPath;
+        this.args = args || [];
+        this.options = options || {};
+      }
+      _debug(message) {
+        if (this.options.listeners && this.options.listeners.debug) {
+          this.options.listeners.debug(message);
         }
       }
-      function rejected(value) {
-        try {
-          step(generator["throw"](value));
-        } catch (e) {
-          reject(e);
-        }
-      }
-      function step(result) {
-        result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
-      }
-      step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-  };
-  var __importStar = exports2 && exports2.__importStar || function(mod) {
-    if (mod && mod.__esModule)
-      return mod;
-    var result = {};
-    if (mod != null) {
-      for (var k in mod)
-        if (Object.hasOwnProperty.call(mod, k))
-          result[k] = mod[k];
-    }
-    result["default"] = mod;
-    return result;
-  };
-  Object.defineProperty(exports2, "__esModule", {value: true});
-  var os2 = __importStar(require("os"));
-  var events = __importStar(require("events"));
-  var child = __importStar(require("child_process"));
-  var path2 = __importStar(require("path"));
-  var io2 = __importStar(require_io());
-  var ioUtil = __importStar(require_io_util());
-  var IS_WINDOWS = process.platform === "win32";
-  var ToolRunner = class extends events.EventEmitter {
-    constructor(toolPath, args, options) {
-      super();
-      if (!toolPath) {
-        throw new Error("Parameter 'toolPath' cannot be null or empty.");
-      }
-      this.toolPath = toolPath;
-      this.args = args || [];
-      this.options = options || {};
-    }
-    _debug(message) {
-      if (this.options.listeners && this.options.listeners.debug) {
-        this.options.listeners.debug(message);
-      }
-    }
-    _getCommandString(options, noPrefix) {
-      const toolPath = this._getSpawnFileName();
-      const args = this._getSpawnArgs(options);
-      let cmd = noPrefix ? "" : "[command]";
-      if (IS_WINDOWS) {
-        if (this._isCmdFile()) {
+      _getCommandString(options, noPrefix) {
+        const toolPath = this._getSpawnFileName();
+        const args = this._getSpawnArgs(options);
+        let cmd = noPrefix ? "" : "[command]";
+        if (IS_WINDOWS) {
+          if (this._isCmdFile()) {
+            cmd += toolPath;
+            for (const a of args) {
+              cmd += ` ${a}`;
+            }
+          } else if (options.windowsVerbatimArguments) {
+            cmd += `"${toolPath}"`;
+            for (const a of args) {
+              cmd += ` ${a}`;
+            }
+          } else {
+            cmd += this._windowsQuoteCmdArg(toolPath);
+            for (const a of args) {
+              cmd += ` ${this._windowsQuoteCmdArg(a)}`;
+            }
+          }
+        } else {
           cmd += toolPath;
           for (const a of args) {
             cmd += ` ${a}`;
           }
-        } else if (options.windowsVerbatimArguments) {
-          cmd += `"${toolPath}"`;
-          for (const a of args) {
-            cmd += ` ${a}`;
+        }
+        return cmd;
+      }
+      _processLineBuffer(data, strBuffer, onLine) {
+        try {
+          let s = strBuffer + data.toString();
+          let n = s.indexOf(os2.EOL);
+          while (n > -1) {
+            const line = s.substring(0, n);
+            onLine(line);
+            s = s.substring(n + os2.EOL.length);
+            n = s.indexOf(os2.EOL);
           }
-        } else {
-          cmd += this._windowsQuoteCmdArg(toolPath);
-          for (const a of args) {
-            cmd += ` ${this._windowsQuoteCmdArg(a)}`;
+          strBuffer = s;
+        } catch (err) {
+          this._debug(`error processing line. Failed with error ${err}`);
+        }
+      }
+      _getSpawnFileName() {
+        if (IS_WINDOWS) {
+          if (this._isCmdFile()) {
+            return process.env["COMSPEC"] || "cmd.exe";
           }
         }
-      } else {
-        cmd += toolPath;
-        for (const a of args) {
-          cmd += ` ${a}`;
-        }
+        return this.toolPath;
       }
-      return cmd;
-    }
-    _processLineBuffer(data, strBuffer, onLine) {
-      try {
-        let s = strBuffer + data.toString();
-        let n = s.indexOf(os2.EOL);
-        while (n > -1) {
-          const line = s.substring(0, n);
-          onLine(line);
-          s = s.substring(n + os2.EOL.length);
-          n = s.indexOf(os2.EOL);
-        }
-        strBuffer = s;
-      } catch (err) {
-        this._debug(`error processing line. Failed with error ${err}`);
-      }
-    }
-    _getSpawnFileName() {
-      if (IS_WINDOWS) {
-        if (this._isCmdFile()) {
-          return process.env["COMSPEC"] || "cmd.exe";
-        }
-      }
-      return this.toolPath;
-    }
-    _getSpawnArgs(options) {
-      if (IS_WINDOWS) {
-        if (this._isCmdFile()) {
-          let argline = `/D /S /C "${this._windowsQuoteCmdArg(this.toolPath)}`;
-          for (const a of this.args) {
-            argline += " ";
-            argline += options.windowsVerbatimArguments ? a : this._windowsQuoteCmdArg(a);
+      _getSpawnArgs(options) {
+        if (IS_WINDOWS) {
+          if (this._isCmdFile()) {
+            let argline = `/D /S /C "${this._windowsQuoteCmdArg(this.toolPath)}`;
+            for (const a of this.args) {
+              argline += " ";
+              argline += options.windowsVerbatimArguments ? a : this._windowsQuoteCmdArg(a);
+            }
+            argline += '"';
+            return [argline];
           }
-          argline += '"';
-          return [argline];
         }
+        return this.args;
       }
-      return this.args;
-    }
-    _endsWith(str, end) {
-      return str.endsWith(end);
-    }
-    _isCmdFile() {
-      const upperToolPath = this.toolPath.toUpperCase();
-      return this._endsWith(upperToolPath, ".CMD") || this._endsWith(upperToolPath, ".BAT");
-    }
-    _windowsQuoteCmdArg(arg) {
-      if (!this._isCmdFile()) {
-        return this._uvQuoteCmdArg(arg);
+      _endsWith(str, end) {
+        return str.endsWith(end);
       }
-      if (!arg) {
-        return '""';
+      _isCmdFile() {
+        const upperToolPath = this.toolPath.toUpperCase();
+        return this._endsWith(upperToolPath, ".CMD") || this._endsWith(upperToolPath, ".BAT");
       }
-      const cmdSpecialChars = [
-        " ",
-        "	",
-        "&",
-        "(",
-        ")",
-        "[",
-        "]",
-        "{",
-        "}",
-        "^",
-        "=",
-        ";",
-        "!",
-        "'",
-        "+",
-        ",",
-        "`",
-        "~",
-        "|",
-        "<",
-        ">",
-        '"'
-      ];
-      let needsQuotes = false;
-      for (const char of arg) {
-        if (cmdSpecialChars.some((x) => x === char)) {
-          needsQuotes = true;
-          break;
+      _windowsQuoteCmdArg(arg) {
+        if (!this._isCmdFile()) {
+          return this._uvQuoteCmdArg(arg);
         }
-      }
-      if (!needsQuotes) {
-        return arg;
-      }
-      let reverse = '"';
-      let quoteHit = true;
-      for (let i = arg.length; i > 0; i--) {
-        reverse += arg[i - 1];
-        if (quoteHit && arg[i - 1] === "\\") {
-          reverse += "\\";
-        } else if (arg[i - 1] === '"') {
-          quoteHit = true;
-          reverse += '"';
-        } else {
-          quoteHit = false;
+        if (!arg) {
+          return '""';
         }
-      }
-      reverse += '"';
-      return reverse.split("").reverse().join("");
-    }
-    _uvQuoteCmdArg(arg) {
-      if (!arg) {
-        return '""';
-      }
-      if (!arg.includes(" ") && !arg.includes("	") && !arg.includes('"')) {
-        return arg;
-      }
-      if (!arg.includes('"') && !arg.includes("\\")) {
-        return `"${arg}"`;
-      }
-      let reverse = '"';
-      let quoteHit = true;
-      for (let i = arg.length; i > 0; i--) {
-        reverse += arg[i - 1];
-        if (quoteHit && arg[i - 1] === "\\") {
-          reverse += "\\";
-        } else if (arg[i - 1] === '"') {
-          quoteHit = true;
-          reverse += "\\";
-        } else {
-          quoteHit = false;
-        }
-      }
-      reverse += '"';
-      return reverse.split("").reverse().join("");
-    }
-    _cloneExecOptions(options) {
-      options = options || {};
-      const result = {
-        cwd: options.cwd || process.cwd(),
-        env: options.env || process.env,
-        silent: options.silent || false,
-        windowsVerbatimArguments: options.windowsVerbatimArguments || false,
-        failOnStdErr: options.failOnStdErr || false,
-        ignoreReturnCode: options.ignoreReturnCode || false,
-        delay: options.delay || 1e4
-      };
-      result.outStream = options.outStream || process.stdout;
-      result.errStream = options.errStream || process.stderr;
-      return result;
-    }
-    _getSpawnOptions(options, toolPath) {
-      options = options || {};
-      const result = {};
-      result.cwd = options.cwd;
-      result.env = options.env;
-      result["windowsVerbatimArguments"] = options.windowsVerbatimArguments || this._isCmdFile();
-      if (options.windowsVerbatimArguments) {
-        result.argv0 = `"${toolPath}"`;
-      }
-      return result;
-    }
-    exec() {
-      return __awaiter(this, void 0, void 0, function* () {
-        if (!ioUtil.isRooted(this.toolPath) && (this.toolPath.includes("/") || IS_WINDOWS && this.toolPath.includes("\\"))) {
-          this.toolPath = path2.resolve(process.cwd(), this.options.cwd || process.cwd(), this.toolPath);
-        }
-        this.toolPath = yield io2.which(this.toolPath, true);
-        return new Promise((resolve, reject) => {
-          this._debug(`exec tool: ${this.toolPath}`);
-          this._debug("arguments:");
-          for (const arg of this.args) {
-            this._debug(`   ${arg}`);
+        const cmdSpecialChars = [
+          " ",
+          "	",
+          "&",
+          "(",
+          ")",
+          "[",
+          "]",
+          "{",
+          "}",
+          "^",
+          "=",
+          ";",
+          "!",
+          "'",
+          "+",
+          ",",
+          "`",
+          "~",
+          "|",
+          "<",
+          ">",
+          '"'
+        ];
+        let needsQuotes = false;
+        for (const char of arg) {
+          if (cmdSpecialChars.some((x) => x === char)) {
+            needsQuotes = true;
+            break;
           }
-          const optionsNonNull = this._cloneExecOptions(this.options);
-          if (!optionsNonNull.silent && optionsNonNull.outStream) {
-            optionsNonNull.outStream.write(this._getCommandString(optionsNonNull) + os2.EOL);
+        }
+        if (!needsQuotes) {
+          return arg;
+        }
+        let reverse = '"';
+        let quoteHit = true;
+        for (let i = arg.length; i > 0; i--) {
+          reverse += arg[i - 1];
+          if (quoteHit && arg[i - 1] === "\\") {
+            reverse += "\\";
+          } else if (arg[i - 1] === '"') {
+            quoteHit = true;
+            reverse += '"';
+          } else {
+            quoteHit = false;
           }
-          const state = new ExecState(optionsNonNull, this.toolPath);
-          state.on("debug", (message) => {
-            this._debug(message);
-          });
-          const fileName = this._getSpawnFileName();
-          const cp = child.spawn(fileName, this._getSpawnArgs(optionsNonNull), this._getSpawnOptions(this.options, fileName));
-          const stdbuffer = "";
-          if (cp.stdout) {
-            cp.stdout.on("data", (data) => {
-              if (this.options.listeners && this.options.listeners.stdout) {
-                this.options.listeners.stdout(data);
-              }
-              if (!optionsNonNull.silent && optionsNonNull.outStream) {
-                optionsNonNull.outStream.write(data);
-              }
-              this._processLineBuffer(data, stdbuffer, (line) => {
-                if (this.options.listeners && this.options.listeners.stdline) {
-                  this.options.listeners.stdline(line);
-                }
-              });
+        }
+        reverse += '"';
+        return reverse.split("").reverse().join("");
+      }
+      _uvQuoteCmdArg(arg) {
+        if (!arg) {
+          return '""';
+        }
+        if (!arg.includes(" ") && !arg.includes("	") && !arg.includes('"')) {
+          return arg;
+        }
+        if (!arg.includes('"') && !arg.includes("\\")) {
+          return `"${arg}"`;
+        }
+        let reverse = '"';
+        let quoteHit = true;
+        for (let i = arg.length; i > 0; i--) {
+          reverse += arg[i - 1];
+          if (quoteHit && arg[i - 1] === "\\") {
+            reverse += "\\";
+          } else if (arg[i - 1] === '"') {
+            quoteHit = true;
+            reverse += "\\";
+          } else {
+            quoteHit = false;
+          }
+        }
+        reverse += '"';
+        return reverse.split("").reverse().join("");
+      }
+      _cloneExecOptions(options) {
+        options = options || {};
+        const result = {
+          cwd: options.cwd || process.cwd(),
+          env: options.env || process.env,
+          silent: options.silent || false,
+          windowsVerbatimArguments: options.windowsVerbatimArguments || false,
+          failOnStdErr: options.failOnStdErr || false,
+          ignoreReturnCode: options.ignoreReturnCode || false,
+          delay: options.delay || 1e4
+        };
+        result.outStream = options.outStream || process.stdout;
+        result.errStream = options.errStream || process.stderr;
+        return result;
+      }
+      _getSpawnOptions(options, toolPath) {
+        options = options || {};
+        const result = {};
+        result.cwd = options.cwd;
+        result.env = options.env;
+        result["windowsVerbatimArguments"] = options.windowsVerbatimArguments || this._isCmdFile();
+        if (options.windowsVerbatimArguments) {
+          result.argv0 = `"${toolPath}"`;
+        }
+        return result;
+      }
+      exec() {
+        return __awaiter(this, void 0, void 0, function* () {
+          if (!ioUtil.isRooted(this.toolPath) && (this.toolPath.includes("/") || IS_WINDOWS && this.toolPath.includes("\\"))) {
+            this.toolPath = path2.resolve(process.cwd(), this.options.cwd || process.cwd(), this.toolPath);
+          }
+          this.toolPath = yield io2.which(this.toolPath, true);
+          return new Promise((resolve, reject) => {
+            this._debug(`exec tool: ${this.toolPath}`);
+            this._debug("arguments:");
+            for (const arg of this.args) {
+              this._debug(`   ${arg}`);
+            }
+            const optionsNonNull = this._cloneExecOptions(this.options);
+            if (!optionsNonNull.silent && optionsNonNull.outStream) {
+              optionsNonNull.outStream.write(this._getCommandString(optionsNonNull) + os2.EOL);
+            }
+            const state = new ExecState(optionsNonNull, this.toolPath);
+            state.on("debug", (message) => {
+              this._debug(message);
             });
-          }
-          const errbuffer = "";
-          if (cp.stderr) {
-            cp.stderr.on("data", (data) => {
-              state.processStderr = true;
-              if (this.options.listeners && this.options.listeners.stderr) {
-                this.options.listeners.stderr(data);
-              }
-              if (!optionsNonNull.silent && optionsNonNull.errStream && optionsNonNull.outStream) {
-                const s = optionsNonNull.failOnStdErr ? optionsNonNull.errStream : optionsNonNull.outStream;
-                s.write(data);
-              }
-              this._processLineBuffer(data, errbuffer, (line) => {
-                if (this.options.listeners && this.options.listeners.errline) {
-                  this.options.listeners.errline(line);
+            const fileName = this._getSpawnFileName();
+            const cp = child.spawn(fileName, this._getSpawnArgs(optionsNonNull), this._getSpawnOptions(this.options, fileName));
+            const stdbuffer = "";
+            if (cp.stdout) {
+              cp.stdout.on("data", (data) => {
+                if (this.options.listeners && this.options.listeners.stdout) {
+                  this.options.listeners.stdout(data);
                 }
+                if (!optionsNonNull.silent && optionsNonNull.outStream) {
+                  optionsNonNull.outStream.write(data);
+                }
+                this._processLineBuffer(data, stdbuffer, (line) => {
+                  if (this.options.listeners && this.options.listeners.stdline) {
+                    this.options.listeners.stdline(line);
+                  }
+                });
               });
+            }
+            const errbuffer = "";
+            if (cp.stderr) {
+              cp.stderr.on("data", (data) => {
+                state.processStderr = true;
+                if (this.options.listeners && this.options.listeners.stderr) {
+                  this.options.listeners.stderr(data);
+                }
+                if (!optionsNonNull.silent && optionsNonNull.errStream && optionsNonNull.outStream) {
+                  const s = optionsNonNull.failOnStdErr ? optionsNonNull.errStream : optionsNonNull.outStream;
+                  s.write(data);
+                }
+                this._processLineBuffer(data, errbuffer, (line) => {
+                  if (this.options.listeners && this.options.listeners.errline) {
+                    this.options.listeners.errline(line);
+                  }
+                });
+              });
+            }
+            cp.on("error", (err) => {
+              state.processError = err.message;
+              state.processExited = true;
+              state.processClosed = true;
+              state.CheckComplete();
             });
-          }
-          cp.on("error", (err) => {
-            state.processError = err.message;
-            state.processExited = true;
-            state.processClosed = true;
-            state.CheckComplete();
-          });
-          cp.on("exit", (code) => {
-            state.processExitCode = code;
-            state.processExited = true;
-            this._debug(`Exit code ${code} received from tool '${this.toolPath}'`);
-            state.CheckComplete();
-          });
-          cp.on("close", (code) => {
-            state.processExitCode = code;
-            state.processExited = true;
-            state.processClosed = true;
-            this._debug(`STDIO streams have closed for tool '${this.toolPath}'`);
-            state.CheckComplete();
-          });
-          state.on("done", (error, exitCode) => {
-            if (stdbuffer.length > 0) {
-              this.emit("stdline", stdbuffer);
+            cp.on("exit", (code) => {
+              state.processExitCode = code;
+              state.processExited = true;
+              this._debug(`Exit code ${code} received from tool '${this.toolPath}'`);
+              state.CheckComplete();
+            });
+            cp.on("close", (code) => {
+              state.processExitCode = code;
+              state.processExited = true;
+              state.processClosed = true;
+              this._debug(`STDIO streams have closed for tool '${this.toolPath}'`);
+              state.CheckComplete();
+            });
+            state.on("done", (error, exitCode) => {
+              if (stdbuffer.length > 0) {
+                this.emit("stdline", stdbuffer);
+              }
+              if (errbuffer.length > 0) {
+                this.emit("errline", errbuffer);
+              }
+              cp.removeAllListeners();
+              if (error) {
+                reject(error);
+              } else {
+                resolve(exitCode);
+              }
+            });
+            if (this.options.input) {
+              if (!cp.stdin) {
+                throw new Error("child process missing stdin");
+              }
+              cp.stdin.end(this.options.input);
             }
-            if (errbuffer.length > 0) {
-              this.emit("errline", errbuffer);
-            }
-            cp.removeAllListeners();
-            if (error) {
-              reject(error);
-            } else {
-              resolve(exitCode);
-            }
           });
-          if (this.options.input) {
-            if (!cp.stdin) {
-              throw new Error("child process missing stdin");
-            }
-            cp.stdin.end(this.options.input);
-          }
         });
-      });
-    }
-  };
-  exports2.ToolRunner = ToolRunner;
-  function argStringToArray(argString) {
-    const args = [];
-    let inQuotes = false;
-    let escaped = false;
-    let arg = "";
-    function append(c) {
-      if (escaped && c !== '"') {
-        arg += "\\";
       }
-      arg += c;
-      escaped = false;
-    }
-    for (let i = 0; i < argString.length; i++) {
-      const c = argString.charAt(i);
-      if (c === '"') {
-        if (!escaped) {
-          inQuotes = !inQuotes;
-        } else {
+    };
+    exports2.ToolRunner = ToolRunner;
+    function argStringToArray(argString) {
+      const args = [];
+      let inQuotes = false;
+      let escaped = false;
+      let arg = "";
+      function append(c) {
+        if (escaped && c !== '"') {
+          arg += "\\";
+        }
+        arg += c;
+        escaped = false;
+      }
+      for (let i = 0; i < argString.length; i++) {
+        const c = argString.charAt(i);
+        if (c === '"') {
+          if (!escaped) {
+            inQuotes = !inQuotes;
+          } else {
+            append(c);
+          }
+          continue;
+        }
+        if (c === "\\" && escaped) {
           append(c);
+          continue;
         }
-        continue;
-      }
-      if (c === "\\" && escaped) {
+        if (c === "\\" && inQuotes) {
+          escaped = true;
+          continue;
+        }
+        if (c === " " && !inQuotes) {
+          if (arg.length > 0) {
+            args.push(arg);
+            arg = "";
+          }
+          continue;
+        }
         append(c);
-        continue;
       }
-      if (c === "\\" && inQuotes) {
-        escaped = true;
-        continue;
+      if (arg.length > 0) {
+        args.push(arg.trim());
       }
-      if (c === " " && !inQuotes) {
-        if (arg.length > 0) {
-          args.push(arg);
-          arg = "";
-        }
-        continue;
-      }
-      append(c);
+      return args;
     }
-    if (arg.length > 0) {
-      args.push(arg.trim());
-    }
-    return args;
-  }
-  exports2.argStringToArray = argStringToArray;
-  var ExecState = class extends events.EventEmitter {
-    constructor(options, toolPath) {
-      super();
-      this.processClosed = false;
-      this.processError = "";
-      this.processExitCode = 0;
-      this.processExited = false;
-      this.processStderr = false;
-      this.delay = 1e4;
-      this.done = false;
-      this.timeout = null;
-      if (!toolPath) {
-        throw new Error("toolPath must not be empty");
-      }
-      this.options = options;
-      this.toolPath = toolPath;
-      if (options.delay) {
-        this.delay = options.delay;
-      }
-    }
-    CheckComplete() {
-      if (this.done) {
-        return;
-      }
-      if (this.processClosed) {
-        this._setResult();
-      } else if (this.processExited) {
-        this.timeout = setTimeout(ExecState.HandleTimeout, this.delay, this);
-      }
-    }
-    _debug(message) {
-      this.emit("debug", message);
-    }
-    _setResult() {
-      let error;
-      if (this.processExited) {
-        if (this.processError) {
-          error = new Error(`There was an error when attempting to execute the process '${this.toolPath}'. This may indicate the process failed to start. Error: ${this.processError}`);
-        } else if (this.processExitCode !== 0 && !this.options.ignoreReturnCode) {
-          error = new Error(`The process '${this.toolPath}' failed with exit code ${this.processExitCode}`);
-        } else if (this.processStderr && this.options.failOnStdErr) {
-          error = new Error(`The process '${this.toolPath}' failed because one or more lines were written to the STDERR stream`);
-        }
-      }
-      if (this.timeout) {
-        clearTimeout(this.timeout);
+    exports2.argStringToArray = argStringToArray;
+    var ExecState = class extends events.EventEmitter {
+      constructor(options, toolPath) {
+        super();
+        this.processClosed = false;
+        this.processError = "";
+        this.processExitCode = 0;
+        this.processExited = false;
+        this.processStderr = false;
+        this.delay = 1e4;
+        this.done = false;
         this.timeout = null;
+        if (!toolPath) {
+          throw new Error("toolPath must not be empty");
+        }
+        this.options = options;
+        this.toolPath = toolPath;
+        if (options.delay) {
+          this.delay = options.delay;
+        }
       }
-      this.done = true;
-      this.emit("done", error, this.processExitCode);
-    }
-    static HandleTimeout(state) {
-      if (state.done) {
-        return;
+      CheckComplete() {
+        if (this.done) {
+          return;
+        }
+        if (this.processClosed) {
+          this._setResult();
+        } else if (this.processExited) {
+          this.timeout = setTimeout(ExecState.HandleTimeout, this.delay, this);
+        }
       }
-      if (!state.processClosed && state.processExited) {
-        const message = `The STDIO streams did not close within ${state.delay / 1e3} seconds of the exit event from process '${state.toolPath}'. This may indicate a child process inherited the STDIO streams and has not yet exited.`;
-        state._debug(message);
+      _debug(message) {
+        this.emit("debug", message);
       }
-      state._setResult();
-    }
-  };
+      _setResult() {
+        let error;
+        if (this.processExited) {
+          if (this.processError) {
+            error = new Error(`There was an error when attempting to execute the process '${this.toolPath}'. This may indicate the process failed to start. Error: ${this.processError}`);
+          } else if (this.processExitCode !== 0 && !this.options.ignoreReturnCode) {
+            error = new Error(`The process '${this.toolPath}' failed with exit code ${this.processExitCode}`);
+          } else if (this.processStderr && this.options.failOnStdErr) {
+            error = new Error(`The process '${this.toolPath}' failed because one or more lines were written to the STDERR stream`);
+          }
+        }
+        if (this.timeout) {
+          clearTimeout(this.timeout);
+          this.timeout = null;
+        }
+        this.done = true;
+        this.emit("done", error, this.processExitCode);
+      }
+      static HandleTimeout(state) {
+        if (state.done) {
+          return;
+        }
+        if (!state.processClosed && state.processExited) {
+          const message = `The STDIO streams did not close within ${state.delay / 1e3} seconds of the exit event from process '${state.toolPath}'. This may indicate a child process inherited the STDIO streams and has not yet exited.`;
+          state._debug(message);
+        }
+        state._setResult();
+      }
+    };
+  }
 });
 
 // node_modules/@actions/exec/lib/exec.js
-var require_exec = __commonJS((exports2) => {
-  "use strict";
-  var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
-    function adopt(value) {
-      return value instanceof P ? value : new P(function(resolve) {
-        resolve(value);
+var require_exec = __commonJS({
+  "node_modules/@actions/exec/lib/exec.js"(exports2) {
+    "use strict";
+    var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve) {
+          resolve(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+      });
+    };
+    var __importStar = exports2 && exports2.__importStar || function(mod) {
+      if (mod && mod.__esModule)
+        return mod;
+      var result = {};
+      if (mod != null) {
+        for (var k in mod)
+          if (Object.hasOwnProperty.call(mod, k))
+            result[k] = mod[k];
+      }
+      result["default"] = mod;
+      return result;
+    };
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    var tr = __importStar(require_toolrunner());
+    function exec5(commandLine, args, options) {
+      return __awaiter(this, void 0, void 0, function* () {
+        const commandArgs = tr.argStringToArray(commandLine);
+        if (commandArgs.length === 0) {
+          throw new Error(`Parameter 'commandLine' cannot be null or empty.`);
+        }
+        const toolPath = commandArgs[0];
+        args = commandArgs.slice(1).concat(args || []);
+        const runner = new tr.ToolRunner(toolPath, args, options);
+        return runner.exec();
       });
     }
-    return new (P || (P = Promise))(function(resolve, reject) {
-      function fulfilled(value) {
-        try {
-          step(generator.next(value));
-        } catch (e) {
-          reject(e);
-        }
-      }
-      function rejected(value) {
-        try {
-          step(generator["throw"](value));
-        } catch (e) {
-          reject(e);
-        }
-      }
-      function step(result) {
-        result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
-      }
-      step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-  };
-  var __importStar = exports2 && exports2.__importStar || function(mod) {
-    if (mod && mod.__esModule)
-      return mod;
-    var result = {};
-    if (mod != null) {
-      for (var k in mod)
-        if (Object.hasOwnProperty.call(mod, k))
-          result[k] = mod[k];
-    }
-    result["default"] = mod;
-    return result;
-  };
-  Object.defineProperty(exports2, "__esModule", {value: true});
-  var tr = __importStar(require_toolrunner());
-  function exec5(commandLine, args, options) {
-    return __awaiter(this, void 0, void 0, function* () {
-      const commandArgs = tr.argStringToArray(commandLine);
-      if (commandArgs.length === 0) {
-        throw new Error(`Parameter 'commandLine' cannot be null or empty.`);
-      }
-      const toolPath = commandArgs[0];
-      args = commandArgs.slice(1).concat(args || []);
-      const runner = new tr.ToolRunner(toolPath, args, options);
-      return runner.exec();
-    });
+    exports2.exec = exec5;
   }
-  exports2.exec = exec5;
+});
+
+// node_modules/@actions/io/lib/io-util.js
+var require_io_util2 = __commonJS({
+  "node_modules/@actions/io/lib/io-util.js"(exports2) {
+    "use strict";
+    var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve) {
+          resolve(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+      });
+    };
+    var _a;
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    var assert_1 = require("assert");
+    var fs2 = require("fs");
+    var path2 = require("path");
+    _a = fs2.promises, exports2.chmod = _a.chmod, exports2.copyFile = _a.copyFile, exports2.lstat = _a.lstat, exports2.mkdir = _a.mkdir, exports2.readdir = _a.readdir, exports2.readlink = _a.readlink, exports2.rename = _a.rename, exports2.rmdir = _a.rmdir, exports2.stat = _a.stat, exports2.symlink = _a.symlink, exports2.unlink = _a.unlink;
+    exports2.IS_WINDOWS = process.platform === "win32";
+    function exists(fsPath) {
+      return __awaiter(this, void 0, void 0, function* () {
+        try {
+          yield exports2.stat(fsPath);
+        } catch (err) {
+          if (err.code === "ENOENT") {
+            return false;
+          }
+          throw err;
+        }
+        return true;
+      });
+    }
+    exports2.exists = exists;
+    function isDirectory(fsPath, useStat = false) {
+      return __awaiter(this, void 0, void 0, function* () {
+        const stats = useStat ? yield exports2.stat(fsPath) : yield exports2.lstat(fsPath);
+        return stats.isDirectory();
+      });
+    }
+    exports2.isDirectory = isDirectory;
+    function isRooted(p) {
+      p = normalizeSeparators(p);
+      if (!p) {
+        throw new Error('isRooted() parameter "p" cannot be empty');
+      }
+      if (exports2.IS_WINDOWS) {
+        return p.startsWith("\\") || /^[A-Z]:/i.test(p);
+      }
+      return p.startsWith("/");
+    }
+    exports2.isRooted = isRooted;
+    function mkdirP(fsPath, maxDepth = 1e3, depth = 1) {
+      return __awaiter(this, void 0, void 0, function* () {
+        assert_1.ok(fsPath, "a path argument must be provided");
+        fsPath = path2.resolve(fsPath);
+        if (depth >= maxDepth)
+          return exports2.mkdir(fsPath);
+        try {
+          yield exports2.mkdir(fsPath);
+          return;
+        } catch (err) {
+          switch (err.code) {
+            case "ENOENT": {
+              yield mkdirP(path2.dirname(fsPath), maxDepth, depth + 1);
+              yield exports2.mkdir(fsPath);
+              return;
+            }
+            default: {
+              let stats;
+              try {
+                stats = yield exports2.stat(fsPath);
+              } catch (err2) {
+                throw err;
+              }
+              if (!stats.isDirectory())
+                throw err;
+            }
+          }
+        }
+      });
+    }
+    exports2.mkdirP = mkdirP;
+    function tryGetExecutablePath(filePath, extensions) {
+      return __awaiter(this, void 0, void 0, function* () {
+        let stats = void 0;
+        try {
+          stats = yield exports2.stat(filePath);
+        } catch (err) {
+          if (err.code !== "ENOENT") {
+            console.log(`Unexpected error attempting to determine if executable file exists '${filePath}': ${err}`);
+          }
+        }
+        if (stats && stats.isFile()) {
+          if (exports2.IS_WINDOWS) {
+            const upperExt = path2.extname(filePath).toUpperCase();
+            if (extensions.some((validExt) => validExt.toUpperCase() === upperExt)) {
+              return filePath;
+            }
+          } else {
+            if (isUnixExecutable(stats)) {
+              return filePath;
+            }
+          }
+        }
+        const originalFilePath = filePath;
+        for (const extension of extensions) {
+          filePath = originalFilePath + extension;
+          stats = void 0;
+          try {
+            stats = yield exports2.stat(filePath);
+          } catch (err) {
+            if (err.code !== "ENOENT") {
+              console.log(`Unexpected error attempting to determine if executable file exists '${filePath}': ${err}`);
+            }
+          }
+          if (stats && stats.isFile()) {
+            if (exports2.IS_WINDOWS) {
+              try {
+                const directory = path2.dirname(filePath);
+                const upperName = path2.basename(filePath).toUpperCase();
+                for (const actualName of yield exports2.readdir(directory)) {
+                  if (upperName === actualName.toUpperCase()) {
+                    filePath = path2.join(directory, actualName);
+                    break;
+                  }
+                }
+              } catch (err) {
+                console.log(`Unexpected error attempting to determine the actual case of the file '${filePath}': ${err}`);
+              }
+              return filePath;
+            } else {
+              if (isUnixExecutable(stats)) {
+                return filePath;
+              }
+            }
+          }
+        }
+        return "";
+      });
+    }
+    exports2.tryGetExecutablePath = tryGetExecutablePath;
+    function normalizeSeparators(p) {
+      p = p || "";
+      if (exports2.IS_WINDOWS) {
+        p = p.replace(/\//g, "\\");
+        return p.replace(/\\\\+/g, "\\");
+      }
+      return p.replace(/\/\/+/g, "/");
+    }
+    function isUnixExecutable(stats) {
+      return (stats.mode & 1) > 0 || (stats.mode & 8) > 0 && stats.gid === process.getgid() || (stats.mode & 64) > 0 && stats.uid === process.getuid();
+    }
+  }
+});
+
+// node_modules/@actions/io/lib/io.js
+var require_io2 = __commonJS({
+  "node_modules/@actions/io/lib/io.js"(exports2) {
+    "use strict";
+    var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve) {
+          resolve(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+      });
+    };
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    var childProcess = require("child_process");
+    var path2 = require("path");
+    var util_1 = require("util");
+    var ioUtil = require_io_util2();
+    var exec5 = util_1.promisify(childProcess.exec);
+    function cp(source, dest, options = {}) {
+      return __awaiter(this, void 0, void 0, function* () {
+        const { force, recursive } = readCopyOptions(options);
+        const destStat = (yield ioUtil.exists(dest)) ? yield ioUtil.stat(dest) : null;
+        if (destStat && destStat.isFile() && !force) {
+          return;
+        }
+        const newDest = destStat && destStat.isDirectory() ? path2.join(dest, path2.basename(source)) : dest;
+        if (!(yield ioUtil.exists(source))) {
+          throw new Error(`no such file or directory: ${source}`);
+        }
+        const sourceStat = yield ioUtil.stat(source);
+        if (sourceStat.isDirectory()) {
+          if (!recursive) {
+            throw new Error(`Failed to copy. ${source} is a directory, but tried to copy without recursive flag.`);
+          } else {
+            yield cpDirRecursive(source, newDest, 0, force);
+          }
+        } else {
+          if (path2.relative(source, newDest) === "") {
+            throw new Error(`'${newDest}' and '${source}' are the same file`);
+          }
+          yield copyFile(source, newDest, force);
+        }
+      });
+    }
+    exports2.cp = cp;
+    function mv(source, dest, options = {}) {
+      return __awaiter(this, void 0, void 0, function* () {
+        if (yield ioUtil.exists(dest)) {
+          let destExists = true;
+          if (yield ioUtil.isDirectory(dest)) {
+            dest = path2.join(dest, path2.basename(source));
+            destExists = yield ioUtil.exists(dest);
+          }
+          if (destExists) {
+            if (options.force == null || options.force) {
+              yield rmRF(dest);
+            } else {
+              throw new Error("Destination already exists");
+            }
+          }
+        }
+        yield mkdirP(path2.dirname(dest));
+        yield ioUtil.rename(source, dest);
+      });
+    }
+    exports2.mv = mv;
+    function rmRF(inputPath) {
+      return __awaiter(this, void 0, void 0, function* () {
+        if (ioUtil.IS_WINDOWS) {
+          try {
+            if (yield ioUtil.isDirectory(inputPath, true)) {
+              yield exec5(`rd /s /q "${inputPath}"`);
+            } else {
+              yield exec5(`del /f /a "${inputPath}"`);
+            }
+          } catch (err) {
+            if (err.code !== "ENOENT")
+              throw err;
+          }
+          try {
+            yield ioUtil.unlink(inputPath);
+          } catch (err) {
+            if (err.code !== "ENOENT")
+              throw err;
+          }
+        } else {
+          let isDir = false;
+          try {
+            isDir = yield ioUtil.isDirectory(inputPath);
+          } catch (err) {
+            if (err.code !== "ENOENT")
+              throw err;
+            return;
+          }
+          if (isDir) {
+            yield exec5(`rm -rf "${inputPath}"`);
+          } else {
+            yield ioUtil.unlink(inputPath);
+          }
+        }
+      });
+    }
+    exports2.rmRF = rmRF;
+    function mkdirP(fsPath) {
+      return __awaiter(this, void 0, void 0, function* () {
+        yield ioUtil.mkdirP(fsPath);
+      });
+    }
+    exports2.mkdirP = mkdirP;
+    function which2(tool, check) {
+      return __awaiter(this, void 0, void 0, function* () {
+        if (!tool) {
+          throw new Error("parameter 'tool' is required");
+        }
+        if (check) {
+          const result = yield which2(tool, false);
+          if (!result) {
+            if (ioUtil.IS_WINDOWS) {
+              throw new Error(`Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also verify the file has a valid extension for an executable file.`);
+            } else {
+              throw new Error(`Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also check the file mode to verify the file is executable.`);
+            }
+          }
+        }
+        try {
+          const extensions = [];
+          if (ioUtil.IS_WINDOWS && process.env.PATHEXT) {
+            for (const extension of process.env.PATHEXT.split(path2.delimiter)) {
+              if (extension) {
+                extensions.push(extension);
+              }
+            }
+          }
+          if (ioUtil.isRooted(tool)) {
+            const filePath = yield ioUtil.tryGetExecutablePath(tool, extensions);
+            if (filePath) {
+              return filePath;
+            }
+            return "";
+          }
+          if (tool.includes("/") || ioUtil.IS_WINDOWS && tool.includes("\\")) {
+            return "";
+          }
+          const directories = [];
+          if (process.env.PATH) {
+            for (const p of process.env.PATH.split(path2.delimiter)) {
+              if (p) {
+                directories.push(p);
+              }
+            }
+          }
+          for (const directory of directories) {
+            const filePath = yield ioUtil.tryGetExecutablePath(directory + path2.sep + tool, extensions);
+            if (filePath) {
+              return filePath;
+            }
+          }
+          return "";
+        } catch (err) {
+          throw new Error(`which failed with message ${err.message}`);
+        }
+      });
+    }
+    exports2.which = which2;
+    function readCopyOptions(options) {
+      const force = options.force == null ? true : options.force;
+      const recursive = Boolean(options.recursive);
+      return { force, recursive };
+    }
+    function cpDirRecursive(sourceDir, destDir, currentDepth, force) {
+      return __awaiter(this, void 0, void 0, function* () {
+        if (currentDepth >= 255)
+          return;
+        currentDepth++;
+        yield mkdirP(destDir);
+        const files = yield ioUtil.readdir(sourceDir);
+        for (const fileName of files) {
+          const srcFile = `${sourceDir}/${fileName}`;
+          const destFile = `${destDir}/${fileName}`;
+          const srcFileStat = yield ioUtil.lstat(srcFile);
+          if (srcFileStat.isDirectory()) {
+            yield cpDirRecursive(srcFile, destFile, currentDepth, force);
+          } else {
+            yield copyFile(srcFile, destFile, force);
+          }
+        }
+        yield ioUtil.chmod(destDir, (yield ioUtil.stat(sourceDir)).mode);
+      });
+    }
+    function copyFile(srcFile, destFile, force) {
+      return __awaiter(this, void 0, void 0, function* () {
+        if ((yield ioUtil.lstat(srcFile)).isSymbolicLink()) {
+          try {
+            yield ioUtil.lstat(destFile);
+            yield ioUtil.unlink(destFile);
+          } catch (e) {
+            if (e.code === "EPERM") {
+              yield ioUtil.chmod(destFile, "0666");
+              yield ioUtil.unlink(destFile);
+            }
+          }
+          const symlinkFull = yield ioUtil.readlink(srcFile);
+          yield ioUtil.symlink(symlinkFull, destFile, ioUtil.IS_WINDOWS ? "junction" : null);
+        } else if (!(yield ioUtil.exists(destFile)) || force) {
+          yield ioUtil.copyFile(srcFile, destFile);
+        }
+      });
+    }
+  }
 });
 
 // lib/plugins-add/main.ts
@@ -1222,7 +1689,7 @@ var fs = __toModule(require("fs"));
 // lib/setup/index.ts
 var core = __toModule(require_core());
 var exec = __toModule(require_exec());
-var io = __toModule(require_io());
+var io = __toModule(require_io2());
 var os = __toModule(require("os"));
 var path = __toModule(require("path"));
 async function setupAsdf() {
@@ -1236,7 +1703,7 @@ async function setupAsdf() {
   core.addPath(`${asdfDir}/bin`);
   core.addPath(`${asdfDir}/shims`);
   core.info(`Cloning asdf into ASDF_DIR: ${asdfDir}`);
-  const branch = core.getInput("asdf_branch", {required: true});
+  const branch = core.getInput("asdf_branch", { required: true });
   await exec.exec("git", [
     "clone",
     "--depth",
@@ -1273,7 +1740,7 @@ async function pluginList() {
 }
 async function pluginsAdd() {
   await setupAsdf();
-  let toolVersions = core2.getInput("tool_versions", {required: false});
+  let toolVersions = core2.getInput("tool_versions", { required: false });
   if (toolVersions) {
     await fs.promises.writeFile(".tool-versions", toolVersions, {
       encoding: "utf8"

--- a/plugins-add/main.js
+++ b/plugins-add/main.js
@@ -1,403 +1,424 @@
 var __create = Object.create;
 var __defProp = Object.defineProperty;
-var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
-var __getOwnPropNames = Object.getOwnPropertyNames;
 var __getProtoOf = Object.getPrototypeOf;
 var __hasOwnProp = Object.prototype.hasOwnProperty;
-var __markAsModule = (target) => __defProp(target, "__esModule", { value: true });
-var __commonJS = (cb, mod) => function __require() {
-  return mod || (0, cb[Object.keys(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __markAsModule = (target) => __defProp(target, "__esModule", {value: true});
+var __commonJS = (callback, module2) => () => {
+  if (!module2) {
+    module2 = {exports: {}};
+    callback(module2.exports, module2);
+  }
+  return module2.exports;
 };
-var __reExport = (target, module2, desc) => {
+var __exportStar = (target, module2, desc) => {
+  __markAsModule(target);
   if (module2 && typeof module2 === "object" || typeof module2 === "function") {
     for (let key of __getOwnPropNames(module2))
       if (!__hasOwnProp.call(target, key) && key !== "default")
-        __defProp(target, key, { get: () => module2[key], enumerable: !(desc = __getOwnPropDesc(module2, key)) || desc.enumerable });
+        __defProp(target, key, {get: () => module2[key], enumerable: !(desc = __getOwnPropDesc(module2, key)) || desc.enumerable});
   }
   return target;
 };
 var __toModule = (module2) => {
-  return __reExport(__markAsModule(__defProp(module2 != null ? __create(__getProtoOf(module2)) : {}, "default", module2 && module2.__esModule && "default" in module2 ? { get: () => module2.default, enumerable: true } : { value: module2, enumerable: true })), module2);
+  if (module2 && module2.__esModule)
+    return module2;
+  return __exportStar(__defProp(module2 != null ? __create(__getProtoOf(module2)) : {}, "default", {value: module2, enumerable: true}), module2);
 };
 
 // node_modules/@actions/core/lib/utils.js
-var require_utils = __commonJS({
-  "node_modules/@actions/core/lib/utils.js"(exports2) {
-    "use strict";
-    Object.defineProperty(exports2, "__esModule", { value: true });
-    function toCommandValue(input) {
-      if (input === null || input === void 0) {
-        return "";
-      } else if (typeof input === "string" || input instanceof String) {
-        return input;
-      }
-      return JSON.stringify(input);
+var require_utils = __commonJS((exports2) => {
+  "use strict";
+  Object.defineProperty(exports2, "__esModule", {value: true});
+  function toCommandValue(input) {
+    if (input === null || input === void 0) {
+      return "";
+    } else if (typeof input === "string" || input instanceof String) {
+      return input;
     }
-    exports2.toCommandValue = toCommandValue;
+    return JSON.stringify(input);
   }
+  exports2.toCommandValue = toCommandValue;
 });
 
 // node_modules/@actions/core/lib/command.js
-var require_command = __commonJS({
-  "node_modules/@actions/core/lib/command.js"(exports2) {
-    "use strict";
-    var __importStar = exports2 && exports2.__importStar || function(mod) {
-      if (mod && mod.__esModule)
-        return mod;
-      var result = {};
-      if (mod != null) {
-        for (var k in mod)
-          if (Object.hasOwnProperty.call(mod, k))
-            result[k] = mod[k];
-      }
-      result["default"] = mod;
-      return result;
-    };
-    Object.defineProperty(exports2, "__esModule", { value: true });
-    var os2 = __importStar(require("os"));
-    var utils_1 = require_utils();
-    function issueCommand(command, properties, message) {
-      const cmd = new Command(command, properties, message);
-      process.stdout.write(cmd.toString() + os2.EOL);
+var require_command = __commonJS((exports2) => {
+  "use strict";
+  var __importStar = exports2 && exports2.__importStar || function(mod) {
+    if (mod && mod.__esModule)
+      return mod;
+    var result = {};
+    if (mod != null) {
+      for (var k in mod)
+        if (Object.hasOwnProperty.call(mod, k))
+          result[k] = mod[k];
     }
-    exports2.issueCommand = issueCommand;
-    function issue(name, message = "") {
-      issueCommand(name, {}, message);
-    }
-    exports2.issue = issue;
-    var CMD_STRING = "::";
-    var Command = class {
-      constructor(command, properties, message) {
-        if (!command) {
-          command = "missing.command";
-        }
-        this.command = command;
-        this.properties = properties;
-        this.message = message;
+    result["default"] = mod;
+    return result;
+  };
+  Object.defineProperty(exports2, "__esModule", {value: true});
+  var os2 = __importStar(require("os"));
+  var utils_1 = require_utils();
+  function issueCommand(command, properties, message) {
+    const cmd = new Command(command, properties, message);
+    process.stdout.write(cmd.toString() + os2.EOL);
+  }
+  exports2.issueCommand = issueCommand;
+  function issue(name, message = "") {
+    issueCommand(name, {}, message);
+  }
+  exports2.issue = issue;
+  var CMD_STRING = "::";
+  var Command = class {
+    constructor(command, properties, message) {
+      if (!command) {
+        command = "missing.command";
       }
-      toString() {
-        let cmdStr = CMD_STRING + this.command;
-        if (this.properties && Object.keys(this.properties).length > 0) {
-          cmdStr += " ";
-          let first = true;
-          for (const key in this.properties) {
-            if (this.properties.hasOwnProperty(key)) {
-              const val = this.properties[key];
-              if (val) {
-                if (first) {
-                  first = false;
-                } else {
-                  cmdStr += ",";
-                }
-                cmdStr += `${key}=${escapeProperty(val)}`;
+      this.command = command;
+      this.properties = properties;
+      this.message = message;
+    }
+    toString() {
+      let cmdStr = CMD_STRING + this.command;
+      if (this.properties && Object.keys(this.properties).length > 0) {
+        cmdStr += " ";
+        let first = true;
+        for (const key in this.properties) {
+          if (this.properties.hasOwnProperty(key)) {
+            const val = this.properties[key];
+            if (val) {
+              if (first) {
+                first = false;
+              } else {
+                cmdStr += ",";
               }
+              cmdStr += `${key}=${escapeProperty(val)}`;
             }
           }
         }
-        cmdStr += `${CMD_STRING}${escapeData(this.message)}`;
-        return cmdStr;
       }
-    };
-    function escapeData(s) {
-      return utils_1.toCommandValue(s).replace(/%/g, "%25").replace(/\r/g, "%0D").replace(/\n/g, "%0A");
+      cmdStr += `${CMD_STRING}${escapeData(this.message)}`;
+      return cmdStr;
     }
-    function escapeProperty(s) {
-      return utils_1.toCommandValue(s).replace(/%/g, "%25").replace(/\r/g, "%0D").replace(/\n/g, "%0A").replace(/:/g, "%3A").replace(/,/g, "%2C");
-    }
+  };
+  function escapeData(s) {
+    return utils_1.toCommandValue(s).replace(/%/g, "%25").replace(/\r/g, "%0D").replace(/\n/g, "%0A");
+  }
+  function escapeProperty(s) {
+    return utils_1.toCommandValue(s).replace(/%/g, "%25").replace(/\r/g, "%0D").replace(/\n/g, "%0A").replace(/:/g, "%3A").replace(/,/g, "%2C");
   }
 });
 
 // node_modules/@actions/core/lib/file-command.js
-var require_file_command = __commonJS({
-  "node_modules/@actions/core/lib/file-command.js"(exports2) {
-    "use strict";
-    var __importStar = exports2 && exports2.__importStar || function(mod) {
-      if (mod && mod.__esModule)
-        return mod;
-      var result = {};
-      if (mod != null) {
-        for (var k in mod)
-          if (Object.hasOwnProperty.call(mod, k))
-            result[k] = mod[k];
-      }
-      result["default"] = mod;
-      return result;
-    };
-    Object.defineProperty(exports2, "__esModule", { value: true });
-    var fs2 = __importStar(require("fs"));
-    var os2 = __importStar(require("os"));
-    var utils_1 = require_utils();
-    function issueCommand(command, message) {
-      const filePath = process.env[`GITHUB_${command}`];
-      if (!filePath) {
-        throw new Error(`Unable to find environment variable for file command ${command}`);
-      }
-      if (!fs2.existsSync(filePath)) {
-        throw new Error(`Missing file at path: ${filePath}`);
-      }
-      fs2.appendFileSync(filePath, `${utils_1.toCommandValue(message)}${os2.EOL}`, {
-        encoding: "utf8"
-      });
+var require_file_command = __commonJS((exports2) => {
+  "use strict";
+  var __importStar = exports2 && exports2.__importStar || function(mod) {
+    if (mod && mod.__esModule)
+      return mod;
+    var result = {};
+    if (mod != null) {
+      for (var k in mod)
+        if (Object.hasOwnProperty.call(mod, k))
+          result[k] = mod[k];
     }
-    exports2.issueCommand = issueCommand;
+    result["default"] = mod;
+    return result;
+  };
+  Object.defineProperty(exports2, "__esModule", {value: true});
+  var fs2 = __importStar(require("fs"));
+  var os2 = __importStar(require("os"));
+  var utils_1 = require_utils();
+  function issueCommand(command, message) {
+    const filePath = process.env[`GITHUB_${command}`];
+    if (!filePath) {
+      throw new Error(`Unable to find environment variable for file command ${command}`);
+    }
+    if (!fs2.existsSync(filePath)) {
+      throw new Error(`Missing file at path: ${filePath}`);
+    }
+    fs2.appendFileSync(filePath, `${utils_1.toCommandValue(message)}${os2.EOL}`, {
+      encoding: "utf8"
+    });
   }
+  exports2.issueCommand = issueCommand;
 });
 
 // node_modules/@actions/core/lib/core.js
-var require_core = __commonJS({
-  "node_modules/@actions/core/lib/core.js"(exports2) {
-    "use strict";
-    var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
-      function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve) {
-          resolve(value);
-        });
-      }
-      return new (P || (P = Promise))(function(resolve, reject) {
-        function fulfilled(value) {
-          try {
-            step(generator.next(value));
-          } catch (e) {
-            reject(e);
-          }
-        }
-        function rejected(value) {
-          try {
-            step(generator["throw"](value));
-          } catch (e) {
-            reject(e);
-          }
-        }
-        function step(result) {
-          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
-        }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
+var require_core = __commonJS((exports2) => {
+  "use strict";
+  var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+    function adopt(value) {
+      return value instanceof P ? value : new P(function(resolve) {
+        resolve(value);
       });
-    };
-    var __importStar = exports2 && exports2.__importStar || function(mod) {
-      if (mod && mod.__esModule)
-        return mod;
-      var result = {};
-      if (mod != null) {
-        for (var k in mod)
-          if (Object.hasOwnProperty.call(mod, k))
-            result[k] = mod[k];
-      }
-      result["default"] = mod;
-      return result;
-    };
-    Object.defineProperty(exports2, "__esModule", { value: true });
-    var command_1 = require_command();
-    var file_command_1 = require_file_command();
-    var utils_1 = require_utils();
-    var os2 = __importStar(require("os"));
-    var path2 = __importStar(require("path"));
-    var ExitCode;
-    (function(ExitCode2) {
-      ExitCode2[ExitCode2["Success"] = 0] = "Success";
-      ExitCode2[ExitCode2["Failure"] = 1] = "Failure";
-    })(ExitCode = exports2.ExitCode || (exports2.ExitCode = {}));
-    function exportVariable2(name, val) {
-      const convertedVal = utils_1.toCommandValue(val);
-      process.env[name] = convertedVal;
-      const filePath = process.env["GITHUB_ENV"] || "";
-      if (filePath) {
-        const delimiter = "_GitHubActionsFileCommandDelimeter_";
-        const commandValue = `${name}<<${delimiter}${os2.EOL}${convertedVal}${os2.EOL}${delimiter}`;
-        file_command_1.issueCommand("ENV", commandValue);
-      } else {
-        command_1.issueCommand("set-env", { name }, convertedVal);
-      }
     }
-    exports2.exportVariable = exportVariable2;
-    function setSecret(secret) {
-      command_1.issueCommand("add-mask", {}, secret);
-    }
-    exports2.setSecret = setSecret;
-    function addPath2(inputPath) {
-      const filePath = process.env["GITHUB_PATH"] || "";
-      if (filePath) {
-        file_command_1.issueCommand("PATH", inputPath);
-      } else {
-        command_1.issueCommand("add-path", {}, inputPath);
-      }
-      process.env["PATH"] = `${inputPath}${path2.delimiter}${process.env["PATH"]}`;
-    }
-    exports2.addPath = addPath2;
-    function getInput3(name, options) {
-      const val = process.env[`INPUT_${name.replace(/ /g, "_").toUpperCase()}`] || "";
-      if (options && options.required && !val) {
-        throw new Error(`Input required and not supplied: ${name}`);
-      }
-      return val.trim();
-    }
-    exports2.getInput = getInput3;
-    function setOutput(name, value) {
-      command_1.issueCommand("set-output", { name }, value);
-    }
-    exports2.setOutput = setOutput;
-    function setCommandEcho(enabled) {
-      command_1.issue("echo", enabled ? "on" : "off");
-    }
-    exports2.setCommandEcho = setCommandEcho;
-    function setFailed2(message) {
-      process.exitCode = ExitCode.Failure;
-      error(message);
-    }
-    exports2.setFailed = setFailed2;
-    function isDebug() {
-      return process.env["RUNNER_DEBUG"] === "1";
-    }
-    exports2.isDebug = isDebug;
-    function debug(message) {
-      command_1.issueCommand("debug", {}, message);
-    }
-    exports2.debug = debug;
-    function error(message) {
-      command_1.issue("error", message instanceof Error ? message.toString() : message);
-    }
-    exports2.error = error;
-    function warning(message) {
-      command_1.issue("warning", message instanceof Error ? message.toString() : message);
-    }
-    exports2.warning = warning;
-    function info3(message) {
-      process.stdout.write(message + os2.EOL);
-    }
-    exports2.info = info3;
-    function startGroup(name) {
-      command_1.issue("group", name);
-    }
-    exports2.startGroup = startGroup;
-    function endGroup() {
-      command_1.issue("endgroup");
-    }
-    exports2.endGroup = endGroup;
-    function group(name, fn) {
-      return __awaiter(this, void 0, void 0, function* () {
-        startGroup(name);
-        let result;
+    return new (P || (P = Promise))(function(resolve, reject) {
+      function fulfilled(value) {
         try {
-          result = yield fn();
-        } finally {
-          endGroup();
+          step(generator.next(value));
+        } catch (e) {
+          reject(e);
         }
-        return result;
-      });
+      }
+      function rejected(value) {
+        try {
+          step(generator["throw"](value));
+        } catch (e) {
+          reject(e);
+        }
+      }
+      function step(result) {
+        result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+      }
+      step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+  };
+  var __importStar = exports2 && exports2.__importStar || function(mod) {
+    if (mod && mod.__esModule)
+      return mod;
+    var result = {};
+    if (mod != null) {
+      for (var k in mod)
+        if (Object.hasOwnProperty.call(mod, k))
+          result[k] = mod[k];
     }
-    exports2.group = group;
-    function saveState(name, value) {
-      command_1.issueCommand("save-state", { name }, value);
+    result["default"] = mod;
+    return result;
+  };
+  Object.defineProperty(exports2, "__esModule", {value: true});
+  var command_1 = require_command();
+  var file_command_1 = require_file_command();
+  var utils_1 = require_utils();
+  var os2 = __importStar(require("os"));
+  var path2 = __importStar(require("path"));
+  var ExitCode;
+  (function(ExitCode2) {
+    ExitCode2[ExitCode2["Success"] = 0] = "Success";
+    ExitCode2[ExitCode2["Failure"] = 1] = "Failure";
+  })(ExitCode = exports2.ExitCode || (exports2.ExitCode = {}));
+  function exportVariable2(name, val) {
+    const convertedVal = utils_1.toCommandValue(val);
+    process.env[name] = convertedVal;
+    const filePath = process.env["GITHUB_ENV"] || "";
+    if (filePath) {
+      const delimiter = "_GitHubActionsFileCommandDelimeter_";
+      const commandValue = `${name}<<${delimiter}${os2.EOL}${convertedVal}${os2.EOL}${delimiter}`;
+      file_command_1.issueCommand("ENV", commandValue);
+    } else {
+      command_1.issueCommand("set-env", {name}, convertedVal);
     }
-    exports2.saveState = saveState;
-    function getState(name) {
-      return process.env[`STATE_${name}`] || "";
-    }
-    exports2.getState = getState;
   }
+  exports2.exportVariable = exportVariable2;
+  function setSecret(secret) {
+    command_1.issueCommand("add-mask", {}, secret);
+  }
+  exports2.setSecret = setSecret;
+  function addPath2(inputPath) {
+    const filePath = process.env["GITHUB_PATH"] || "";
+    if (filePath) {
+      file_command_1.issueCommand("PATH", inputPath);
+    } else {
+      command_1.issueCommand("add-path", {}, inputPath);
+    }
+    process.env["PATH"] = `${inputPath}${path2.delimiter}${process.env["PATH"]}`;
+  }
+  exports2.addPath = addPath2;
+  function getInput3(name, options) {
+    const val = process.env[`INPUT_${name.replace(/ /g, "_").toUpperCase()}`] || "";
+    if (options && options.required && !val) {
+      throw new Error(`Input required and not supplied: ${name}`);
+    }
+    return val.trim();
+  }
+  exports2.getInput = getInput3;
+  function setOutput(name, value) {
+    command_1.issueCommand("set-output", {name}, value);
+  }
+  exports2.setOutput = setOutput;
+  function setCommandEcho(enabled) {
+    command_1.issue("echo", enabled ? "on" : "off");
+  }
+  exports2.setCommandEcho = setCommandEcho;
+  function setFailed2(message) {
+    process.exitCode = ExitCode.Failure;
+    error(message);
+  }
+  exports2.setFailed = setFailed2;
+  function isDebug() {
+    return process.env["RUNNER_DEBUG"] === "1";
+  }
+  exports2.isDebug = isDebug;
+  function debug(message) {
+    command_1.issueCommand("debug", {}, message);
+  }
+  exports2.debug = debug;
+  function error(message) {
+    command_1.issue("error", message instanceof Error ? message.toString() : message);
+  }
+  exports2.error = error;
+  function warning(message) {
+    command_1.issue("warning", message instanceof Error ? message.toString() : message);
+  }
+  exports2.warning = warning;
+  function info3(message) {
+    process.stdout.write(message + os2.EOL);
+  }
+  exports2.info = info3;
+  function startGroup(name) {
+    command_1.issue("group", name);
+  }
+  exports2.startGroup = startGroup;
+  function endGroup() {
+    command_1.issue("endgroup");
+  }
+  exports2.endGroup = endGroup;
+  function group(name, fn) {
+    return __awaiter(this, void 0, void 0, function* () {
+      startGroup(name);
+      let result;
+      try {
+        result = yield fn();
+      } finally {
+        endGroup();
+      }
+      return result;
+    });
+  }
+  exports2.group = group;
+  function saveState(name, value) {
+    command_1.issueCommand("save-state", {name}, value);
+  }
+  exports2.saveState = saveState;
+  function getState(name) {
+    return process.env[`STATE_${name}`] || "";
+  }
+  exports2.getState = getState;
 });
 
 // node_modules/@actions/exec/node_modules/@actions/io/lib/io-util.js
-var require_io_util = __commonJS({
-  "node_modules/@actions/exec/node_modules/@actions/io/lib/io-util.js"(exports2) {
-    "use strict";
-    var __createBinding = exports2 && exports2.__createBinding || (Object.create ? function(o, m, k, k2) {
-      if (k2 === void 0)
-        k2 = k;
-      Object.defineProperty(o, k2, { enumerable: true, get: function() {
-        return m[k];
-      } });
-    } : function(o, m, k, k2) {
-      if (k2 === void 0)
-        k2 = k;
-      o[k2] = m[k];
-    });
-    var __setModuleDefault = exports2 && exports2.__setModuleDefault || (Object.create ? function(o, v) {
-      Object.defineProperty(o, "default", { enumerable: true, value: v });
-    } : function(o, v) {
-      o["default"] = v;
-    });
-    var __importStar = exports2 && exports2.__importStar || function(mod) {
-      if (mod && mod.__esModule)
-        return mod;
-      var result = {};
-      if (mod != null) {
-        for (var k in mod)
-          if (k !== "default" && Object.hasOwnProperty.call(mod, k))
-            __createBinding(result, mod, k);
-      }
-      __setModuleDefault(result, mod);
-      return result;
-    };
-    var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
-      function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve) {
-          resolve(value);
-        });
-      }
-      return new (P || (P = Promise))(function(resolve, reject) {
-        function fulfilled(value) {
-          try {
-            step(generator.next(value));
-          } catch (e) {
-            reject(e);
-          }
-        }
-        function rejected(value) {
-          try {
-            step(generator["throw"](value));
-          } catch (e) {
-            reject(e);
-          }
-        }
-        function step(result) {
-          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
-        }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
+var require_io_util = __commonJS((exports2) => {
+  "use strict";
+  var __createBinding = exports2 && exports2.__createBinding || (Object.create ? function(o, m, k, k2) {
+    if (k2 === void 0)
+      k2 = k;
+    Object.defineProperty(o, k2, {enumerable: true, get: function() {
+      return m[k];
+    }});
+  } : function(o, m, k, k2) {
+    if (k2 === void 0)
+      k2 = k;
+    o[k2] = m[k];
+  });
+  var __setModuleDefault = exports2 && exports2.__setModuleDefault || (Object.create ? function(o, v) {
+    Object.defineProperty(o, "default", {enumerable: true, value: v});
+  } : function(o, v) {
+    o["default"] = v;
+  });
+  var __importStar = exports2 && exports2.__importStar || function(mod) {
+    if (mod && mod.__esModule)
+      return mod;
+    var result = {};
+    if (mod != null) {
+      for (var k in mod)
+        if (k !== "default" && Object.hasOwnProperty.call(mod, k))
+          __createBinding(result, mod, k);
+    }
+    __setModuleDefault(result, mod);
+    return result;
+  };
+  var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+    function adopt(value) {
+      return value instanceof P ? value : new P(function(resolve) {
+        resolve(value);
       });
-    };
-    var _a;
-    Object.defineProperty(exports2, "__esModule", { value: true });
-    exports2.getCmdPath = exports2.tryGetExecutablePath = exports2.isRooted = exports2.isDirectory = exports2.exists = exports2.IS_WINDOWS = exports2.unlink = exports2.symlink = exports2.stat = exports2.rmdir = exports2.rename = exports2.readlink = exports2.readdir = exports2.mkdir = exports2.lstat = exports2.copyFile = exports2.chmod = void 0;
-    var fs2 = __importStar(require("fs"));
-    var path2 = __importStar(require("path"));
-    _a = fs2.promises, exports2.chmod = _a.chmod, exports2.copyFile = _a.copyFile, exports2.lstat = _a.lstat, exports2.mkdir = _a.mkdir, exports2.readdir = _a.readdir, exports2.readlink = _a.readlink, exports2.rename = _a.rename, exports2.rmdir = _a.rmdir, exports2.stat = _a.stat, exports2.symlink = _a.symlink, exports2.unlink = _a.unlink;
-    exports2.IS_WINDOWS = process.platform === "win32";
-    function exists(fsPath) {
-      return __awaiter(this, void 0, void 0, function* () {
+    }
+    return new (P || (P = Promise))(function(resolve, reject) {
+      function fulfilled(value) {
         try {
-          yield exports2.stat(fsPath);
-        } catch (err) {
-          if (err.code === "ENOENT") {
-            return false;
-          }
-          throw err;
+          step(generator.next(value));
+        } catch (e) {
+          reject(e);
         }
-        return true;
-      });
-    }
-    exports2.exists = exists;
-    function isDirectory(fsPath, useStat = false) {
-      return __awaiter(this, void 0, void 0, function* () {
-        const stats = useStat ? yield exports2.stat(fsPath) : yield exports2.lstat(fsPath);
-        return stats.isDirectory();
-      });
-    }
-    exports2.isDirectory = isDirectory;
-    function isRooted(p) {
-      p = normalizeSeparators(p);
-      if (!p) {
-        throw new Error('isRooted() parameter "p" cannot be empty');
       }
-      if (exports2.IS_WINDOWS) {
-        return p.startsWith("\\") || /^[A-Z]:/i.test(p);
+      function rejected(value) {
+        try {
+          step(generator["throw"](value));
+        } catch (e) {
+          reject(e);
+        }
       }
-      return p.startsWith("/");
+      function step(result) {
+        result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+      }
+      step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+  };
+  var _a;
+  Object.defineProperty(exports2, "__esModule", {value: true});
+  exports2.getCmdPath = exports2.tryGetExecutablePath = exports2.isRooted = exports2.isDirectory = exports2.exists = exports2.IS_WINDOWS = exports2.unlink = exports2.symlink = exports2.stat = exports2.rmdir = exports2.rename = exports2.readlink = exports2.readdir = exports2.mkdir = exports2.lstat = exports2.copyFile = exports2.chmod = void 0;
+  var fs2 = __importStar(require("fs"));
+  var path2 = __importStar(require("path"));
+  _a = fs2.promises, exports2.chmod = _a.chmod, exports2.copyFile = _a.copyFile, exports2.lstat = _a.lstat, exports2.mkdir = _a.mkdir, exports2.readdir = _a.readdir, exports2.readlink = _a.readlink, exports2.rename = _a.rename, exports2.rmdir = _a.rmdir, exports2.stat = _a.stat, exports2.symlink = _a.symlink, exports2.unlink = _a.unlink;
+  exports2.IS_WINDOWS = process.platform === "win32";
+  function exists(fsPath) {
+    return __awaiter(this, void 0, void 0, function* () {
+      try {
+        yield exports2.stat(fsPath);
+      } catch (err) {
+        if (err.code === "ENOENT") {
+          return false;
+        }
+        throw err;
+      }
+      return true;
+    });
+  }
+  exports2.exists = exists;
+  function isDirectory(fsPath, useStat = false) {
+    return __awaiter(this, void 0, void 0, function* () {
+      const stats = useStat ? yield exports2.stat(fsPath) : yield exports2.lstat(fsPath);
+      return stats.isDirectory();
+    });
+  }
+  exports2.isDirectory = isDirectory;
+  function isRooted(p) {
+    p = normalizeSeparators(p);
+    if (!p) {
+      throw new Error('isRooted() parameter "p" cannot be empty');
     }
-    exports2.isRooted = isRooted;
-    function tryGetExecutablePath(filePath, extensions) {
-      return __awaiter(this, void 0, void 0, function* () {
-        let stats = void 0;
+    if (exports2.IS_WINDOWS) {
+      return p.startsWith("\\") || /^[A-Z]:/i.test(p);
+    }
+    return p.startsWith("/");
+  }
+  exports2.isRooted = isRooted;
+  function tryGetExecutablePath(filePath, extensions) {
+    return __awaiter(this, void 0, void 0, function* () {
+      let stats = void 0;
+      try {
+        stats = yield exports2.stat(filePath);
+      } catch (err) {
+        if (err.code !== "ENOENT") {
+          console.log(`Unexpected error attempting to determine if executable file exists '${filePath}': ${err}`);
+        }
+      }
+      if (stats && stats.isFile()) {
+        if (exports2.IS_WINDOWS) {
+          const upperExt = path2.extname(filePath).toUpperCase();
+          if (extensions.some((validExt) => validExt.toUpperCase() === upperExt)) {
+            return filePath;
+          }
+        } else {
+          if (isUnixExecutable(stats)) {
+            return filePath;
+          }
+        }
+      }
+      const originalFilePath = filePath;
+      for (const extension of extensions) {
+        filePath = originalFilePath + extension;
+        stats = void 0;
         try {
           stats = yield exports2.stat(filePath);
         } catch (err) {
@@ -407,272 +428,1161 @@ var require_io_util = __commonJS({
         }
         if (stats && stats.isFile()) {
           if (exports2.IS_WINDOWS) {
-            const upperExt = path2.extname(filePath).toUpperCase();
-            if (extensions.some((validExt) => validExt.toUpperCase() === upperExt)) {
-              return filePath;
+            try {
+              const directory = path2.dirname(filePath);
+              const upperName = path2.basename(filePath).toUpperCase();
+              for (const actualName of yield exports2.readdir(directory)) {
+                if (upperName === actualName.toUpperCase()) {
+                  filePath = path2.join(directory, actualName);
+                  break;
+                }
+              }
+            } catch (err) {
+              console.log(`Unexpected error attempting to determine the actual case of the file '${filePath}': ${err}`);
             }
+            return filePath;
           } else {
             if (isUnixExecutable(stats)) {
               return filePath;
             }
           }
         }
-        const originalFilePath = filePath;
-        for (const extension of extensions) {
-          filePath = originalFilePath + extension;
-          stats = void 0;
-          try {
-            stats = yield exports2.stat(filePath);
-          } catch (err) {
-            if (err.code !== "ENOENT") {
-              console.log(`Unexpected error attempting to determine if executable file exists '${filePath}': ${err}`);
-            }
-          }
-          if (stats && stats.isFile()) {
-            if (exports2.IS_WINDOWS) {
-              try {
-                const directory = path2.dirname(filePath);
-                const upperName = path2.basename(filePath).toUpperCase();
-                for (const actualName of yield exports2.readdir(directory)) {
-                  if (upperName === actualName.toUpperCase()) {
-                    filePath = path2.join(directory, actualName);
-                    break;
-                  }
-                }
-              } catch (err) {
-                console.log(`Unexpected error attempting to determine the actual case of the file '${filePath}': ${err}`);
-              }
-              return filePath;
-            } else {
-              if (isUnixExecutable(stats)) {
-                return filePath;
-              }
-            }
-          }
-        }
-        return "";
-      });
-    }
-    exports2.tryGetExecutablePath = tryGetExecutablePath;
-    function normalizeSeparators(p) {
-      p = p || "";
-      if (exports2.IS_WINDOWS) {
-        p = p.replace(/\//g, "\\");
-        return p.replace(/\\\\+/g, "\\");
       }
-      return p.replace(/\/\/+/g, "/");
-    }
-    function isUnixExecutable(stats) {
-      return (stats.mode & 1) > 0 || (stats.mode & 8) > 0 && stats.gid === process.getgid() || (stats.mode & 64) > 0 && stats.uid === process.getuid();
-    }
-    function getCmdPath() {
-      var _a2;
-      return (_a2 = process.env["COMSPEC"]) !== null && _a2 !== void 0 ? _a2 : `cmd.exe`;
-    }
-    exports2.getCmdPath = getCmdPath;
+      return "";
+    });
   }
+  exports2.tryGetExecutablePath = tryGetExecutablePath;
+  function normalizeSeparators(p) {
+    p = p || "";
+    if (exports2.IS_WINDOWS) {
+      p = p.replace(/\//g, "\\");
+      return p.replace(/\\\\+/g, "\\");
+    }
+    return p.replace(/\/\/+/g, "/");
+  }
+  function isUnixExecutable(stats) {
+    return (stats.mode & 1) > 0 || (stats.mode & 8) > 0 && stats.gid === process.getgid() || (stats.mode & 64) > 0 && stats.uid === process.getuid();
+  }
+  function getCmdPath() {
+    var _a2;
+    return (_a2 = process.env["COMSPEC"]) !== null && _a2 !== void 0 ? _a2 : `cmd.exe`;
+  }
+  exports2.getCmdPath = getCmdPath;
 });
 
 // node_modules/@actions/exec/node_modules/@actions/io/lib/io.js
-var require_io = __commonJS({
-  "node_modules/@actions/exec/node_modules/@actions/io/lib/io.js"(exports2) {
-    "use strict";
-    var __createBinding = exports2 && exports2.__createBinding || (Object.create ? function(o, m, k, k2) {
-      if (k2 === void 0)
-        k2 = k;
-      Object.defineProperty(o, k2, { enumerable: true, get: function() {
-        return m[k];
-      } });
-    } : function(o, m, k, k2) {
-      if (k2 === void 0)
-        k2 = k;
-      o[k2] = m[k];
-    });
-    var __setModuleDefault = exports2 && exports2.__setModuleDefault || (Object.create ? function(o, v) {
-      Object.defineProperty(o, "default", { enumerable: true, value: v });
-    } : function(o, v) {
-      o["default"] = v;
-    });
-    var __importStar = exports2 && exports2.__importStar || function(mod) {
-      if (mod && mod.__esModule)
-        return mod;
-      var result = {};
-      if (mod != null) {
-        for (var k in mod)
-          if (k !== "default" && Object.hasOwnProperty.call(mod, k))
-            __createBinding(result, mod, k);
-      }
-      __setModuleDefault(result, mod);
-      return result;
-    };
-    var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
-      function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve) {
-          resolve(value);
-        });
-      }
-      return new (P || (P = Promise))(function(resolve, reject) {
-        function fulfilled(value) {
-          try {
-            step(generator.next(value));
-          } catch (e) {
-            reject(e);
-          }
-        }
-        function rejected(value) {
-          try {
-            step(generator["throw"](value));
-          } catch (e) {
-            reject(e);
-          }
-        }
-        function step(result) {
-          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
-        }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
+var require_io = __commonJS((exports2) => {
+  "use strict";
+  var __createBinding = exports2 && exports2.__createBinding || (Object.create ? function(o, m, k, k2) {
+    if (k2 === void 0)
+      k2 = k;
+    Object.defineProperty(o, k2, {enumerable: true, get: function() {
+      return m[k];
+    }});
+  } : function(o, m, k, k2) {
+    if (k2 === void 0)
+      k2 = k;
+    o[k2] = m[k];
+  });
+  var __setModuleDefault = exports2 && exports2.__setModuleDefault || (Object.create ? function(o, v) {
+    Object.defineProperty(o, "default", {enumerable: true, value: v});
+  } : function(o, v) {
+    o["default"] = v;
+  });
+  var __importStar = exports2 && exports2.__importStar || function(mod) {
+    if (mod && mod.__esModule)
+      return mod;
+    var result = {};
+    if (mod != null) {
+      for (var k in mod)
+        if (k !== "default" && Object.hasOwnProperty.call(mod, k))
+          __createBinding(result, mod, k);
+    }
+    __setModuleDefault(result, mod);
+    return result;
+  };
+  var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+    function adopt(value) {
+      return value instanceof P ? value : new P(function(resolve) {
+        resolve(value);
       });
-    };
-    Object.defineProperty(exports2, "__esModule", { value: true });
-    exports2.findInPath = exports2.which = exports2.mkdirP = exports2.rmRF = exports2.mv = exports2.cp = void 0;
-    var assert_1 = require("assert");
-    var childProcess = __importStar(require("child_process"));
-    var path2 = __importStar(require("path"));
-    var util_1 = require("util");
-    var ioUtil = __importStar(require_io_util());
-    var exec5 = util_1.promisify(childProcess.exec);
-    var execFile = util_1.promisify(childProcess.execFile);
-    function cp(source, dest, options = {}) {
-      return __awaiter(this, void 0, void 0, function* () {
-        const { force, recursive, copySourceDirectory } = readCopyOptions(options);
-        const destStat = (yield ioUtil.exists(dest)) ? yield ioUtil.stat(dest) : null;
-        if (destStat && destStat.isFile() && !force) {
+    }
+    return new (P || (P = Promise))(function(resolve, reject) {
+      function fulfilled(value) {
+        try {
+          step(generator.next(value));
+        } catch (e) {
+          reject(e);
+        }
+      }
+      function rejected(value) {
+        try {
+          step(generator["throw"](value));
+        } catch (e) {
+          reject(e);
+        }
+      }
+      function step(result) {
+        result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+      }
+      step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+  };
+  Object.defineProperty(exports2, "__esModule", {value: true});
+  exports2.findInPath = exports2.which = exports2.mkdirP = exports2.rmRF = exports2.mv = exports2.cp = void 0;
+  var assert_1 = require("assert");
+  var childProcess = __importStar(require("child_process"));
+  var path2 = __importStar(require("path"));
+  var util_1 = require("util");
+  var ioUtil = __importStar(require_io_util());
+  var exec5 = util_1.promisify(childProcess.exec);
+  var execFile = util_1.promisify(childProcess.execFile);
+  function cp(source, dest, options = {}) {
+    return __awaiter(this, void 0, void 0, function* () {
+      const {force, recursive, copySourceDirectory} = readCopyOptions(options);
+      const destStat = (yield ioUtil.exists(dest)) ? yield ioUtil.stat(dest) : null;
+      if (destStat && destStat.isFile() && !force) {
+        return;
+      }
+      const newDest = destStat && destStat.isDirectory() && copySourceDirectory ? path2.join(dest, path2.basename(source)) : dest;
+      if (!(yield ioUtil.exists(source))) {
+        throw new Error(`no such file or directory: ${source}`);
+      }
+      const sourceStat = yield ioUtil.stat(source);
+      if (sourceStat.isDirectory()) {
+        if (!recursive) {
+          throw new Error(`Failed to copy. ${source} is a directory, but tried to copy without recursive flag.`);
+        } else {
+          yield cpDirRecursive(source, newDest, 0, force);
+        }
+      } else {
+        if (path2.relative(source, newDest) === "") {
+          throw new Error(`'${newDest}' and '${source}' are the same file`);
+        }
+        yield copyFile(source, newDest, force);
+      }
+    });
+  }
+  exports2.cp = cp;
+  function mv(source, dest, options = {}) {
+    return __awaiter(this, void 0, void 0, function* () {
+      if (yield ioUtil.exists(dest)) {
+        let destExists = true;
+        if (yield ioUtil.isDirectory(dest)) {
+          dest = path2.join(dest, path2.basename(source));
+          destExists = yield ioUtil.exists(dest);
+        }
+        if (destExists) {
+          if (options.force == null || options.force) {
+            yield rmRF(dest);
+          } else {
+            throw new Error("Destination already exists");
+          }
+        }
+      }
+      yield mkdirP(path2.dirname(dest));
+      yield ioUtil.rename(source, dest);
+    });
+  }
+  exports2.mv = mv;
+  function rmRF(inputPath) {
+    return __awaiter(this, void 0, void 0, function* () {
+      if (ioUtil.IS_WINDOWS) {
+        if (/[*"<>|]/.test(inputPath)) {
+          throw new Error('File path must not contain `*`, `"`, `<`, `>` or `|` on Windows');
+        }
+        try {
+          const cmdPath = ioUtil.getCmdPath();
+          if (yield ioUtil.isDirectory(inputPath, true)) {
+            yield exec5(`${cmdPath} /s /c "rd /s /q "%inputPath%""`, {
+              env: {inputPath}
+            });
+          } else {
+            yield exec5(`${cmdPath} /s /c "del /f /a "%inputPath%""`, {
+              env: {inputPath}
+            });
+          }
+        } catch (err) {
+          if (err.code !== "ENOENT")
+            throw err;
+        }
+        try {
+          yield ioUtil.unlink(inputPath);
+        } catch (err) {
+          if (err.code !== "ENOENT")
+            throw err;
+        }
+      } else {
+        let isDir = false;
+        try {
+          isDir = yield ioUtil.isDirectory(inputPath);
+        } catch (err) {
+          if (err.code !== "ENOENT")
+            throw err;
           return;
         }
-        const newDest = destStat && destStat.isDirectory() && copySourceDirectory ? path2.join(dest, path2.basename(source)) : dest;
-        if (!(yield ioUtil.exists(source))) {
-          throw new Error(`no such file or directory: ${source}`);
+        if (isDir) {
+          yield execFile(`rm`, [`-rf`, `${inputPath}`]);
+        } else {
+          yield ioUtil.unlink(inputPath);
         }
-        const sourceStat = yield ioUtil.stat(source);
-        if (sourceStat.isDirectory()) {
-          if (!recursive) {
-            throw new Error(`Failed to copy. ${source} is a directory, but tried to copy without recursive flag.`);
+      }
+    });
+  }
+  exports2.rmRF = rmRF;
+  function mkdirP(fsPath) {
+    return __awaiter(this, void 0, void 0, function* () {
+      assert_1.ok(fsPath, "a path argument must be provided");
+      yield ioUtil.mkdir(fsPath, {recursive: true});
+    });
+  }
+  exports2.mkdirP = mkdirP;
+  function which2(tool, check) {
+    return __awaiter(this, void 0, void 0, function* () {
+      if (!tool) {
+        throw new Error("parameter 'tool' is required");
+      }
+      if (check) {
+        const result = yield which2(tool, false);
+        if (!result) {
+          if (ioUtil.IS_WINDOWS) {
+            throw new Error(`Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also verify the file has a valid extension for an executable file.`);
           } else {
-            yield cpDirRecursive(source, newDest, 0, force);
-          }
-        } else {
-          if (path2.relative(source, newDest) === "") {
-            throw new Error(`'${newDest}' and '${source}' are the same file`);
-          }
-          yield copyFile(source, newDest, force);
-        }
-      });
-    }
-    exports2.cp = cp;
-    function mv(source, dest, options = {}) {
-      return __awaiter(this, void 0, void 0, function* () {
-        if (yield ioUtil.exists(dest)) {
-          let destExists = true;
-          if (yield ioUtil.isDirectory(dest)) {
-            dest = path2.join(dest, path2.basename(source));
-            destExists = yield ioUtil.exists(dest);
-          }
-          if (destExists) {
-            if (options.force == null || options.force) {
-              yield rmRF(dest);
-            } else {
-              throw new Error("Destination already exists");
-            }
+            throw new Error(`Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also check the file mode to verify the file is executable.`);
           }
         }
-        yield mkdirP(path2.dirname(dest));
-        yield ioUtil.rename(source, dest);
+        return result;
+      }
+      const matches = yield findInPath(tool);
+      if (matches && matches.length > 0) {
+        return matches[0];
+      }
+      return "";
+    });
+  }
+  exports2.which = which2;
+  function findInPath(tool) {
+    return __awaiter(this, void 0, void 0, function* () {
+      if (!tool) {
+        throw new Error("parameter 'tool' is required");
+      }
+      const extensions = [];
+      if (ioUtil.IS_WINDOWS && process.env["PATHEXT"]) {
+        for (const extension of process.env["PATHEXT"].split(path2.delimiter)) {
+          if (extension) {
+            extensions.push(extension);
+          }
+        }
+      }
+      if (ioUtil.isRooted(tool)) {
+        const filePath = yield ioUtil.tryGetExecutablePath(tool, extensions);
+        if (filePath) {
+          return [filePath];
+        }
+        return [];
+      }
+      if (tool.includes(path2.sep)) {
+        return [];
+      }
+      const directories = [];
+      if (process.env.PATH) {
+        for (const p of process.env.PATH.split(path2.delimiter)) {
+          if (p) {
+            directories.push(p);
+          }
+        }
+      }
+      const matches = [];
+      for (const directory of directories) {
+        const filePath = yield ioUtil.tryGetExecutablePath(path2.join(directory, tool), extensions);
+        if (filePath) {
+          matches.push(filePath);
+        }
+      }
+      return matches;
+    });
+  }
+  exports2.findInPath = findInPath;
+  function readCopyOptions(options) {
+    const force = options.force == null ? true : options.force;
+    const recursive = Boolean(options.recursive);
+    const copySourceDirectory = options.copySourceDirectory == null ? true : Boolean(options.copySourceDirectory);
+    return {force, recursive, copySourceDirectory};
+  }
+  function cpDirRecursive(sourceDir, destDir, currentDepth, force) {
+    return __awaiter(this, void 0, void 0, function* () {
+      if (currentDepth >= 255)
+        return;
+      currentDepth++;
+      yield mkdirP(destDir);
+      const files = yield ioUtil.readdir(sourceDir);
+      for (const fileName of files) {
+        const srcFile = `${sourceDir}/${fileName}`;
+        const destFile = `${destDir}/${fileName}`;
+        const srcFileStat = yield ioUtil.lstat(srcFile);
+        if (srcFileStat.isDirectory()) {
+          yield cpDirRecursive(srcFile, destFile, currentDepth, force);
+        } else {
+          yield copyFile(srcFile, destFile, force);
+        }
+      }
+      yield ioUtil.chmod(destDir, (yield ioUtil.stat(sourceDir)).mode);
+    });
+  }
+  function copyFile(srcFile, destFile, force) {
+    return __awaiter(this, void 0, void 0, function* () {
+      if ((yield ioUtil.lstat(srcFile)).isSymbolicLink()) {
+        try {
+          yield ioUtil.lstat(destFile);
+          yield ioUtil.unlink(destFile);
+        } catch (e) {
+          if (e.code === "EPERM") {
+            yield ioUtil.chmod(destFile, "0666");
+            yield ioUtil.unlink(destFile);
+          }
+        }
+        const symlinkFull = yield ioUtil.readlink(srcFile);
+        yield ioUtil.symlink(symlinkFull, destFile, ioUtil.IS_WINDOWS ? "junction" : null);
+      } else if (!(yield ioUtil.exists(destFile)) || force) {
+        yield ioUtil.copyFile(srcFile, destFile);
+      }
+    });
+  }
+});
+
+// node_modules/@actions/exec/lib/toolrunner.js
+var require_toolrunner = __commonJS((exports2) => {
+  "use strict";
+  var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+    function adopt(value) {
+      return value instanceof P ? value : new P(function(resolve) {
+        resolve(value);
       });
     }
-    exports2.mv = mv;
-    function rmRF(inputPath) {
-      return __awaiter(this, void 0, void 0, function* () {
-        if (ioUtil.IS_WINDOWS) {
-          if (/[*"<>|]/.test(inputPath)) {
-            throw new Error('File path must not contain `*`, `"`, `<`, `>` or `|` on Windows');
+    return new (P || (P = Promise))(function(resolve, reject) {
+      function fulfilled(value) {
+        try {
+          step(generator.next(value));
+        } catch (e) {
+          reject(e);
+        }
+      }
+      function rejected(value) {
+        try {
+          step(generator["throw"](value));
+        } catch (e) {
+          reject(e);
+        }
+      }
+      function step(result) {
+        result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+      }
+      step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+  };
+  var __importStar = exports2 && exports2.__importStar || function(mod) {
+    if (mod && mod.__esModule)
+      return mod;
+    var result = {};
+    if (mod != null) {
+      for (var k in mod)
+        if (Object.hasOwnProperty.call(mod, k))
+          result[k] = mod[k];
+    }
+    result["default"] = mod;
+    return result;
+  };
+  Object.defineProperty(exports2, "__esModule", {value: true});
+  var os2 = __importStar(require("os"));
+  var events = __importStar(require("events"));
+  var child = __importStar(require("child_process"));
+  var path2 = __importStar(require("path"));
+  var io2 = __importStar(require_io());
+  var ioUtil = __importStar(require_io_util());
+  var IS_WINDOWS = process.platform === "win32";
+  var ToolRunner = class extends events.EventEmitter {
+    constructor(toolPath, args, options) {
+      super();
+      if (!toolPath) {
+        throw new Error("Parameter 'toolPath' cannot be null or empty.");
+      }
+      this.toolPath = toolPath;
+      this.args = args || [];
+      this.options = options || {};
+    }
+    _debug(message) {
+      if (this.options.listeners && this.options.listeners.debug) {
+        this.options.listeners.debug(message);
+      }
+    }
+    _getCommandString(options, noPrefix) {
+      const toolPath = this._getSpawnFileName();
+      const args = this._getSpawnArgs(options);
+      let cmd = noPrefix ? "" : "[command]";
+      if (IS_WINDOWS) {
+        if (this._isCmdFile()) {
+          cmd += toolPath;
+          for (const a of args) {
+            cmd += ` ${a}`;
           }
-          try {
-            const cmdPath = ioUtil.getCmdPath();
-            if (yield ioUtil.isDirectory(inputPath, true)) {
-              yield exec5(`${cmdPath} /s /c "rd /s /q "%inputPath%""`, {
-                env: { inputPath }
-              });
-            } else {
-              yield exec5(`${cmdPath} /s /c "del /f /a "%inputPath%""`, {
-                env: { inputPath }
-              });
-            }
-          } catch (err) {
-            if (err.code !== "ENOENT")
-              throw err;
-          }
-          try {
-            yield ioUtil.unlink(inputPath);
-          } catch (err) {
-            if (err.code !== "ENOENT")
-              throw err;
+        } else if (options.windowsVerbatimArguments) {
+          cmd += `"${toolPath}"`;
+          for (const a of args) {
+            cmd += ` ${a}`;
           }
         } else {
-          let isDir = false;
-          try {
-            isDir = yield ioUtil.isDirectory(inputPath);
-          } catch (err) {
-            if (err.code !== "ENOENT")
-              throw err;
+          cmd += this._windowsQuoteCmdArg(toolPath);
+          for (const a of args) {
+            cmd += ` ${this._windowsQuoteCmdArg(a)}`;
+          }
+        }
+      } else {
+        cmd += toolPath;
+        for (const a of args) {
+          cmd += ` ${a}`;
+        }
+      }
+      return cmd;
+    }
+    _processLineBuffer(data, strBuffer, onLine) {
+      try {
+        let s = strBuffer + data.toString();
+        let n = s.indexOf(os2.EOL);
+        while (n > -1) {
+          const line = s.substring(0, n);
+          onLine(line);
+          s = s.substring(n + os2.EOL.length);
+          n = s.indexOf(os2.EOL);
+        }
+        strBuffer = s;
+      } catch (err) {
+        this._debug(`error processing line. Failed with error ${err}`);
+      }
+    }
+    _getSpawnFileName() {
+      if (IS_WINDOWS) {
+        if (this._isCmdFile()) {
+          return process.env["COMSPEC"] || "cmd.exe";
+        }
+      }
+      return this.toolPath;
+    }
+    _getSpawnArgs(options) {
+      if (IS_WINDOWS) {
+        if (this._isCmdFile()) {
+          let argline = `/D /S /C "${this._windowsQuoteCmdArg(this.toolPath)}`;
+          for (const a of this.args) {
+            argline += " ";
+            argline += options.windowsVerbatimArguments ? a : this._windowsQuoteCmdArg(a);
+          }
+          argline += '"';
+          return [argline];
+        }
+      }
+      return this.args;
+    }
+    _endsWith(str, end) {
+      return str.endsWith(end);
+    }
+    _isCmdFile() {
+      const upperToolPath = this.toolPath.toUpperCase();
+      return this._endsWith(upperToolPath, ".CMD") || this._endsWith(upperToolPath, ".BAT");
+    }
+    _windowsQuoteCmdArg(arg) {
+      if (!this._isCmdFile()) {
+        return this._uvQuoteCmdArg(arg);
+      }
+      if (!arg) {
+        return '""';
+      }
+      const cmdSpecialChars = [
+        " ",
+        "	",
+        "&",
+        "(",
+        ")",
+        "[",
+        "]",
+        "{",
+        "}",
+        "^",
+        "=",
+        ";",
+        "!",
+        "'",
+        "+",
+        ",",
+        "`",
+        "~",
+        "|",
+        "<",
+        ">",
+        '"'
+      ];
+      let needsQuotes = false;
+      for (const char of arg) {
+        if (cmdSpecialChars.some((x) => x === char)) {
+          needsQuotes = true;
+          break;
+        }
+      }
+      if (!needsQuotes) {
+        return arg;
+      }
+      let reverse = '"';
+      let quoteHit = true;
+      for (let i = arg.length; i > 0; i--) {
+        reverse += arg[i - 1];
+        if (quoteHit && arg[i - 1] === "\\") {
+          reverse += "\\";
+        } else if (arg[i - 1] === '"') {
+          quoteHit = true;
+          reverse += '"';
+        } else {
+          quoteHit = false;
+        }
+      }
+      reverse += '"';
+      return reverse.split("").reverse().join("");
+    }
+    _uvQuoteCmdArg(arg) {
+      if (!arg) {
+        return '""';
+      }
+      if (!arg.includes(" ") && !arg.includes("	") && !arg.includes('"')) {
+        return arg;
+      }
+      if (!arg.includes('"') && !arg.includes("\\")) {
+        return `"${arg}"`;
+      }
+      let reverse = '"';
+      let quoteHit = true;
+      for (let i = arg.length; i > 0; i--) {
+        reverse += arg[i - 1];
+        if (quoteHit && arg[i - 1] === "\\") {
+          reverse += "\\";
+        } else if (arg[i - 1] === '"') {
+          quoteHit = true;
+          reverse += "\\";
+        } else {
+          quoteHit = false;
+        }
+      }
+      reverse += '"';
+      return reverse.split("").reverse().join("");
+    }
+    _cloneExecOptions(options) {
+      options = options || {};
+      const result = {
+        cwd: options.cwd || process.cwd(),
+        env: options.env || process.env,
+        silent: options.silent || false,
+        windowsVerbatimArguments: options.windowsVerbatimArguments || false,
+        failOnStdErr: options.failOnStdErr || false,
+        ignoreReturnCode: options.ignoreReturnCode || false,
+        delay: options.delay || 1e4
+      };
+      result.outStream = options.outStream || process.stdout;
+      result.errStream = options.errStream || process.stderr;
+      return result;
+    }
+    _getSpawnOptions(options, toolPath) {
+      options = options || {};
+      const result = {};
+      result.cwd = options.cwd;
+      result.env = options.env;
+      result["windowsVerbatimArguments"] = options.windowsVerbatimArguments || this._isCmdFile();
+      if (options.windowsVerbatimArguments) {
+        result.argv0 = `"${toolPath}"`;
+      }
+      return result;
+    }
+    exec() {
+      return __awaiter(this, void 0, void 0, function* () {
+        if (!ioUtil.isRooted(this.toolPath) && (this.toolPath.includes("/") || IS_WINDOWS && this.toolPath.includes("\\"))) {
+          this.toolPath = path2.resolve(process.cwd(), this.options.cwd || process.cwd(), this.toolPath);
+        }
+        this.toolPath = yield io2.which(this.toolPath, true);
+        return new Promise((resolve, reject) => {
+          this._debug(`exec tool: ${this.toolPath}`);
+          this._debug("arguments:");
+          for (const arg of this.args) {
+            this._debug(`   ${arg}`);
+          }
+          const optionsNonNull = this._cloneExecOptions(this.options);
+          if (!optionsNonNull.silent && optionsNonNull.outStream) {
+            optionsNonNull.outStream.write(this._getCommandString(optionsNonNull) + os2.EOL);
+          }
+          const state = new ExecState(optionsNonNull, this.toolPath);
+          state.on("debug", (message) => {
+            this._debug(message);
+          });
+          const fileName = this._getSpawnFileName();
+          const cp = child.spawn(fileName, this._getSpawnArgs(optionsNonNull), this._getSpawnOptions(this.options, fileName));
+          const stdbuffer = "";
+          if (cp.stdout) {
+            cp.stdout.on("data", (data) => {
+              if (this.options.listeners && this.options.listeners.stdout) {
+                this.options.listeners.stdout(data);
+              }
+              if (!optionsNonNull.silent && optionsNonNull.outStream) {
+                optionsNonNull.outStream.write(data);
+              }
+              this._processLineBuffer(data, stdbuffer, (line) => {
+                if (this.options.listeners && this.options.listeners.stdline) {
+                  this.options.listeners.stdline(line);
+                }
+              });
+            });
+          }
+          const errbuffer = "";
+          if (cp.stderr) {
+            cp.stderr.on("data", (data) => {
+              state.processStderr = true;
+              if (this.options.listeners && this.options.listeners.stderr) {
+                this.options.listeners.stderr(data);
+              }
+              if (!optionsNonNull.silent && optionsNonNull.errStream && optionsNonNull.outStream) {
+                const s = optionsNonNull.failOnStdErr ? optionsNonNull.errStream : optionsNonNull.outStream;
+                s.write(data);
+              }
+              this._processLineBuffer(data, errbuffer, (line) => {
+                if (this.options.listeners && this.options.listeners.errline) {
+                  this.options.listeners.errline(line);
+                }
+              });
+            });
+          }
+          cp.on("error", (err) => {
+            state.processError = err.message;
+            state.processExited = true;
+            state.processClosed = true;
+            state.CheckComplete();
+          });
+          cp.on("exit", (code) => {
+            state.processExitCode = code;
+            state.processExited = true;
+            this._debug(`Exit code ${code} received from tool '${this.toolPath}'`);
+            state.CheckComplete();
+          });
+          cp.on("close", (code) => {
+            state.processExitCode = code;
+            state.processExited = true;
+            state.processClosed = true;
+            this._debug(`STDIO streams have closed for tool '${this.toolPath}'`);
+            state.CheckComplete();
+          });
+          state.on("done", (error, exitCode) => {
+            if (stdbuffer.length > 0) {
+              this.emit("stdline", stdbuffer);
+            }
+            if (errbuffer.length > 0) {
+              this.emit("errline", errbuffer);
+            }
+            cp.removeAllListeners();
+            if (error) {
+              reject(error);
+            } else {
+              resolve(exitCode);
+            }
+          });
+          if (this.options.input) {
+            if (!cp.stdin) {
+              throw new Error("child process missing stdin");
+            }
+            cp.stdin.end(this.options.input);
+          }
+        });
+      });
+    }
+  };
+  exports2.ToolRunner = ToolRunner;
+  function argStringToArray(argString) {
+    const args = [];
+    let inQuotes = false;
+    let escaped = false;
+    let arg = "";
+    function append(c) {
+      if (escaped && c !== '"') {
+        arg += "\\";
+      }
+      arg += c;
+      escaped = false;
+    }
+    for (let i = 0; i < argString.length; i++) {
+      const c = argString.charAt(i);
+      if (c === '"') {
+        if (!escaped) {
+          inQuotes = !inQuotes;
+        } else {
+          append(c);
+        }
+        continue;
+      }
+      if (c === "\\" && escaped) {
+        append(c);
+        continue;
+      }
+      if (c === "\\" && inQuotes) {
+        escaped = true;
+        continue;
+      }
+      if (c === " " && !inQuotes) {
+        if (arg.length > 0) {
+          args.push(arg);
+          arg = "";
+        }
+        continue;
+      }
+      append(c);
+    }
+    if (arg.length > 0) {
+      args.push(arg.trim());
+    }
+    return args;
+  }
+  exports2.argStringToArray = argStringToArray;
+  var ExecState = class extends events.EventEmitter {
+    constructor(options, toolPath) {
+      super();
+      this.processClosed = false;
+      this.processError = "";
+      this.processExitCode = 0;
+      this.processExited = false;
+      this.processStderr = false;
+      this.delay = 1e4;
+      this.done = false;
+      this.timeout = null;
+      if (!toolPath) {
+        throw new Error("toolPath must not be empty");
+      }
+      this.options = options;
+      this.toolPath = toolPath;
+      if (options.delay) {
+        this.delay = options.delay;
+      }
+    }
+    CheckComplete() {
+      if (this.done) {
+        return;
+      }
+      if (this.processClosed) {
+        this._setResult();
+      } else if (this.processExited) {
+        this.timeout = setTimeout(ExecState.HandleTimeout, this.delay, this);
+      }
+    }
+    _debug(message) {
+      this.emit("debug", message);
+    }
+    _setResult() {
+      let error;
+      if (this.processExited) {
+        if (this.processError) {
+          error = new Error(`There was an error when attempting to execute the process '${this.toolPath}'. This may indicate the process failed to start. Error: ${this.processError}`);
+        } else if (this.processExitCode !== 0 && !this.options.ignoreReturnCode) {
+          error = new Error(`The process '${this.toolPath}' failed with exit code ${this.processExitCode}`);
+        } else if (this.processStderr && this.options.failOnStdErr) {
+          error = new Error(`The process '${this.toolPath}' failed because one or more lines were written to the STDERR stream`);
+        }
+      }
+      if (this.timeout) {
+        clearTimeout(this.timeout);
+        this.timeout = null;
+      }
+      this.done = true;
+      this.emit("done", error, this.processExitCode);
+    }
+    static HandleTimeout(state) {
+      if (state.done) {
+        return;
+      }
+      if (!state.processClosed && state.processExited) {
+        const message = `The STDIO streams did not close within ${state.delay / 1e3} seconds of the exit event from process '${state.toolPath}'. This may indicate a child process inherited the STDIO streams and has not yet exited.`;
+        state._debug(message);
+      }
+      state._setResult();
+    }
+  };
+});
+
+// node_modules/@actions/exec/lib/exec.js
+var require_exec = __commonJS((exports2) => {
+  "use strict";
+  var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+    function adopt(value) {
+      return value instanceof P ? value : new P(function(resolve) {
+        resolve(value);
+      });
+    }
+    return new (P || (P = Promise))(function(resolve, reject) {
+      function fulfilled(value) {
+        try {
+          step(generator.next(value));
+        } catch (e) {
+          reject(e);
+        }
+      }
+      function rejected(value) {
+        try {
+          step(generator["throw"](value));
+        } catch (e) {
+          reject(e);
+        }
+      }
+      function step(result) {
+        result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+      }
+      step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+  };
+  var __importStar = exports2 && exports2.__importStar || function(mod) {
+    if (mod && mod.__esModule)
+      return mod;
+    var result = {};
+    if (mod != null) {
+      for (var k in mod)
+        if (Object.hasOwnProperty.call(mod, k))
+          result[k] = mod[k];
+    }
+    result["default"] = mod;
+    return result;
+  };
+  Object.defineProperty(exports2, "__esModule", {value: true});
+  var tr = __importStar(require_toolrunner());
+  function exec5(commandLine, args, options) {
+    return __awaiter(this, void 0, void 0, function* () {
+      const commandArgs = tr.argStringToArray(commandLine);
+      if (commandArgs.length === 0) {
+        throw new Error(`Parameter 'commandLine' cannot be null or empty.`);
+      }
+      const toolPath = commandArgs[0];
+      args = commandArgs.slice(1).concat(args || []);
+      const runner = new tr.ToolRunner(toolPath, args, options);
+      return runner.exec();
+    });
+  }
+  exports2.exec = exec5;
+});
+
+// node_modules/@actions/io/lib/io-util.js
+var require_io_util2 = __commonJS((exports2) => {
+  "use strict";
+  var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+    function adopt(value) {
+      return value instanceof P ? value : new P(function(resolve) {
+        resolve(value);
+      });
+    }
+    return new (P || (P = Promise))(function(resolve, reject) {
+      function fulfilled(value) {
+        try {
+          step(generator.next(value));
+        } catch (e) {
+          reject(e);
+        }
+      }
+      function rejected(value) {
+        try {
+          step(generator["throw"](value));
+        } catch (e) {
+          reject(e);
+        }
+      }
+      function step(result) {
+        result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+      }
+      step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+  };
+  var _a;
+  Object.defineProperty(exports2, "__esModule", {value: true});
+  var assert_1 = require("assert");
+  var fs2 = require("fs");
+  var path2 = require("path");
+  _a = fs2.promises, exports2.chmod = _a.chmod, exports2.copyFile = _a.copyFile, exports2.lstat = _a.lstat, exports2.mkdir = _a.mkdir, exports2.readdir = _a.readdir, exports2.readlink = _a.readlink, exports2.rename = _a.rename, exports2.rmdir = _a.rmdir, exports2.stat = _a.stat, exports2.symlink = _a.symlink, exports2.unlink = _a.unlink;
+  exports2.IS_WINDOWS = process.platform === "win32";
+  function exists(fsPath) {
+    return __awaiter(this, void 0, void 0, function* () {
+      try {
+        yield exports2.stat(fsPath);
+      } catch (err) {
+        if (err.code === "ENOENT") {
+          return false;
+        }
+        throw err;
+      }
+      return true;
+    });
+  }
+  exports2.exists = exists;
+  function isDirectory(fsPath, useStat = false) {
+    return __awaiter(this, void 0, void 0, function* () {
+      const stats = useStat ? yield exports2.stat(fsPath) : yield exports2.lstat(fsPath);
+      return stats.isDirectory();
+    });
+  }
+  exports2.isDirectory = isDirectory;
+  function isRooted(p) {
+    p = normalizeSeparators(p);
+    if (!p) {
+      throw new Error('isRooted() parameter "p" cannot be empty');
+    }
+    if (exports2.IS_WINDOWS) {
+      return p.startsWith("\\") || /^[A-Z]:/i.test(p);
+    }
+    return p.startsWith("/");
+  }
+  exports2.isRooted = isRooted;
+  function mkdirP(fsPath, maxDepth = 1e3, depth = 1) {
+    return __awaiter(this, void 0, void 0, function* () {
+      assert_1.ok(fsPath, "a path argument must be provided");
+      fsPath = path2.resolve(fsPath);
+      if (depth >= maxDepth)
+        return exports2.mkdir(fsPath);
+      try {
+        yield exports2.mkdir(fsPath);
+        return;
+      } catch (err) {
+        switch (err.code) {
+          case "ENOENT": {
+            yield mkdirP(path2.dirname(fsPath), maxDepth, depth + 1);
+            yield exports2.mkdir(fsPath);
             return;
           }
-          if (isDir) {
-            yield execFile(`rm`, [`-rf`, `${inputPath}`]);
-          } else {
-            yield ioUtil.unlink(inputPath);
+          default: {
+            let stats;
+            try {
+              stats = yield exports2.stat(fsPath);
+            } catch (err2) {
+              throw err;
+            }
+            if (!stats.isDirectory())
+              throw err;
           }
         }
-      });
-    }
-    exports2.rmRF = rmRF;
-    function mkdirP(fsPath) {
-      return __awaiter(this, void 0, void 0, function* () {
-        assert_1.ok(fsPath, "a path argument must be provided");
-        yield ioUtil.mkdir(fsPath, { recursive: true });
-      });
-    }
-    exports2.mkdirP = mkdirP;
-    function which2(tool, check) {
-      return __awaiter(this, void 0, void 0, function* () {
-        if (!tool) {
-          throw new Error("parameter 'tool' is required");
+      }
+    });
+  }
+  exports2.mkdirP = mkdirP;
+  function tryGetExecutablePath(filePath, extensions) {
+    return __awaiter(this, void 0, void 0, function* () {
+      let stats = void 0;
+      try {
+        stats = yield exports2.stat(filePath);
+      } catch (err) {
+        if (err.code !== "ENOENT") {
+          console.log(`Unexpected error attempting to determine if executable file exists '${filePath}': ${err}`);
         }
-        if (check) {
-          const result = yield which2(tool, false);
-          if (!result) {
-            if (ioUtil.IS_WINDOWS) {
-              throw new Error(`Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also verify the file has a valid extension for an executable file.`);
-            } else {
-              throw new Error(`Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also check the file mode to verify the file is executable.`);
+      }
+      if (stats && stats.isFile()) {
+        if (exports2.IS_WINDOWS) {
+          const upperExt = path2.extname(filePath).toUpperCase();
+          if (extensions.some((validExt) => validExt.toUpperCase() === upperExt)) {
+            return filePath;
+          }
+        } else {
+          if (isUnixExecutable(stats)) {
+            return filePath;
+          }
+        }
+      }
+      const originalFilePath = filePath;
+      for (const extension of extensions) {
+        filePath = originalFilePath + extension;
+        stats = void 0;
+        try {
+          stats = yield exports2.stat(filePath);
+        } catch (err) {
+          if (err.code !== "ENOENT") {
+            console.log(`Unexpected error attempting to determine if executable file exists '${filePath}': ${err}`);
+          }
+        }
+        if (stats && stats.isFile()) {
+          if (exports2.IS_WINDOWS) {
+            try {
+              const directory = path2.dirname(filePath);
+              const upperName = path2.basename(filePath).toUpperCase();
+              for (const actualName of yield exports2.readdir(directory)) {
+                if (upperName === actualName.toUpperCase()) {
+                  filePath = path2.join(directory, actualName);
+                  break;
+                }
+              }
+            } catch (err) {
+              console.log(`Unexpected error attempting to determine the actual case of the file '${filePath}': ${err}`);
+            }
+            return filePath;
+          } else {
+            if (isUnixExecutable(stats)) {
+              return filePath;
             }
           }
-          return result;
         }
-        const matches = yield findInPath(tool);
-        if (matches && matches.length > 0) {
-          return matches[0];
-        }
-        return "";
+      }
+      return "";
+    });
+  }
+  exports2.tryGetExecutablePath = tryGetExecutablePath;
+  function normalizeSeparators(p) {
+    p = p || "";
+    if (exports2.IS_WINDOWS) {
+      p = p.replace(/\//g, "\\");
+      return p.replace(/\\\\+/g, "\\");
+    }
+    return p.replace(/\/\/+/g, "/");
+  }
+  function isUnixExecutable(stats) {
+    return (stats.mode & 1) > 0 || (stats.mode & 8) > 0 && stats.gid === process.getgid() || (stats.mode & 64) > 0 && stats.uid === process.getuid();
+  }
+});
+
+// node_modules/@actions/io/lib/io.js
+var require_io2 = __commonJS((exports2) => {
+  "use strict";
+  var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+    function adopt(value) {
+      return value instanceof P ? value : new P(function(resolve) {
+        resolve(value);
       });
     }
-    exports2.which = which2;
-    function findInPath(tool) {
-      return __awaiter(this, void 0, void 0, function* () {
-        if (!tool) {
-          throw new Error("parameter 'tool' is required");
+    return new (P || (P = Promise))(function(resolve, reject) {
+      function fulfilled(value) {
+        try {
+          step(generator.next(value));
+        } catch (e) {
+          reject(e);
         }
+      }
+      function rejected(value) {
+        try {
+          step(generator["throw"](value));
+        } catch (e) {
+          reject(e);
+        }
+      }
+      function step(result) {
+        result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+      }
+      step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+  };
+  Object.defineProperty(exports2, "__esModule", {value: true});
+  var childProcess = require("child_process");
+  var path2 = require("path");
+  var util_1 = require("util");
+  var ioUtil = require_io_util2();
+  var exec5 = util_1.promisify(childProcess.exec);
+  function cp(source, dest, options = {}) {
+    return __awaiter(this, void 0, void 0, function* () {
+      const {force, recursive} = readCopyOptions(options);
+      const destStat = (yield ioUtil.exists(dest)) ? yield ioUtil.stat(dest) : null;
+      if (destStat && destStat.isFile() && !force) {
+        return;
+      }
+      const newDest = destStat && destStat.isDirectory() ? path2.join(dest, path2.basename(source)) : dest;
+      if (!(yield ioUtil.exists(source))) {
+        throw new Error(`no such file or directory: ${source}`);
+      }
+      const sourceStat = yield ioUtil.stat(source);
+      if (sourceStat.isDirectory()) {
+        if (!recursive) {
+          throw new Error(`Failed to copy. ${source} is a directory, but tried to copy without recursive flag.`);
+        } else {
+          yield cpDirRecursive(source, newDest, 0, force);
+        }
+      } else {
+        if (path2.relative(source, newDest) === "") {
+          throw new Error(`'${newDest}' and '${source}' are the same file`);
+        }
+        yield copyFile(source, newDest, force);
+      }
+    });
+  }
+  exports2.cp = cp;
+  function mv(source, dest, options = {}) {
+    return __awaiter(this, void 0, void 0, function* () {
+      if (yield ioUtil.exists(dest)) {
+        let destExists = true;
+        if (yield ioUtil.isDirectory(dest)) {
+          dest = path2.join(dest, path2.basename(source));
+          destExists = yield ioUtil.exists(dest);
+        }
+        if (destExists) {
+          if (options.force == null || options.force) {
+            yield rmRF(dest);
+          } else {
+            throw new Error("Destination already exists");
+          }
+        }
+      }
+      yield mkdirP(path2.dirname(dest));
+      yield ioUtil.rename(source, dest);
+    });
+  }
+  exports2.mv = mv;
+  function rmRF(inputPath) {
+    return __awaiter(this, void 0, void 0, function* () {
+      if (ioUtil.IS_WINDOWS) {
+        try {
+          if (yield ioUtil.isDirectory(inputPath, true)) {
+            yield exec5(`rd /s /q "${inputPath}"`);
+          } else {
+            yield exec5(`del /f /a "${inputPath}"`);
+          }
+        } catch (err) {
+          if (err.code !== "ENOENT")
+            throw err;
+        }
+        try {
+          yield ioUtil.unlink(inputPath);
+        } catch (err) {
+          if (err.code !== "ENOENT")
+            throw err;
+        }
+      } else {
+        let isDir = false;
+        try {
+          isDir = yield ioUtil.isDirectory(inputPath);
+        } catch (err) {
+          if (err.code !== "ENOENT")
+            throw err;
+          return;
+        }
+        if (isDir) {
+          yield exec5(`rm -rf "${inputPath}"`);
+        } else {
+          yield ioUtil.unlink(inputPath);
+        }
+      }
+    });
+  }
+  exports2.rmRF = rmRF;
+  function mkdirP(fsPath) {
+    return __awaiter(this, void 0, void 0, function* () {
+      yield ioUtil.mkdirP(fsPath);
+    });
+  }
+  exports2.mkdirP = mkdirP;
+  function which2(tool, check) {
+    return __awaiter(this, void 0, void 0, function* () {
+      if (!tool) {
+        throw new Error("parameter 'tool' is required");
+      }
+      if (check) {
+        const result = yield which2(tool, false);
+        if (!result) {
+          if (ioUtil.IS_WINDOWS) {
+            throw new Error(`Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also verify the file has a valid extension for an executable file.`);
+          } else {
+            throw new Error(`Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also check the file mode to verify the file is executable.`);
+          }
+        }
+      }
+      try {
         const extensions = [];
-        if (ioUtil.IS_WINDOWS && process.env["PATHEXT"]) {
-          for (const extension of process.env["PATHEXT"].split(path2.delimiter)) {
+        if (ioUtil.IS_WINDOWS && process.env.PATHEXT) {
+          for (const extension of process.env.PATHEXT.split(path2.delimiter)) {
             if (extension) {
               extensions.push(extension);
             }
@@ -681,12 +1591,12 @@ var require_io = __commonJS({
         if (ioUtil.isRooted(tool)) {
           const filePath = yield ioUtil.tryGetExecutablePath(tool, extensions);
           if (filePath) {
-            return [filePath];
+            return filePath;
           }
-          return [];
+          return "";
         }
-        if (tool.includes(path2.sep)) {
-          return [];
+        if (tool.includes("/") || ioUtil.IS_WINDOWS && tool.includes("\\")) {
+          return "";
         }
         const directories = [];
         if (process.env.PATH) {
@@ -696,985 +1606,62 @@ var require_io = __commonJS({
             }
           }
         }
-        const matches = [];
         for (const directory of directories) {
-          const filePath = yield ioUtil.tryGetExecutablePath(path2.join(directory, tool), extensions);
+          const filePath = yield ioUtil.tryGetExecutablePath(directory + path2.sep + tool, extensions);
           if (filePath) {
-            matches.push(filePath);
-          }
-        }
-        return matches;
-      });
-    }
-    exports2.findInPath = findInPath;
-    function readCopyOptions(options) {
-      const force = options.force == null ? true : options.force;
-      const recursive = Boolean(options.recursive);
-      const copySourceDirectory = options.copySourceDirectory == null ? true : Boolean(options.copySourceDirectory);
-      return { force, recursive, copySourceDirectory };
-    }
-    function cpDirRecursive(sourceDir, destDir, currentDepth, force) {
-      return __awaiter(this, void 0, void 0, function* () {
-        if (currentDepth >= 255)
-          return;
-        currentDepth++;
-        yield mkdirP(destDir);
-        const files = yield ioUtil.readdir(sourceDir);
-        for (const fileName of files) {
-          const srcFile = `${sourceDir}/${fileName}`;
-          const destFile = `${destDir}/${fileName}`;
-          const srcFileStat = yield ioUtil.lstat(srcFile);
-          if (srcFileStat.isDirectory()) {
-            yield cpDirRecursive(srcFile, destFile, currentDepth, force);
-          } else {
-            yield copyFile(srcFile, destFile, force);
-          }
-        }
-        yield ioUtil.chmod(destDir, (yield ioUtil.stat(sourceDir)).mode);
-      });
-    }
-    function copyFile(srcFile, destFile, force) {
-      return __awaiter(this, void 0, void 0, function* () {
-        if ((yield ioUtil.lstat(srcFile)).isSymbolicLink()) {
-          try {
-            yield ioUtil.lstat(destFile);
-            yield ioUtil.unlink(destFile);
-          } catch (e) {
-            if (e.code === "EPERM") {
-              yield ioUtil.chmod(destFile, "0666");
-              yield ioUtil.unlink(destFile);
-            }
-          }
-          const symlinkFull = yield ioUtil.readlink(srcFile);
-          yield ioUtil.symlink(symlinkFull, destFile, ioUtil.IS_WINDOWS ? "junction" : null);
-        } else if (!(yield ioUtil.exists(destFile)) || force) {
-          yield ioUtil.copyFile(srcFile, destFile);
-        }
-      });
-    }
-  }
-});
-
-// node_modules/@actions/exec/lib/toolrunner.js
-var require_toolrunner = __commonJS({
-  "node_modules/@actions/exec/lib/toolrunner.js"(exports2) {
-    "use strict";
-    var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
-      function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve) {
-          resolve(value);
-        });
-      }
-      return new (P || (P = Promise))(function(resolve, reject) {
-        function fulfilled(value) {
-          try {
-            step(generator.next(value));
-          } catch (e) {
-            reject(e);
-          }
-        }
-        function rejected(value) {
-          try {
-            step(generator["throw"](value));
-          } catch (e) {
-            reject(e);
-          }
-        }
-        function step(result) {
-          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
-        }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-      });
-    };
-    var __importStar = exports2 && exports2.__importStar || function(mod) {
-      if (mod && mod.__esModule)
-        return mod;
-      var result = {};
-      if (mod != null) {
-        for (var k in mod)
-          if (Object.hasOwnProperty.call(mod, k))
-            result[k] = mod[k];
-      }
-      result["default"] = mod;
-      return result;
-    };
-    Object.defineProperty(exports2, "__esModule", { value: true });
-    var os2 = __importStar(require("os"));
-    var events = __importStar(require("events"));
-    var child = __importStar(require("child_process"));
-    var path2 = __importStar(require("path"));
-    var io2 = __importStar(require_io());
-    var ioUtil = __importStar(require_io_util());
-    var IS_WINDOWS = process.platform === "win32";
-    var ToolRunner = class extends events.EventEmitter {
-      constructor(toolPath, args, options) {
-        super();
-        if (!toolPath) {
-          throw new Error("Parameter 'toolPath' cannot be null or empty.");
-        }
-        this.toolPath = toolPath;
-        this.args = args || [];
-        this.options = options || {};
-      }
-      _debug(message) {
-        if (this.options.listeners && this.options.listeners.debug) {
-          this.options.listeners.debug(message);
-        }
-      }
-      _getCommandString(options, noPrefix) {
-        const toolPath = this._getSpawnFileName();
-        const args = this._getSpawnArgs(options);
-        let cmd = noPrefix ? "" : "[command]";
-        if (IS_WINDOWS) {
-          if (this._isCmdFile()) {
-            cmd += toolPath;
-            for (const a of args) {
-              cmd += ` ${a}`;
-            }
-          } else if (options.windowsVerbatimArguments) {
-            cmd += `"${toolPath}"`;
-            for (const a of args) {
-              cmd += ` ${a}`;
-            }
-          } else {
-            cmd += this._windowsQuoteCmdArg(toolPath);
-            for (const a of args) {
-              cmd += ` ${this._windowsQuoteCmdArg(a)}`;
-            }
-          }
-        } else {
-          cmd += toolPath;
-          for (const a of args) {
-            cmd += ` ${a}`;
-          }
-        }
-        return cmd;
-      }
-      _processLineBuffer(data, strBuffer, onLine) {
-        try {
-          let s = strBuffer + data.toString();
-          let n = s.indexOf(os2.EOL);
-          while (n > -1) {
-            const line = s.substring(0, n);
-            onLine(line);
-            s = s.substring(n + os2.EOL.length);
-            n = s.indexOf(os2.EOL);
-          }
-          strBuffer = s;
-        } catch (err) {
-          this._debug(`error processing line. Failed with error ${err}`);
-        }
-      }
-      _getSpawnFileName() {
-        if (IS_WINDOWS) {
-          if (this._isCmdFile()) {
-            return process.env["COMSPEC"] || "cmd.exe";
-          }
-        }
-        return this.toolPath;
-      }
-      _getSpawnArgs(options) {
-        if (IS_WINDOWS) {
-          if (this._isCmdFile()) {
-            let argline = `/D /S /C "${this._windowsQuoteCmdArg(this.toolPath)}`;
-            for (const a of this.args) {
-              argline += " ";
-              argline += options.windowsVerbatimArguments ? a : this._windowsQuoteCmdArg(a);
-            }
-            argline += '"';
-            return [argline];
-          }
-        }
-        return this.args;
-      }
-      _endsWith(str, end) {
-        return str.endsWith(end);
-      }
-      _isCmdFile() {
-        const upperToolPath = this.toolPath.toUpperCase();
-        return this._endsWith(upperToolPath, ".CMD") || this._endsWith(upperToolPath, ".BAT");
-      }
-      _windowsQuoteCmdArg(arg) {
-        if (!this._isCmdFile()) {
-          return this._uvQuoteCmdArg(arg);
-        }
-        if (!arg) {
-          return '""';
-        }
-        const cmdSpecialChars = [
-          " ",
-          "	",
-          "&",
-          "(",
-          ")",
-          "[",
-          "]",
-          "{",
-          "}",
-          "^",
-          "=",
-          ";",
-          "!",
-          "'",
-          "+",
-          ",",
-          "`",
-          "~",
-          "|",
-          "<",
-          ">",
-          '"'
-        ];
-        let needsQuotes = false;
-        for (const char of arg) {
-          if (cmdSpecialChars.some((x) => x === char)) {
-            needsQuotes = true;
-            break;
-          }
-        }
-        if (!needsQuotes) {
-          return arg;
-        }
-        let reverse = '"';
-        let quoteHit = true;
-        for (let i = arg.length; i > 0; i--) {
-          reverse += arg[i - 1];
-          if (quoteHit && arg[i - 1] === "\\") {
-            reverse += "\\";
-          } else if (arg[i - 1] === '"') {
-            quoteHit = true;
-            reverse += '"';
-          } else {
-            quoteHit = false;
-          }
-        }
-        reverse += '"';
-        return reverse.split("").reverse().join("");
-      }
-      _uvQuoteCmdArg(arg) {
-        if (!arg) {
-          return '""';
-        }
-        if (!arg.includes(" ") && !arg.includes("	") && !arg.includes('"')) {
-          return arg;
-        }
-        if (!arg.includes('"') && !arg.includes("\\")) {
-          return `"${arg}"`;
-        }
-        let reverse = '"';
-        let quoteHit = true;
-        for (let i = arg.length; i > 0; i--) {
-          reverse += arg[i - 1];
-          if (quoteHit && arg[i - 1] === "\\") {
-            reverse += "\\";
-          } else if (arg[i - 1] === '"') {
-            quoteHit = true;
-            reverse += "\\";
-          } else {
-            quoteHit = false;
-          }
-        }
-        reverse += '"';
-        return reverse.split("").reverse().join("");
-      }
-      _cloneExecOptions(options) {
-        options = options || {};
-        const result = {
-          cwd: options.cwd || process.cwd(),
-          env: options.env || process.env,
-          silent: options.silent || false,
-          windowsVerbatimArguments: options.windowsVerbatimArguments || false,
-          failOnStdErr: options.failOnStdErr || false,
-          ignoreReturnCode: options.ignoreReturnCode || false,
-          delay: options.delay || 1e4
-        };
-        result.outStream = options.outStream || process.stdout;
-        result.errStream = options.errStream || process.stderr;
-        return result;
-      }
-      _getSpawnOptions(options, toolPath) {
-        options = options || {};
-        const result = {};
-        result.cwd = options.cwd;
-        result.env = options.env;
-        result["windowsVerbatimArguments"] = options.windowsVerbatimArguments || this._isCmdFile();
-        if (options.windowsVerbatimArguments) {
-          result.argv0 = `"${toolPath}"`;
-        }
-        return result;
-      }
-      exec() {
-        return __awaiter(this, void 0, void 0, function* () {
-          if (!ioUtil.isRooted(this.toolPath) && (this.toolPath.includes("/") || IS_WINDOWS && this.toolPath.includes("\\"))) {
-            this.toolPath = path2.resolve(process.cwd(), this.options.cwd || process.cwd(), this.toolPath);
-          }
-          this.toolPath = yield io2.which(this.toolPath, true);
-          return new Promise((resolve, reject) => {
-            this._debug(`exec tool: ${this.toolPath}`);
-            this._debug("arguments:");
-            for (const arg of this.args) {
-              this._debug(`   ${arg}`);
-            }
-            const optionsNonNull = this._cloneExecOptions(this.options);
-            if (!optionsNonNull.silent && optionsNonNull.outStream) {
-              optionsNonNull.outStream.write(this._getCommandString(optionsNonNull) + os2.EOL);
-            }
-            const state = new ExecState(optionsNonNull, this.toolPath);
-            state.on("debug", (message) => {
-              this._debug(message);
-            });
-            const fileName = this._getSpawnFileName();
-            const cp = child.spawn(fileName, this._getSpawnArgs(optionsNonNull), this._getSpawnOptions(this.options, fileName));
-            const stdbuffer = "";
-            if (cp.stdout) {
-              cp.stdout.on("data", (data) => {
-                if (this.options.listeners && this.options.listeners.stdout) {
-                  this.options.listeners.stdout(data);
-                }
-                if (!optionsNonNull.silent && optionsNonNull.outStream) {
-                  optionsNonNull.outStream.write(data);
-                }
-                this._processLineBuffer(data, stdbuffer, (line) => {
-                  if (this.options.listeners && this.options.listeners.stdline) {
-                    this.options.listeners.stdline(line);
-                  }
-                });
-              });
-            }
-            const errbuffer = "";
-            if (cp.stderr) {
-              cp.stderr.on("data", (data) => {
-                state.processStderr = true;
-                if (this.options.listeners && this.options.listeners.stderr) {
-                  this.options.listeners.stderr(data);
-                }
-                if (!optionsNonNull.silent && optionsNonNull.errStream && optionsNonNull.outStream) {
-                  const s = optionsNonNull.failOnStdErr ? optionsNonNull.errStream : optionsNonNull.outStream;
-                  s.write(data);
-                }
-                this._processLineBuffer(data, errbuffer, (line) => {
-                  if (this.options.listeners && this.options.listeners.errline) {
-                    this.options.listeners.errline(line);
-                  }
-                });
-              });
-            }
-            cp.on("error", (err) => {
-              state.processError = err.message;
-              state.processExited = true;
-              state.processClosed = true;
-              state.CheckComplete();
-            });
-            cp.on("exit", (code) => {
-              state.processExitCode = code;
-              state.processExited = true;
-              this._debug(`Exit code ${code} received from tool '${this.toolPath}'`);
-              state.CheckComplete();
-            });
-            cp.on("close", (code) => {
-              state.processExitCode = code;
-              state.processExited = true;
-              state.processClosed = true;
-              this._debug(`STDIO streams have closed for tool '${this.toolPath}'`);
-              state.CheckComplete();
-            });
-            state.on("done", (error, exitCode) => {
-              if (stdbuffer.length > 0) {
-                this.emit("stdline", stdbuffer);
-              }
-              if (errbuffer.length > 0) {
-                this.emit("errline", errbuffer);
-              }
-              cp.removeAllListeners();
-              if (error) {
-                reject(error);
-              } else {
-                resolve(exitCode);
-              }
-            });
-            if (this.options.input) {
-              if (!cp.stdin) {
-                throw new Error("child process missing stdin");
-              }
-              cp.stdin.end(this.options.input);
-            }
-          });
-        });
-      }
-    };
-    exports2.ToolRunner = ToolRunner;
-    function argStringToArray(argString) {
-      const args = [];
-      let inQuotes = false;
-      let escaped = false;
-      let arg = "";
-      function append(c) {
-        if (escaped && c !== '"') {
-          arg += "\\";
-        }
-        arg += c;
-        escaped = false;
-      }
-      for (let i = 0; i < argString.length; i++) {
-        const c = argString.charAt(i);
-        if (c === '"') {
-          if (!escaped) {
-            inQuotes = !inQuotes;
-          } else {
-            append(c);
-          }
-          continue;
-        }
-        if (c === "\\" && escaped) {
-          append(c);
-          continue;
-        }
-        if (c === "\\" && inQuotes) {
-          escaped = true;
-          continue;
-        }
-        if (c === " " && !inQuotes) {
-          if (arg.length > 0) {
-            args.push(arg);
-            arg = "";
-          }
-          continue;
-        }
-        append(c);
-      }
-      if (arg.length > 0) {
-        args.push(arg.trim());
-      }
-      return args;
-    }
-    exports2.argStringToArray = argStringToArray;
-    var ExecState = class extends events.EventEmitter {
-      constructor(options, toolPath) {
-        super();
-        this.processClosed = false;
-        this.processError = "";
-        this.processExitCode = 0;
-        this.processExited = false;
-        this.processStderr = false;
-        this.delay = 1e4;
-        this.done = false;
-        this.timeout = null;
-        if (!toolPath) {
-          throw new Error("toolPath must not be empty");
-        }
-        this.options = options;
-        this.toolPath = toolPath;
-        if (options.delay) {
-          this.delay = options.delay;
-        }
-      }
-      CheckComplete() {
-        if (this.done) {
-          return;
-        }
-        if (this.processClosed) {
-          this._setResult();
-        } else if (this.processExited) {
-          this.timeout = setTimeout(ExecState.HandleTimeout, this.delay, this);
-        }
-      }
-      _debug(message) {
-        this.emit("debug", message);
-      }
-      _setResult() {
-        let error;
-        if (this.processExited) {
-          if (this.processError) {
-            error = new Error(`There was an error when attempting to execute the process '${this.toolPath}'. This may indicate the process failed to start. Error: ${this.processError}`);
-          } else if (this.processExitCode !== 0 && !this.options.ignoreReturnCode) {
-            error = new Error(`The process '${this.toolPath}' failed with exit code ${this.processExitCode}`);
-          } else if (this.processStderr && this.options.failOnStdErr) {
-            error = new Error(`The process '${this.toolPath}' failed because one or more lines were written to the STDERR stream`);
-          }
-        }
-        if (this.timeout) {
-          clearTimeout(this.timeout);
-          this.timeout = null;
-        }
-        this.done = true;
-        this.emit("done", error, this.processExitCode);
-      }
-      static HandleTimeout(state) {
-        if (state.done) {
-          return;
-        }
-        if (!state.processClosed && state.processExited) {
-          const message = `The STDIO streams did not close within ${state.delay / 1e3} seconds of the exit event from process '${state.toolPath}'. This may indicate a child process inherited the STDIO streams and has not yet exited.`;
-          state._debug(message);
-        }
-        state._setResult();
-      }
-    };
-  }
-});
-
-// node_modules/@actions/exec/lib/exec.js
-var require_exec = __commonJS({
-  "node_modules/@actions/exec/lib/exec.js"(exports2) {
-    "use strict";
-    var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
-      function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve) {
-          resolve(value);
-        });
-      }
-      return new (P || (P = Promise))(function(resolve, reject) {
-        function fulfilled(value) {
-          try {
-            step(generator.next(value));
-          } catch (e) {
-            reject(e);
-          }
-        }
-        function rejected(value) {
-          try {
-            step(generator["throw"](value));
-          } catch (e) {
-            reject(e);
-          }
-        }
-        function step(result) {
-          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
-        }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-      });
-    };
-    var __importStar = exports2 && exports2.__importStar || function(mod) {
-      if (mod && mod.__esModule)
-        return mod;
-      var result = {};
-      if (mod != null) {
-        for (var k in mod)
-          if (Object.hasOwnProperty.call(mod, k))
-            result[k] = mod[k];
-      }
-      result["default"] = mod;
-      return result;
-    };
-    Object.defineProperty(exports2, "__esModule", { value: true });
-    var tr = __importStar(require_toolrunner());
-    function exec5(commandLine, args, options) {
-      return __awaiter(this, void 0, void 0, function* () {
-        const commandArgs = tr.argStringToArray(commandLine);
-        if (commandArgs.length === 0) {
-          throw new Error(`Parameter 'commandLine' cannot be null or empty.`);
-        }
-        const toolPath = commandArgs[0];
-        args = commandArgs.slice(1).concat(args || []);
-        const runner = new tr.ToolRunner(toolPath, args, options);
-        return runner.exec();
-      });
-    }
-    exports2.exec = exec5;
-  }
-});
-
-// node_modules/@actions/io/lib/io-util.js
-var require_io_util2 = __commonJS({
-  "node_modules/@actions/io/lib/io-util.js"(exports2) {
-    "use strict";
-    var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
-      function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve) {
-          resolve(value);
-        });
-      }
-      return new (P || (P = Promise))(function(resolve, reject) {
-        function fulfilled(value) {
-          try {
-            step(generator.next(value));
-          } catch (e) {
-            reject(e);
-          }
-        }
-        function rejected(value) {
-          try {
-            step(generator["throw"](value));
-          } catch (e) {
-            reject(e);
-          }
-        }
-        function step(result) {
-          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
-        }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-      });
-    };
-    var _a;
-    Object.defineProperty(exports2, "__esModule", { value: true });
-    var assert_1 = require("assert");
-    var fs2 = require("fs");
-    var path2 = require("path");
-    _a = fs2.promises, exports2.chmod = _a.chmod, exports2.copyFile = _a.copyFile, exports2.lstat = _a.lstat, exports2.mkdir = _a.mkdir, exports2.readdir = _a.readdir, exports2.readlink = _a.readlink, exports2.rename = _a.rename, exports2.rmdir = _a.rmdir, exports2.stat = _a.stat, exports2.symlink = _a.symlink, exports2.unlink = _a.unlink;
-    exports2.IS_WINDOWS = process.platform === "win32";
-    function exists(fsPath) {
-      return __awaiter(this, void 0, void 0, function* () {
-        try {
-          yield exports2.stat(fsPath);
-        } catch (err) {
-          if (err.code === "ENOENT") {
-            return false;
-          }
-          throw err;
-        }
-        return true;
-      });
-    }
-    exports2.exists = exists;
-    function isDirectory(fsPath, useStat = false) {
-      return __awaiter(this, void 0, void 0, function* () {
-        const stats = useStat ? yield exports2.stat(fsPath) : yield exports2.lstat(fsPath);
-        return stats.isDirectory();
-      });
-    }
-    exports2.isDirectory = isDirectory;
-    function isRooted(p) {
-      p = normalizeSeparators(p);
-      if (!p) {
-        throw new Error('isRooted() parameter "p" cannot be empty');
-      }
-      if (exports2.IS_WINDOWS) {
-        return p.startsWith("\\") || /^[A-Z]:/i.test(p);
-      }
-      return p.startsWith("/");
-    }
-    exports2.isRooted = isRooted;
-    function mkdirP(fsPath, maxDepth = 1e3, depth = 1) {
-      return __awaiter(this, void 0, void 0, function* () {
-        assert_1.ok(fsPath, "a path argument must be provided");
-        fsPath = path2.resolve(fsPath);
-        if (depth >= maxDepth)
-          return exports2.mkdir(fsPath);
-        try {
-          yield exports2.mkdir(fsPath);
-          return;
-        } catch (err) {
-          switch (err.code) {
-            case "ENOENT": {
-              yield mkdirP(path2.dirname(fsPath), maxDepth, depth + 1);
-              yield exports2.mkdir(fsPath);
-              return;
-            }
-            default: {
-              let stats;
-              try {
-                stats = yield exports2.stat(fsPath);
-              } catch (err2) {
-                throw err;
-              }
-              if (!stats.isDirectory())
-                throw err;
-            }
-          }
-        }
-      });
-    }
-    exports2.mkdirP = mkdirP;
-    function tryGetExecutablePath(filePath, extensions) {
-      return __awaiter(this, void 0, void 0, function* () {
-        let stats = void 0;
-        try {
-          stats = yield exports2.stat(filePath);
-        } catch (err) {
-          if (err.code !== "ENOENT") {
-            console.log(`Unexpected error attempting to determine if executable file exists '${filePath}': ${err}`);
-          }
-        }
-        if (stats && stats.isFile()) {
-          if (exports2.IS_WINDOWS) {
-            const upperExt = path2.extname(filePath).toUpperCase();
-            if (extensions.some((validExt) => validExt.toUpperCase() === upperExt)) {
-              return filePath;
-            }
-          } else {
-            if (isUnixExecutable(stats)) {
-              return filePath;
-            }
-          }
-        }
-        const originalFilePath = filePath;
-        for (const extension of extensions) {
-          filePath = originalFilePath + extension;
-          stats = void 0;
-          try {
-            stats = yield exports2.stat(filePath);
-          } catch (err) {
-            if (err.code !== "ENOENT") {
-              console.log(`Unexpected error attempting to determine if executable file exists '${filePath}': ${err}`);
-            }
-          }
-          if (stats && stats.isFile()) {
-            if (exports2.IS_WINDOWS) {
-              try {
-                const directory = path2.dirname(filePath);
-                const upperName = path2.basename(filePath).toUpperCase();
-                for (const actualName of yield exports2.readdir(directory)) {
-                  if (upperName === actualName.toUpperCase()) {
-                    filePath = path2.join(directory, actualName);
-                    break;
-                  }
-                }
-              } catch (err) {
-                console.log(`Unexpected error attempting to determine the actual case of the file '${filePath}': ${err}`);
-              }
-              return filePath;
-            } else {
-              if (isUnixExecutable(stats)) {
-                return filePath;
-              }
-            }
+            return filePath;
           }
         }
         return "";
-      });
-    }
-    exports2.tryGetExecutablePath = tryGetExecutablePath;
-    function normalizeSeparators(p) {
-      p = p || "";
-      if (exports2.IS_WINDOWS) {
-        p = p.replace(/\//g, "\\");
-        return p.replace(/\\\\+/g, "\\");
+      } catch (err) {
+        throw new Error(`which failed with message ${err.message}`);
       }
-      return p.replace(/\/\/+/g, "/");
-    }
-    function isUnixExecutable(stats) {
-      return (stats.mode & 1) > 0 || (stats.mode & 8) > 0 && stats.gid === process.getgid() || (stats.mode & 64) > 0 && stats.uid === process.getuid();
-    }
+    });
   }
-});
-
-// node_modules/@actions/io/lib/io.js
-var require_io2 = __commonJS({
-  "node_modules/@actions/io/lib/io.js"(exports2) {
-    "use strict";
-    var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
-      function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve) {
-          resolve(value);
-        });
+  exports2.which = which2;
+  function readCopyOptions(options) {
+    const force = options.force == null ? true : options.force;
+    const recursive = Boolean(options.recursive);
+    return {force, recursive};
+  }
+  function cpDirRecursive(sourceDir, destDir, currentDepth, force) {
+    return __awaiter(this, void 0, void 0, function* () {
+      if (currentDepth >= 255)
+        return;
+      currentDepth++;
+      yield mkdirP(destDir);
+      const files = yield ioUtil.readdir(sourceDir);
+      for (const fileName of files) {
+        const srcFile = `${sourceDir}/${fileName}`;
+        const destFile = `${destDir}/${fileName}`;
+        const srcFileStat = yield ioUtil.lstat(srcFile);
+        if (srcFileStat.isDirectory()) {
+          yield cpDirRecursive(srcFile, destFile, currentDepth, force);
+        } else {
+          yield copyFile(srcFile, destFile, force);
+        }
       }
-      return new (P || (P = Promise))(function(resolve, reject) {
-        function fulfilled(value) {
-          try {
-            step(generator.next(value));
-          } catch (e) {
-            reject(e);
-          }
-        }
-        function rejected(value) {
-          try {
-            step(generator["throw"](value));
-          } catch (e) {
-            reject(e);
-          }
-        }
-        function step(result) {
-          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
-        }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-      });
-    };
-    Object.defineProperty(exports2, "__esModule", { value: true });
-    var childProcess = require("child_process");
-    var path2 = require("path");
-    var util_1 = require("util");
-    var ioUtil = require_io_util2();
-    var exec5 = util_1.promisify(childProcess.exec);
-    function cp(source, dest, options = {}) {
-      return __awaiter(this, void 0, void 0, function* () {
-        const { force, recursive } = readCopyOptions(options);
-        const destStat = (yield ioUtil.exists(dest)) ? yield ioUtil.stat(dest) : null;
-        if (destStat && destStat.isFile() && !force) {
-          return;
-        }
-        const newDest = destStat && destStat.isDirectory() ? path2.join(dest, path2.basename(source)) : dest;
-        if (!(yield ioUtil.exists(source))) {
-          throw new Error(`no such file or directory: ${source}`);
-        }
-        const sourceStat = yield ioUtil.stat(source);
-        if (sourceStat.isDirectory()) {
-          if (!recursive) {
-            throw new Error(`Failed to copy. ${source} is a directory, but tried to copy without recursive flag.`);
-          } else {
-            yield cpDirRecursive(source, newDest, 0, force);
-          }
-        } else {
-          if (path2.relative(source, newDest) === "") {
-            throw new Error(`'${newDest}' and '${source}' are the same file`);
-          }
-          yield copyFile(source, newDest, force);
-        }
-      });
-    }
-    exports2.cp = cp;
-    function mv(source, dest, options = {}) {
-      return __awaiter(this, void 0, void 0, function* () {
-        if (yield ioUtil.exists(dest)) {
-          let destExists = true;
-          if (yield ioUtil.isDirectory(dest)) {
-            dest = path2.join(dest, path2.basename(source));
-            destExists = yield ioUtil.exists(dest);
-          }
-          if (destExists) {
-            if (options.force == null || options.force) {
-              yield rmRF(dest);
-            } else {
-              throw new Error("Destination already exists");
-            }
-          }
-        }
-        yield mkdirP(path2.dirname(dest));
-        yield ioUtil.rename(source, dest);
-      });
-    }
-    exports2.mv = mv;
-    function rmRF(inputPath) {
-      return __awaiter(this, void 0, void 0, function* () {
-        if (ioUtil.IS_WINDOWS) {
-          try {
-            if (yield ioUtil.isDirectory(inputPath, true)) {
-              yield exec5(`rd /s /q "${inputPath}"`);
-            } else {
-              yield exec5(`del /f /a "${inputPath}"`);
-            }
-          } catch (err) {
-            if (err.code !== "ENOENT")
-              throw err;
-          }
-          try {
-            yield ioUtil.unlink(inputPath);
-          } catch (err) {
-            if (err.code !== "ENOENT")
-              throw err;
-          }
-        } else {
-          let isDir = false;
-          try {
-            isDir = yield ioUtil.isDirectory(inputPath);
-          } catch (err) {
-            if (err.code !== "ENOENT")
-              throw err;
-            return;
-          }
-          if (isDir) {
-            yield exec5(`rm -rf "${inputPath}"`);
-          } else {
-            yield ioUtil.unlink(inputPath);
-          }
-        }
-      });
-    }
-    exports2.rmRF = rmRF;
-    function mkdirP(fsPath) {
-      return __awaiter(this, void 0, void 0, function* () {
-        yield ioUtil.mkdirP(fsPath);
-      });
-    }
-    exports2.mkdirP = mkdirP;
-    function which2(tool, check) {
-      return __awaiter(this, void 0, void 0, function* () {
-        if (!tool) {
-          throw new Error("parameter 'tool' is required");
-        }
-        if (check) {
-          const result = yield which2(tool, false);
-          if (!result) {
-            if (ioUtil.IS_WINDOWS) {
-              throw new Error(`Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also verify the file has a valid extension for an executable file.`);
-            } else {
-              throw new Error(`Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also check the file mode to verify the file is executable.`);
-            }
-          }
-        }
+      yield ioUtil.chmod(destDir, (yield ioUtil.stat(sourceDir)).mode);
+    });
+  }
+  function copyFile(srcFile, destFile, force) {
+    return __awaiter(this, void 0, void 0, function* () {
+      if ((yield ioUtil.lstat(srcFile)).isSymbolicLink()) {
         try {
-          const extensions = [];
-          if (ioUtil.IS_WINDOWS && process.env.PATHEXT) {
-            for (const extension of process.env.PATHEXT.split(path2.delimiter)) {
-              if (extension) {
-                extensions.push(extension);
-              }
-            }
-          }
-          if (ioUtil.isRooted(tool)) {
-            const filePath = yield ioUtil.tryGetExecutablePath(tool, extensions);
-            if (filePath) {
-              return filePath;
-            }
-            return "";
-          }
-          if (tool.includes("/") || ioUtil.IS_WINDOWS && tool.includes("\\")) {
-            return "";
-          }
-          const directories = [];
-          if (process.env.PATH) {
-            for (const p of process.env.PATH.split(path2.delimiter)) {
-              if (p) {
-                directories.push(p);
-              }
-            }
-          }
-          for (const directory of directories) {
-            const filePath = yield ioUtil.tryGetExecutablePath(directory + path2.sep + tool, extensions);
-            if (filePath) {
-              return filePath;
-            }
-          }
-          return "";
-        } catch (err) {
-          throw new Error(`which failed with message ${err.message}`);
-        }
-      });
-    }
-    exports2.which = which2;
-    function readCopyOptions(options) {
-      const force = options.force == null ? true : options.force;
-      const recursive = Boolean(options.recursive);
-      return { force, recursive };
-    }
-    function cpDirRecursive(sourceDir, destDir, currentDepth, force) {
-      return __awaiter(this, void 0, void 0, function* () {
-        if (currentDepth >= 255)
-          return;
-        currentDepth++;
-        yield mkdirP(destDir);
-        const files = yield ioUtil.readdir(sourceDir);
-        for (const fileName of files) {
-          const srcFile = `${sourceDir}/${fileName}`;
-          const destFile = `${destDir}/${fileName}`;
-          const srcFileStat = yield ioUtil.lstat(srcFile);
-          if (srcFileStat.isDirectory()) {
-            yield cpDirRecursive(srcFile, destFile, currentDepth, force);
-          } else {
-            yield copyFile(srcFile, destFile, force);
-          }
-        }
-        yield ioUtil.chmod(destDir, (yield ioUtil.stat(sourceDir)).mode);
-      });
-    }
-    function copyFile(srcFile, destFile, force) {
-      return __awaiter(this, void 0, void 0, function* () {
-        if ((yield ioUtil.lstat(srcFile)).isSymbolicLink()) {
-          try {
-            yield ioUtil.lstat(destFile);
+          yield ioUtil.lstat(destFile);
+          yield ioUtil.unlink(destFile);
+        } catch (e) {
+          if (e.code === "EPERM") {
+            yield ioUtil.chmod(destFile, "0666");
             yield ioUtil.unlink(destFile);
-          } catch (e) {
-            if (e.code === "EPERM") {
-              yield ioUtil.chmod(destFile, "0666");
-              yield ioUtil.unlink(destFile);
-            }
           }
-          const symlinkFull = yield ioUtil.readlink(srcFile);
-          yield ioUtil.symlink(symlinkFull, destFile, ioUtil.IS_WINDOWS ? "junction" : null);
-        } else if (!(yield ioUtil.exists(destFile)) || force) {
-          yield ioUtil.copyFile(srcFile, destFile);
         }
-      });
-    }
+        const symlinkFull = yield ioUtil.readlink(srcFile);
+        yield ioUtil.symlink(symlinkFull, destFile, ioUtil.IS_WINDOWS ? "junction" : null);
+      } else if (!(yield ioUtil.exists(destFile)) || force) {
+        yield ioUtil.copyFile(srcFile, destFile);
+      }
+    });
   }
 });
 
@@ -1703,7 +1690,7 @@ async function setupAsdf() {
   core.addPath(`${asdfDir}/bin`);
   core.addPath(`${asdfDir}/shims`);
   core.info(`Cloning asdf into ASDF_DIR: ${asdfDir}`);
-  const branch = core.getInput("asdf_branch", { required: true });
+  const branch = core.getInput("asdf_branch", {required: true});
   await exec.exec("git", [
     "clone",
     "--depth",
@@ -1740,7 +1727,7 @@ async function pluginList() {
 }
 async function pluginsAdd() {
   await setupAsdf();
-  let toolVersions = core2.getInput("tool_versions", { required: false });
+  let toolVersions = core2.getInput("tool_versions", {required: false});
   if (toolVersions) {
     await fs.promises.writeFile(".tool-versions", toolVersions, {
       encoding: "utf8"

--- a/setup/main.js
+++ b/setup/main.js
@@ -1,427 +1,403 @@
 var __create = Object.create;
 var __defProp = Object.defineProperty;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __getOwnPropNames = Object.getOwnPropertyNames;
 var __getProtoOf = Object.getPrototypeOf;
 var __hasOwnProp = Object.prototype.hasOwnProperty;
-var __getOwnPropNames = Object.getOwnPropertyNames;
-var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
-var __markAsModule = (target) => __defProp(target, "__esModule", {value: true});
-var __commonJS = (callback, module2) => () => {
-  if (!module2) {
-    module2 = {exports: {}};
-    callback(module2.exports, module2);
-  }
-  return module2.exports;
+var __markAsModule = (target) => __defProp(target, "__esModule", { value: true });
+var __commonJS = (cb, mod) => function __require() {
+  return mod || (0, cb[Object.keys(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports;
 };
-var __exportStar = (target, module2, desc) => {
-  __markAsModule(target);
+var __reExport = (target, module2, desc) => {
   if (module2 && typeof module2 === "object" || typeof module2 === "function") {
     for (let key of __getOwnPropNames(module2))
       if (!__hasOwnProp.call(target, key) && key !== "default")
-        __defProp(target, key, {get: () => module2[key], enumerable: !(desc = __getOwnPropDesc(module2, key)) || desc.enumerable});
+        __defProp(target, key, { get: () => module2[key], enumerable: !(desc = __getOwnPropDesc(module2, key)) || desc.enumerable });
   }
   return target;
 };
 var __toModule = (module2) => {
-  if (module2 && module2.__esModule)
-    return module2;
-  return __exportStar(__defProp(module2 != null ? __create(__getProtoOf(module2)) : {}, "default", {value: module2, enumerable: true}), module2);
+  return __reExport(__markAsModule(__defProp(module2 != null ? __create(__getProtoOf(module2)) : {}, "default", module2 && module2.__esModule && "default" in module2 ? { get: () => module2.default, enumerable: true } : { value: module2, enumerable: true })), module2);
 };
 
 // node_modules/@actions/core/lib/utils.js
-var require_utils = __commonJS((exports2) => {
-  "use strict";
-  Object.defineProperty(exports2, "__esModule", {value: true});
-  function toCommandValue(input) {
-    if (input === null || input === void 0) {
-      return "";
-    } else if (typeof input === "string" || input instanceof String) {
-      return input;
+var require_utils = __commonJS({
+  "node_modules/@actions/core/lib/utils.js"(exports2) {
+    "use strict";
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    function toCommandValue(input) {
+      if (input === null || input === void 0) {
+        return "";
+      } else if (typeof input === "string" || input instanceof String) {
+        return input;
+      }
+      return JSON.stringify(input);
     }
-    return JSON.stringify(input);
+    exports2.toCommandValue = toCommandValue;
   }
-  exports2.toCommandValue = toCommandValue;
 });
 
 // node_modules/@actions/core/lib/command.js
-var require_command = __commonJS((exports2) => {
-  "use strict";
-  var __importStar = exports2 && exports2.__importStar || function(mod) {
-    if (mod && mod.__esModule)
-      return mod;
-    var result = {};
-    if (mod != null) {
-      for (var k in mod)
-        if (Object.hasOwnProperty.call(mod, k))
-          result[k] = mod[k];
-    }
-    result["default"] = mod;
-    return result;
-  };
-  Object.defineProperty(exports2, "__esModule", {value: true});
-  var os2 = __importStar(require("os"));
-  var utils_1 = require_utils();
-  function issueCommand(command, properties, message) {
-    const cmd = new Command(command, properties, message);
-    process.stdout.write(cmd.toString() + os2.EOL);
-  }
-  exports2.issueCommand = issueCommand;
-  function issue(name, message = "") {
-    issueCommand(name, {}, message);
-  }
-  exports2.issue = issue;
-  var CMD_STRING = "::";
-  var Command = class {
-    constructor(command, properties, message) {
-      if (!command) {
-        command = "missing.command";
+var require_command = __commonJS({
+  "node_modules/@actions/core/lib/command.js"(exports2) {
+    "use strict";
+    var __importStar = exports2 && exports2.__importStar || function(mod) {
+      if (mod && mod.__esModule)
+        return mod;
+      var result = {};
+      if (mod != null) {
+        for (var k in mod)
+          if (Object.hasOwnProperty.call(mod, k))
+            result[k] = mod[k];
       }
-      this.command = command;
-      this.properties = properties;
-      this.message = message;
+      result["default"] = mod;
+      return result;
+    };
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    var os2 = __importStar(require("os"));
+    var utils_1 = require_utils();
+    function issueCommand(command, properties, message) {
+      const cmd = new Command(command, properties, message);
+      process.stdout.write(cmd.toString() + os2.EOL);
     }
-    toString() {
-      let cmdStr = CMD_STRING + this.command;
-      if (this.properties && Object.keys(this.properties).length > 0) {
-        cmdStr += " ";
-        let first = true;
-        for (const key in this.properties) {
-          if (this.properties.hasOwnProperty(key)) {
-            const val = this.properties[key];
-            if (val) {
-              if (first) {
-                first = false;
-              } else {
-                cmdStr += ",";
+    exports2.issueCommand = issueCommand;
+    function issue(name, message = "") {
+      issueCommand(name, {}, message);
+    }
+    exports2.issue = issue;
+    var CMD_STRING = "::";
+    var Command = class {
+      constructor(command, properties, message) {
+        if (!command) {
+          command = "missing.command";
+        }
+        this.command = command;
+        this.properties = properties;
+        this.message = message;
+      }
+      toString() {
+        let cmdStr = CMD_STRING + this.command;
+        if (this.properties && Object.keys(this.properties).length > 0) {
+          cmdStr += " ";
+          let first = true;
+          for (const key in this.properties) {
+            if (this.properties.hasOwnProperty(key)) {
+              const val = this.properties[key];
+              if (val) {
+                if (first) {
+                  first = false;
+                } else {
+                  cmdStr += ",";
+                }
+                cmdStr += `${key}=${escapeProperty(val)}`;
               }
-              cmdStr += `${key}=${escapeProperty(val)}`;
             }
           }
         }
+        cmdStr += `${CMD_STRING}${escapeData(this.message)}`;
+        return cmdStr;
       }
-      cmdStr += `${CMD_STRING}${escapeData(this.message)}`;
-      return cmdStr;
+    };
+    function escapeData(s) {
+      return utils_1.toCommandValue(s).replace(/%/g, "%25").replace(/\r/g, "%0D").replace(/\n/g, "%0A");
     }
-  };
-  function escapeData(s) {
-    return utils_1.toCommandValue(s).replace(/%/g, "%25").replace(/\r/g, "%0D").replace(/\n/g, "%0A");
-  }
-  function escapeProperty(s) {
-    return utils_1.toCommandValue(s).replace(/%/g, "%25").replace(/\r/g, "%0D").replace(/\n/g, "%0A").replace(/:/g, "%3A").replace(/,/g, "%2C");
+    function escapeProperty(s) {
+      return utils_1.toCommandValue(s).replace(/%/g, "%25").replace(/\r/g, "%0D").replace(/\n/g, "%0A").replace(/:/g, "%3A").replace(/,/g, "%2C");
+    }
   }
 });
 
 // node_modules/@actions/core/lib/file-command.js
-var require_file_command = __commonJS((exports2) => {
-  "use strict";
-  var __importStar = exports2 && exports2.__importStar || function(mod) {
-    if (mod && mod.__esModule)
-      return mod;
-    var result = {};
-    if (mod != null) {
-      for (var k in mod)
-        if (Object.hasOwnProperty.call(mod, k))
-          result[k] = mod[k];
+var require_file_command = __commonJS({
+  "node_modules/@actions/core/lib/file-command.js"(exports2) {
+    "use strict";
+    var __importStar = exports2 && exports2.__importStar || function(mod) {
+      if (mod && mod.__esModule)
+        return mod;
+      var result = {};
+      if (mod != null) {
+        for (var k in mod)
+          if (Object.hasOwnProperty.call(mod, k))
+            result[k] = mod[k];
+      }
+      result["default"] = mod;
+      return result;
+    };
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    var fs = __importStar(require("fs"));
+    var os2 = __importStar(require("os"));
+    var utils_1 = require_utils();
+    function issueCommand(command, message) {
+      const filePath = process.env[`GITHUB_${command}`];
+      if (!filePath) {
+        throw new Error(`Unable to find environment variable for file command ${command}`);
+      }
+      if (!fs.existsSync(filePath)) {
+        throw new Error(`Missing file at path: ${filePath}`);
+      }
+      fs.appendFileSync(filePath, `${utils_1.toCommandValue(message)}${os2.EOL}`, {
+        encoding: "utf8"
+      });
     }
-    result["default"] = mod;
-    return result;
-  };
-  Object.defineProperty(exports2, "__esModule", {value: true});
-  var fs = __importStar(require("fs"));
-  var os2 = __importStar(require("os"));
-  var utils_1 = require_utils();
-  function issueCommand(command, message) {
-    const filePath = process.env[`GITHUB_${command}`];
-    if (!filePath) {
-      throw new Error(`Unable to find environment variable for file command ${command}`);
-    }
-    if (!fs.existsSync(filePath)) {
-      throw new Error(`Missing file at path: ${filePath}`);
-    }
-    fs.appendFileSync(filePath, `${utils_1.toCommandValue(message)}${os2.EOL}`, {
-      encoding: "utf8"
-    });
+    exports2.issueCommand = issueCommand;
   }
-  exports2.issueCommand = issueCommand;
 });
 
 // node_modules/@actions/core/lib/core.js
-var require_core = __commonJS((exports2) => {
-  "use strict";
-  var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
-    function adopt(value) {
-      return value instanceof P ? value : new P(function(resolve) {
-        resolve(value);
+var require_core = __commonJS({
+  "node_modules/@actions/core/lib/core.js"(exports2) {
+    "use strict";
+    var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve) {
+          resolve(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+      });
+    };
+    var __importStar = exports2 && exports2.__importStar || function(mod) {
+      if (mod && mod.__esModule)
+        return mod;
+      var result = {};
+      if (mod != null) {
+        for (var k in mod)
+          if (Object.hasOwnProperty.call(mod, k))
+            result[k] = mod[k];
+      }
+      result["default"] = mod;
+      return result;
+    };
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    var command_1 = require_command();
+    var file_command_1 = require_file_command();
+    var utils_1 = require_utils();
+    var os2 = __importStar(require("os"));
+    var path2 = __importStar(require("path"));
+    var ExitCode;
+    (function(ExitCode2) {
+      ExitCode2[ExitCode2["Success"] = 0] = "Success";
+      ExitCode2[ExitCode2["Failure"] = 1] = "Failure";
+    })(ExitCode = exports2.ExitCode || (exports2.ExitCode = {}));
+    function exportVariable2(name, val) {
+      const convertedVal = utils_1.toCommandValue(val);
+      process.env[name] = convertedVal;
+      const filePath = process.env["GITHUB_ENV"] || "";
+      if (filePath) {
+        const delimiter = "_GitHubActionsFileCommandDelimeter_";
+        const commandValue = `${name}<<${delimiter}${os2.EOL}${convertedVal}${os2.EOL}${delimiter}`;
+        file_command_1.issueCommand("ENV", commandValue);
+      } else {
+        command_1.issueCommand("set-env", { name }, convertedVal);
+      }
+    }
+    exports2.exportVariable = exportVariable2;
+    function setSecret(secret) {
+      command_1.issueCommand("add-mask", {}, secret);
+    }
+    exports2.setSecret = setSecret;
+    function addPath2(inputPath) {
+      const filePath = process.env["GITHUB_PATH"] || "";
+      if (filePath) {
+        file_command_1.issueCommand("PATH", inputPath);
+      } else {
+        command_1.issueCommand("add-path", {}, inputPath);
+      }
+      process.env["PATH"] = `${inputPath}${path2.delimiter}${process.env["PATH"]}`;
+    }
+    exports2.addPath = addPath2;
+    function getInput2(name, options) {
+      const val = process.env[`INPUT_${name.replace(/ /g, "_").toUpperCase()}`] || "";
+      if (options && options.required && !val) {
+        throw new Error(`Input required and not supplied: ${name}`);
+      }
+      return val.trim();
+    }
+    exports2.getInput = getInput2;
+    function setOutput(name, value) {
+      command_1.issueCommand("set-output", { name }, value);
+    }
+    exports2.setOutput = setOutput;
+    function setCommandEcho(enabled) {
+      command_1.issue("echo", enabled ? "on" : "off");
+    }
+    exports2.setCommandEcho = setCommandEcho;
+    function setFailed2(message) {
+      process.exitCode = ExitCode.Failure;
+      error(message);
+    }
+    exports2.setFailed = setFailed2;
+    function isDebug() {
+      return process.env["RUNNER_DEBUG"] === "1";
+    }
+    exports2.isDebug = isDebug;
+    function debug(message) {
+      command_1.issueCommand("debug", {}, message);
+    }
+    exports2.debug = debug;
+    function error(message) {
+      command_1.issue("error", message instanceof Error ? message.toString() : message);
+    }
+    exports2.error = error;
+    function warning(message) {
+      command_1.issue("warning", message instanceof Error ? message.toString() : message);
+    }
+    exports2.warning = warning;
+    function info2(message) {
+      process.stdout.write(message + os2.EOL);
+    }
+    exports2.info = info2;
+    function startGroup(name) {
+      command_1.issue("group", name);
+    }
+    exports2.startGroup = startGroup;
+    function endGroup() {
+      command_1.issue("endgroup");
+    }
+    exports2.endGroup = endGroup;
+    function group(name, fn) {
+      return __awaiter(this, void 0, void 0, function* () {
+        startGroup(name);
+        let result;
+        try {
+          result = yield fn();
+        } finally {
+          endGroup();
+        }
+        return result;
       });
     }
-    return new (P || (P = Promise))(function(resolve, reject) {
-      function fulfilled(value) {
-        try {
-          step(generator.next(value));
-        } catch (e) {
-          reject(e);
-        }
-      }
-      function rejected(value) {
-        try {
-          step(generator["throw"](value));
-        } catch (e) {
-          reject(e);
-        }
-      }
-      function step(result) {
-        result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
-      }
-      step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-  };
-  var __importStar = exports2 && exports2.__importStar || function(mod) {
-    if (mod && mod.__esModule)
-      return mod;
-    var result = {};
-    if (mod != null) {
-      for (var k in mod)
-        if (Object.hasOwnProperty.call(mod, k))
-          result[k] = mod[k];
+    exports2.group = group;
+    function saveState(name, value) {
+      command_1.issueCommand("save-state", { name }, value);
     }
-    result["default"] = mod;
-    return result;
-  };
-  Object.defineProperty(exports2, "__esModule", {value: true});
-  var command_1 = require_command();
-  var file_command_1 = require_file_command();
-  var utils_1 = require_utils();
-  var os2 = __importStar(require("os"));
-  var path2 = __importStar(require("path"));
-  var ExitCode;
-  (function(ExitCode2) {
-    ExitCode2[ExitCode2["Success"] = 0] = "Success";
-    ExitCode2[ExitCode2["Failure"] = 1] = "Failure";
-  })(ExitCode = exports2.ExitCode || (exports2.ExitCode = {}));
-  function exportVariable2(name, val) {
-    const convertedVal = utils_1.toCommandValue(val);
-    process.env[name] = convertedVal;
-    const filePath = process.env["GITHUB_ENV"] || "";
-    if (filePath) {
-      const delimiter = "_GitHubActionsFileCommandDelimeter_";
-      const commandValue = `${name}<<${delimiter}${os2.EOL}${convertedVal}${os2.EOL}${delimiter}`;
-      file_command_1.issueCommand("ENV", commandValue);
-    } else {
-      command_1.issueCommand("set-env", {name}, convertedVal);
+    exports2.saveState = saveState;
+    function getState(name) {
+      return process.env[`STATE_${name}`] || "";
     }
+    exports2.getState = getState;
   }
-  exports2.exportVariable = exportVariable2;
-  function setSecret(secret) {
-    command_1.issueCommand("add-mask", {}, secret);
-  }
-  exports2.setSecret = setSecret;
-  function addPath2(inputPath) {
-    const filePath = process.env["GITHUB_PATH"] || "";
-    if (filePath) {
-      file_command_1.issueCommand("PATH", inputPath);
-    } else {
-      command_1.issueCommand("add-path", {}, inputPath);
-    }
-    process.env["PATH"] = `${inputPath}${path2.delimiter}${process.env["PATH"]}`;
-  }
-  exports2.addPath = addPath2;
-  function getInput2(name, options) {
-    const val = process.env[`INPUT_${name.replace(/ /g, "_").toUpperCase()}`] || "";
-    if (options && options.required && !val) {
-      throw new Error(`Input required and not supplied: ${name}`);
-    }
-    return val.trim();
-  }
-  exports2.getInput = getInput2;
-  function setOutput(name, value) {
-    command_1.issueCommand("set-output", {name}, value);
-  }
-  exports2.setOutput = setOutput;
-  function setCommandEcho(enabled) {
-    command_1.issue("echo", enabled ? "on" : "off");
-  }
-  exports2.setCommandEcho = setCommandEcho;
-  function setFailed2(message) {
-    process.exitCode = ExitCode.Failure;
-    error(message);
-  }
-  exports2.setFailed = setFailed2;
-  function isDebug() {
-    return process.env["RUNNER_DEBUG"] === "1";
-  }
-  exports2.isDebug = isDebug;
-  function debug(message) {
-    command_1.issueCommand("debug", {}, message);
-  }
-  exports2.debug = debug;
-  function error(message) {
-    command_1.issue("error", message instanceof Error ? message.toString() : message);
-  }
-  exports2.error = error;
-  function warning(message) {
-    command_1.issue("warning", message instanceof Error ? message.toString() : message);
-  }
-  exports2.warning = warning;
-  function info2(message) {
-    process.stdout.write(message + os2.EOL);
-  }
-  exports2.info = info2;
-  function startGroup(name) {
-    command_1.issue("group", name);
-  }
-  exports2.startGroup = startGroup;
-  function endGroup() {
-    command_1.issue("endgroup");
-  }
-  exports2.endGroup = endGroup;
-  function group(name, fn) {
-    return __awaiter(this, void 0, void 0, function* () {
-      startGroup(name);
-      let result;
-      try {
-        result = yield fn();
-      } finally {
-        endGroup();
-      }
-      return result;
-    });
-  }
-  exports2.group = group;
-  function saveState(name, value) {
-    command_1.issueCommand("save-state", {name}, value);
-  }
-  exports2.saveState = saveState;
-  function getState(name) {
-    return process.env[`STATE_${name}`] || "";
-  }
-  exports2.getState = getState;
 });
 
-// node_modules/@actions/io/lib/io-util.js
-var require_io_util = __commonJS((exports2) => {
-  "use strict";
-  var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
-    function adopt(value) {
-      return value instanceof P ? value : new P(function(resolve) {
-        resolve(value);
+// node_modules/@actions/exec/node_modules/@actions/io/lib/io-util.js
+var require_io_util = __commonJS({
+  "node_modules/@actions/exec/node_modules/@actions/io/lib/io-util.js"(exports2) {
+    "use strict";
+    var __createBinding = exports2 && exports2.__createBinding || (Object.create ? function(o, m, k, k2) {
+      if (k2 === void 0)
+        k2 = k;
+      Object.defineProperty(o, k2, { enumerable: true, get: function() {
+        return m[k];
+      } });
+    } : function(o, m, k, k2) {
+      if (k2 === void 0)
+        k2 = k;
+      o[k2] = m[k];
+    });
+    var __setModuleDefault = exports2 && exports2.__setModuleDefault || (Object.create ? function(o, v) {
+      Object.defineProperty(o, "default", { enumerable: true, value: v });
+    } : function(o, v) {
+      o["default"] = v;
+    });
+    var __importStar = exports2 && exports2.__importStar || function(mod) {
+      if (mod && mod.__esModule)
+        return mod;
+      var result = {};
+      if (mod != null) {
+        for (var k in mod)
+          if (k !== "default" && Object.hasOwnProperty.call(mod, k))
+            __createBinding(result, mod, k);
+      }
+      __setModuleDefault(result, mod);
+      return result;
+    };
+    var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve) {
+          resolve(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+      });
+    };
+    var _a;
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    exports2.getCmdPath = exports2.tryGetExecutablePath = exports2.isRooted = exports2.isDirectory = exports2.exists = exports2.IS_WINDOWS = exports2.unlink = exports2.symlink = exports2.stat = exports2.rmdir = exports2.rename = exports2.readlink = exports2.readdir = exports2.mkdir = exports2.lstat = exports2.copyFile = exports2.chmod = void 0;
+    var fs = __importStar(require("fs"));
+    var path2 = __importStar(require("path"));
+    _a = fs.promises, exports2.chmod = _a.chmod, exports2.copyFile = _a.copyFile, exports2.lstat = _a.lstat, exports2.mkdir = _a.mkdir, exports2.readdir = _a.readdir, exports2.readlink = _a.readlink, exports2.rename = _a.rename, exports2.rmdir = _a.rmdir, exports2.stat = _a.stat, exports2.symlink = _a.symlink, exports2.unlink = _a.unlink;
+    exports2.IS_WINDOWS = process.platform === "win32";
+    function exists(fsPath) {
+      return __awaiter(this, void 0, void 0, function* () {
+        try {
+          yield exports2.stat(fsPath);
+        } catch (err) {
+          if (err.code === "ENOENT") {
+            return false;
+          }
+          throw err;
+        }
+        return true;
       });
     }
-    return new (P || (P = Promise))(function(resolve, reject) {
-      function fulfilled(value) {
-        try {
-          step(generator.next(value));
-        } catch (e) {
-          reject(e);
-        }
-      }
-      function rejected(value) {
-        try {
-          step(generator["throw"](value));
-        } catch (e) {
-          reject(e);
-        }
-      }
-      function step(result) {
-        result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
-      }
-      step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-  };
-  var _a;
-  Object.defineProperty(exports2, "__esModule", {value: true});
-  var assert_1 = require("assert");
-  var fs = require("fs");
-  var path2 = require("path");
-  _a = fs.promises, exports2.chmod = _a.chmod, exports2.copyFile = _a.copyFile, exports2.lstat = _a.lstat, exports2.mkdir = _a.mkdir, exports2.readdir = _a.readdir, exports2.readlink = _a.readlink, exports2.rename = _a.rename, exports2.rmdir = _a.rmdir, exports2.stat = _a.stat, exports2.symlink = _a.symlink, exports2.unlink = _a.unlink;
-  exports2.IS_WINDOWS = process.platform === "win32";
-  function exists(fsPath) {
-    return __awaiter(this, void 0, void 0, function* () {
-      try {
-        yield exports2.stat(fsPath);
-      } catch (err) {
-        if (err.code === "ENOENT") {
-          return false;
-        }
-        throw err;
-      }
-      return true;
-    });
-  }
-  exports2.exists = exists;
-  function isDirectory(fsPath, useStat = false) {
-    return __awaiter(this, void 0, void 0, function* () {
-      const stats = useStat ? yield exports2.stat(fsPath) : yield exports2.lstat(fsPath);
-      return stats.isDirectory();
-    });
-  }
-  exports2.isDirectory = isDirectory;
-  function isRooted(p) {
-    p = normalizeSeparators(p);
-    if (!p) {
-      throw new Error('isRooted() parameter "p" cannot be empty');
+    exports2.exists = exists;
+    function isDirectory(fsPath, useStat = false) {
+      return __awaiter(this, void 0, void 0, function* () {
+        const stats = useStat ? yield exports2.stat(fsPath) : yield exports2.lstat(fsPath);
+        return stats.isDirectory();
+      });
     }
-    if (exports2.IS_WINDOWS) {
-      return p.startsWith("\\") || /^[A-Z]:/i.test(p);
+    exports2.isDirectory = isDirectory;
+    function isRooted(p) {
+      p = normalizeSeparators(p);
+      if (!p) {
+        throw new Error('isRooted() parameter "p" cannot be empty');
+      }
+      if (exports2.IS_WINDOWS) {
+        return p.startsWith("\\") || /^[A-Z]:/i.test(p);
+      }
+      return p.startsWith("/");
     }
-    return p.startsWith("/");
-  }
-  exports2.isRooted = isRooted;
-  function mkdirP(fsPath, maxDepth = 1e3, depth = 1) {
-    return __awaiter(this, void 0, void 0, function* () {
-      assert_1.ok(fsPath, "a path argument must be provided");
-      fsPath = path2.resolve(fsPath);
-      if (depth >= maxDepth)
-        return exports2.mkdir(fsPath);
-      try {
-        yield exports2.mkdir(fsPath);
-        return;
-      } catch (err) {
-        switch (err.code) {
-          case "ENOENT": {
-            yield mkdirP(path2.dirname(fsPath), maxDepth, depth + 1);
-            yield exports2.mkdir(fsPath);
-            return;
-          }
-          default: {
-            let stats;
-            try {
-              stats = yield exports2.stat(fsPath);
-            } catch (err2) {
-              throw err;
-            }
-            if (!stats.isDirectory())
-              throw err;
-          }
-        }
-      }
-    });
-  }
-  exports2.mkdirP = mkdirP;
-  function tryGetExecutablePath(filePath, extensions) {
-    return __awaiter(this, void 0, void 0, function* () {
-      let stats = void 0;
-      try {
-        stats = yield exports2.stat(filePath);
-      } catch (err) {
-        if (err.code !== "ENOENT") {
-          console.log(`Unexpected error attempting to determine if executable file exists '${filePath}': ${err}`);
-        }
-      }
-      if (stats && stats.isFile()) {
-        if (exports2.IS_WINDOWS) {
-          const upperExt = path2.extname(filePath).toUpperCase();
-          if (extensions.some((validExt) => validExt.toUpperCase() === upperExt)) {
-            return filePath;
-          }
-        } else {
-          if (isUnixExecutable(stats)) {
-            return filePath;
-          }
-        }
-      }
-      const originalFilePath = filePath;
-      for (const extension of extensions) {
-        filePath = originalFilePath + extension;
-        stats = void 0;
+    exports2.isRooted = isRooted;
+    function tryGetExecutablePath(filePath, extensions) {
+      return __awaiter(this, void 0, void 0, function* () {
+        let stats = void 0;
         try {
           stats = yield exports2.stat(filePath);
         } catch (err) {
@@ -431,189 +407,272 @@ var require_io_util = __commonJS((exports2) => {
         }
         if (stats && stats.isFile()) {
           if (exports2.IS_WINDOWS) {
-            try {
-              const directory = path2.dirname(filePath);
-              const upperName = path2.basename(filePath).toUpperCase();
-              for (const actualName of yield exports2.readdir(directory)) {
-                if (upperName === actualName.toUpperCase()) {
-                  filePath = path2.join(directory, actualName);
-                  break;
-                }
-              }
-            } catch (err) {
-              console.log(`Unexpected error attempting to determine the actual case of the file '${filePath}': ${err}`);
+            const upperExt = path2.extname(filePath).toUpperCase();
+            if (extensions.some((validExt) => validExt.toUpperCase() === upperExt)) {
+              return filePath;
             }
-            return filePath;
           } else {
             if (isUnixExecutable(stats)) {
               return filePath;
             }
           }
         }
-      }
-      return "";
-    });
-  }
-  exports2.tryGetExecutablePath = tryGetExecutablePath;
-  function normalizeSeparators(p) {
-    p = p || "";
-    if (exports2.IS_WINDOWS) {
-      p = p.replace(/\//g, "\\");
-      return p.replace(/\\\\+/g, "\\");
+        const originalFilePath = filePath;
+        for (const extension of extensions) {
+          filePath = originalFilePath + extension;
+          stats = void 0;
+          try {
+            stats = yield exports2.stat(filePath);
+          } catch (err) {
+            if (err.code !== "ENOENT") {
+              console.log(`Unexpected error attempting to determine if executable file exists '${filePath}': ${err}`);
+            }
+          }
+          if (stats && stats.isFile()) {
+            if (exports2.IS_WINDOWS) {
+              try {
+                const directory = path2.dirname(filePath);
+                const upperName = path2.basename(filePath).toUpperCase();
+                for (const actualName of yield exports2.readdir(directory)) {
+                  if (upperName === actualName.toUpperCase()) {
+                    filePath = path2.join(directory, actualName);
+                    break;
+                  }
+                }
+              } catch (err) {
+                console.log(`Unexpected error attempting to determine the actual case of the file '${filePath}': ${err}`);
+              }
+              return filePath;
+            } else {
+              if (isUnixExecutable(stats)) {
+                return filePath;
+              }
+            }
+          }
+        }
+        return "";
+      });
     }
-    return p.replace(/\/\/+/g, "/");
-  }
-  function isUnixExecutable(stats) {
-    return (stats.mode & 1) > 0 || (stats.mode & 8) > 0 && stats.gid === process.getgid() || (stats.mode & 64) > 0 && stats.uid === process.getuid();
+    exports2.tryGetExecutablePath = tryGetExecutablePath;
+    function normalizeSeparators(p) {
+      p = p || "";
+      if (exports2.IS_WINDOWS) {
+        p = p.replace(/\//g, "\\");
+        return p.replace(/\\\\+/g, "\\");
+      }
+      return p.replace(/\/\/+/g, "/");
+    }
+    function isUnixExecutable(stats) {
+      return (stats.mode & 1) > 0 || (stats.mode & 8) > 0 && stats.gid === process.getgid() || (stats.mode & 64) > 0 && stats.uid === process.getuid();
+    }
+    function getCmdPath() {
+      var _a2;
+      return (_a2 = process.env["COMSPEC"]) !== null && _a2 !== void 0 ? _a2 : `cmd.exe`;
+    }
+    exports2.getCmdPath = getCmdPath;
   }
 });
 
-// node_modules/@actions/io/lib/io.js
-var require_io = __commonJS((exports2) => {
-  "use strict";
-  var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
-    function adopt(value) {
-      return value instanceof P ? value : new P(function(resolve) {
-        resolve(value);
+// node_modules/@actions/exec/node_modules/@actions/io/lib/io.js
+var require_io = __commonJS({
+  "node_modules/@actions/exec/node_modules/@actions/io/lib/io.js"(exports2) {
+    "use strict";
+    var __createBinding = exports2 && exports2.__createBinding || (Object.create ? function(o, m, k, k2) {
+      if (k2 === void 0)
+        k2 = k;
+      Object.defineProperty(o, k2, { enumerable: true, get: function() {
+        return m[k];
+      } });
+    } : function(o, m, k, k2) {
+      if (k2 === void 0)
+        k2 = k;
+      o[k2] = m[k];
+    });
+    var __setModuleDefault = exports2 && exports2.__setModuleDefault || (Object.create ? function(o, v) {
+      Object.defineProperty(o, "default", { enumerable: true, value: v });
+    } : function(o, v) {
+      o["default"] = v;
+    });
+    var __importStar = exports2 && exports2.__importStar || function(mod) {
+      if (mod && mod.__esModule)
+        return mod;
+      var result = {};
+      if (mod != null) {
+        for (var k in mod)
+          if (k !== "default" && Object.hasOwnProperty.call(mod, k))
+            __createBinding(result, mod, k);
+      }
+      __setModuleDefault(result, mod);
+      return result;
+    };
+    var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve) {
+          resolve(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
-    }
-    return new (P || (P = Promise))(function(resolve, reject) {
-      function fulfilled(value) {
-        try {
-          step(generator.next(value));
-        } catch (e) {
-          reject(e);
-        }
-      }
-      function rejected(value) {
-        try {
-          step(generator["throw"](value));
-        } catch (e) {
-          reject(e);
-        }
-      }
-      function step(result) {
-        result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
-      }
-      step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-  };
-  Object.defineProperty(exports2, "__esModule", {value: true});
-  var childProcess = require("child_process");
-  var path2 = require("path");
-  var util_1 = require("util");
-  var ioUtil = require_io_util();
-  var exec3 = util_1.promisify(childProcess.exec);
-  function cp(source, dest, options = {}) {
-    return __awaiter(this, void 0, void 0, function* () {
-      const {force, recursive} = readCopyOptions(options);
-      const destStat = (yield ioUtil.exists(dest)) ? yield ioUtil.stat(dest) : null;
-      if (destStat && destStat.isFile() && !force) {
-        return;
-      }
-      const newDest = destStat && destStat.isDirectory() ? path2.join(dest, path2.basename(source)) : dest;
-      if (!(yield ioUtil.exists(source))) {
-        throw new Error(`no such file or directory: ${source}`);
-      }
-      const sourceStat = yield ioUtil.stat(source);
-      if (sourceStat.isDirectory()) {
-        if (!recursive) {
-          throw new Error(`Failed to copy. ${source} is a directory, but tried to copy without recursive flag.`);
-        } else {
-          yield cpDirRecursive(source, newDest, 0, force);
-        }
-      } else {
-        if (path2.relative(source, newDest) === "") {
-          throw new Error(`'${newDest}' and '${source}' are the same file`);
-        }
-        yield copyFile(source, newDest, force);
-      }
-    });
-  }
-  exports2.cp = cp;
-  function mv(source, dest, options = {}) {
-    return __awaiter(this, void 0, void 0, function* () {
-      if (yield ioUtil.exists(dest)) {
-        let destExists = true;
-        if (yield ioUtil.isDirectory(dest)) {
-          dest = path2.join(dest, path2.basename(source));
-          destExists = yield ioUtil.exists(dest);
-        }
-        if (destExists) {
-          if (options.force == null || options.force) {
-            yield rmRF(dest);
-          } else {
-            throw new Error("Destination already exists");
-          }
-        }
-      }
-      yield mkdirP(path2.dirname(dest));
-      yield ioUtil.rename(source, dest);
-    });
-  }
-  exports2.mv = mv;
-  function rmRF(inputPath) {
-    return __awaiter(this, void 0, void 0, function* () {
-      if (ioUtil.IS_WINDOWS) {
-        try {
-          if (yield ioUtil.isDirectory(inputPath, true)) {
-            yield exec3(`rd /s /q "${inputPath}"`);
-          } else {
-            yield exec3(`del /f /a "${inputPath}"`);
-          }
-        } catch (err) {
-          if (err.code !== "ENOENT")
-            throw err;
-        }
-        try {
-          yield ioUtil.unlink(inputPath);
-        } catch (err) {
-          if (err.code !== "ENOENT")
-            throw err;
-        }
-      } else {
-        let isDir = false;
-        try {
-          isDir = yield ioUtil.isDirectory(inputPath);
-        } catch (err) {
-          if (err.code !== "ENOENT")
-            throw err;
+    };
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    exports2.findInPath = exports2.which = exports2.mkdirP = exports2.rmRF = exports2.mv = exports2.cp = void 0;
+    var assert_1 = require("assert");
+    var childProcess = __importStar(require("child_process"));
+    var path2 = __importStar(require("path"));
+    var util_1 = require("util");
+    var ioUtil = __importStar(require_io_util());
+    var exec3 = util_1.promisify(childProcess.exec);
+    var execFile = util_1.promisify(childProcess.execFile);
+    function cp(source, dest, options = {}) {
+      return __awaiter(this, void 0, void 0, function* () {
+        const { force, recursive, copySourceDirectory } = readCopyOptions(options);
+        const destStat = (yield ioUtil.exists(dest)) ? yield ioUtil.stat(dest) : null;
+        if (destStat && destStat.isFile() && !force) {
           return;
         }
-        if (isDir) {
-          yield exec3(`rm -rf "${inputPath}"`);
-        } else {
-          yield ioUtil.unlink(inputPath);
+        const newDest = destStat && destStat.isDirectory() && copySourceDirectory ? path2.join(dest, path2.basename(source)) : dest;
+        if (!(yield ioUtil.exists(source))) {
+          throw new Error(`no such file or directory: ${source}`);
         }
-      }
-    });
-  }
-  exports2.rmRF = rmRF;
-  function mkdirP(fsPath) {
-    return __awaiter(this, void 0, void 0, function* () {
-      yield ioUtil.mkdirP(fsPath);
-    });
-  }
-  exports2.mkdirP = mkdirP;
-  function which2(tool, check) {
-    return __awaiter(this, void 0, void 0, function* () {
-      if (!tool) {
-        throw new Error("parameter 'tool' is required");
-      }
-      if (check) {
-        const result = yield which2(tool, false);
-        if (!result) {
-          if (ioUtil.IS_WINDOWS) {
-            throw new Error(`Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also verify the file has a valid extension for an executable file.`);
+        const sourceStat = yield ioUtil.stat(source);
+        if (sourceStat.isDirectory()) {
+          if (!recursive) {
+            throw new Error(`Failed to copy. ${source} is a directory, but tried to copy without recursive flag.`);
           } else {
-            throw new Error(`Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also check the file mode to verify the file is executable.`);
+            yield cpDirRecursive(source, newDest, 0, force);
+          }
+        } else {
+          if (path2.relative(source, newDest) === "") {
+            throw new Error(`'${newDest}' and '${source}' are the same file`);
+          }
+          yield copyFile(source, newDest, force);
+        }
+      });
+    }
+    exports2.cp = cp;
+    function mv(source, dest, options = {}) {
+      return __awaiter(this, void 0, void 0, function* () {
+        if (yield ioUtil.exists(dest)) {
+          let destExists = true;
+          if (yield ioUtil.isDirectory(dest)) {
+            dest = path2.join(dest, path2.basename(source));
+            destExists = yield ioUtil.exists(dest);
+          }
+          if (destExists) {
+            if (options.force == null || options.force) {
+              yield rmRF(dest);
+            } else {
+              throw new Error("Destination already exists");
+            }
           }
         }
-      }
-      try {
+        yield mkdirP(path2.dirname(dest));
+        yield ioUtil.rename(source, dest);
+      });
+    }
+    exports2.mv = mv;
+    function rmRF(inputPath) {
+      return __awaiter(this, void 0, void 0, function* () {
+        if (ioUtil.IS_WINDOWS) {
+          if (/[*"<>|]/.test(inputPath)) {
+            throw new Error('File path must not contain `*`, `"`, `<`, `>` or `|` on Windows');
+          }
+          try {
+            const cmdPath = ioUtil.getCmdPath();
+            if (yield ioUtil.isDirectory(inputPath, true)) {
+              yield exec3(`${cmdPath} /s /c "rd /s /q "%inputPath%""`, {
+                env: { inputPath }
+              });
+            } else {
+              yield exec3(`${cmdPath} /s /c "del /f /a "%inputPath%""`, {
+                env: { inputPath }
+              });
+            }
+          } catch (err) {
+            if (err.code !== "ENOENT")
+              throw err;
+          }
+          try {
+            yield ioUtil.unlink(inputPath);
+          } catch (err) {
+            if (err.code !== "ENOENT")
+              throw err;
+          }
+        } else {
+          let isDir = false;
+          try {
+            isDir = yield ioUtil.isDirectory(inputPath);
+          } catch (err) {
+            if (err.code !== "ENOENT")
+              throw err;
+            return;
+          }
+          if (isDir) {
+            yield execFile(`rm`, [`-rf`, `${inputPath}`]);
+          } else {
+            yield ioUtil.unlink(inputPath);
+          }
+        }
+      });
+    }
+    exports2.rmRF = rmRF;
+    function mkdirP(fsPath) {
+      return __awaiter(this, void 0, void 0, function* () {
+        assert_1.ok(fsPath, "a path argument must be provided");
+        yield ioUtil.mkdir(fsPath, { recursive: true });
+      });
+    }
+    exports2.mkdirP = mkdirP;
+    function which2(tool, check) {
+      return __awaiter(this, void 0, void 0, function* () {
+        if (!tool) {
+          throw new Error("parameter 'tool' is required");
+        }
+        if (check) {
+          const result = yield which2(tool, false);
+          if (!result) {
+            if (ioUtil.IS_WINDOWS) {
+              throw new Error(`Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also verify the file has a valid extension for an executable file.`);
+            } else {
+              throw new Error(`Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also check the file mode to verify the file is executable.`);
+            }
+          }
+          return result;
+        }
+        const matches = yield findInPath(tool);
+        if (matches && matches.length > 0) {
+          return matches[0];
+        }
+        return "";
+      });
+    }
+    exports2.which = which2;
+    function findInPath(tool) {
+      return __awaiter(this, void 0, void 0, function* () {
+        if (!tool) {
+          throw new Error("parameter 'tool' is required");
+        }
         const extensions = [];
-        if (ioUtil.IS_WINDOWS && process.env.PATHEXT) {
-          for (const extension of process.env.PATHEXT.split(path2.delimiter)) {
+        if (ioUtil.IS_WINDOWS && process.env["PATHEXT"]) {
+          for (const extension of process.env["PATHEXT"].split(path2.delimiter)) {
             if (extension) {
               extensions.push(extension);
             }
@@ -622,12 +681,12 @@ var require_io = __commonJS((exports2) => {
         if (ioUtil.isRooted(tool)) {
           const filePath = yield ioUtil.tryGetExecutablePath(tool, extensions);
           if (filePath) {
-            return filePath;
+            return [filePath];
           }
-          return "";
+          return [];
         }
-        if (tool.includes("/") || ioUtil.IS_WINDOWS && tool.includes("\\")) {
-          return "";
+        if (tool.includes(path2.sep)) {
+          return [];
         }
         const directories = [];
         if (process.env.PATH) {
@@ -637,578 +696,986 @@ var require_io = __commonJS((exports2) => {
             }
           }
         }
+        const matches = [];
         for (const directory of directories) {
-          const filePath = yield ioUtil.tryGetExecutablePath(directory + path2.sep + tool, extensions);
+          const filePath = yield ioUtil.tryGetExecutablePath(path2.join(directory, tool), extensions);
           if (filePath) {
-            return filePath;
+            matches.push(filePath);
           }
         }
-        return "";
-      } catch (err) {
-        throw new Error(`which failed with message ${err.message}`);
-      }
-    });
-  }
-  exports2.which = which2;
-  function readCopyOptions(options) {
-    const force = options.force == null ? true : options.force;
-    const recursive = Boolean(options.recursive);
-    return {force, recursive};
-  }
-  function cpDirRecursive(sourceDir, destDir, currentDepth, force) {
-    return __awaiter(this, void 0, void 0, function* () {
-      if (currentDepth >= 255)
-        return;
-      currentDepth++;
-      yield mkdirP(destDir);
-      const files = yield ioUtil.readdir(sourceDir);
-      for (const fileName of files) {
-        const srcFile = `${sourceDir}/${fileName}`;
-        const destFile = `${destDir}/${fileName}`;
-        const srcFileStat = yield ioUtil.lstat(srcFile);
-        if (srcFileStat.isDirectory()) {
-          yield cpDirRecursive(srcFile, destFile, currentDepth, force);
-        } else {
-          yield copyFile(srcFile, destFile, force);
+        return matches;
+      });
+    }
+    exports2.findInPath = findInPath;
+    function readCopyOptions(options) {
+      const force = options.force == null ? true : options.force;
+      const recursive = Boolean(options.recursive);
+      const copySourceDirectory = options.copySourceDirectory == null ? true : Boolean(options.copySourceDirectory);
+      return { force, recursive, copySourceDirectory };
+    }
+    function cpDirRecursive(sourceDir, destDir, currentDepth, force) {
+      return __awaiter(this, void 0, void 0, function* () {
+        if (currentDepth >= 255)
+          return;
+        currentDepth++;
+        yield mkdirP(destDir);
+        const files = yield ioUtil.readdir(sourceDir);
+        for (const fileName of files) {
+          const srcFile = `${sourceDir}/${fileName}`;
+          const destFile = `${destDir}/${fileName}`;
+          const srcFileStat = yield ioUtil.lstat(srcFile);
+          if (srcFileStat.isDirectory()) {
+            yield cpDirRecursive(srcFile, destFile, currentDepth, force);
+          } else {
+            yield copyFile(srcFile, destFile, force);
+          }
         }
-      }
-      yield ioUtil.chmod(destDir, (yield ioUtil.stat(sourceDir)).mode);
-    });
-  }
-  function copyFile(srcFile, destFile, force) {
-    return __awaiter(this, void 0, void 0, function* () {
-      if ((yield ioUtil.lstat(srcFile)).isSymbolicLink()) {
-        try {
-          yield ioUtil.lstat(destFile);
-          yield ioUtil.unlink(destFile);
-        } catch (e) {
-          if (e.code === "EPERM") {
-            yield ioUtil.chmod(destFile, "0666");
+        yield ioUtil.chmod(destDir, (yield ioUtil.stat(sourceDir)).mode);
+      });
+    }
+    function copyFile(srcFile, destFile, force) {
+      return __awaiter(this, void 0, void 0, function* () {
+        if ((yield ioUtil.lstat(srcFile)).isSymbolicLink()) {
+          try {
+            yield ioUtil.lstat(destFile);
             yield ioUtil.unlink(destFile);
+          } catch (e) {
+            if (e.code === "EPERM") {
+              yield ioUtil.chmod(destFile, "0666");
+              yield ioUtil.unlink(destFile);
+            }
           }
+          const symlinkFull = yield ioUtil.readlink(srcFile);
+          yield ioUtil.symlink(symlinkFull, destFile, ioUtil.IS_WINDOWS ? "junction" : null);
+        } else if (!(yield ioUtil.exists(destFile)) || force) {
+          yield ioUtil.copyFile(srcFile, destFile);
         }
-        const symlinkFull = yield ioUtil.readlink(srcFile);
-        yield ioUtil.symlink(symlinkFull, destFile, ioUtil.IS_WINDOWS ? "junction" : null);
-      } else if (!(yield ioUtil.exists(destFile)) || force) {
-        yield ioUtil.copyFile(srcFile, destFile);
-      }
-    });
+      });
+    }
   }
 });
 
 // node_modules/@actions/exec/lib/toolrunner.js
-var require_toolrunner = __commonJS((exports2) => {
-  "use strict";
-  var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
-    function adopt(value) {
-      return value instanceof P ? value : new P(function(resolve) {
-        resolve(value);
+var require_toolrunner = __commonJS({
+  "node_modules/@actions/exec/lib/toolrunner.js"(exports2) {
+    "use strict";
+    var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve) {
+          resolve(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
-    }
-    return new (P || (P = Promise))(function(resolve, reject) {
-      function fulfilled(value) {
-        try {
-          step(generator.next(value));
-        } catch (e) {
-          reject(e);
+    };
+    var __importStar = exports2 && exports2.__importStar || function(mod) {
+      if (mod && mod.__esModule)
+        return mod;
+      var result = {};
+      if (mod != null) {
+        for (var k in mod)
+          if (Object.hasOwnProperty.call(mod, k))
+            result[k] = mod[k];
+      }
+      result["default"] = mod;
+      return result;
+    };
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    var os2 = __importStar(require("os"));
+    var events = __importStar(require("events"));
+    var child = __importStar(require("child_process"));
+    var path2 = __importStar(require("path"));
+    var io2 = __importStar(require_io());
+    var ioUtil = __importStar(require_io_util());
+    var IS_WINDOWS = process.platform === "win32";
+    var ToolRunner = class extends events.EventEmitter {
+      constructor(toolPath, args, options) {
+        super();
+        if (!toolPath) {
+          throw new Error("Parameter 'toolPath' cannot be null or empty.");
+        }
+        this.toolPath = toolPath;
+        this.args = args || [];
+        this.options = options || {};
+      }
+      _debug(message) {
+        if (this.options.listeners && this.options.listeners.debug) {
+          this.options.listeners.debug(message);
         }
       }
-      function rejected(value) {
-        try {
-          step(generator["throw"](value));
-        } catch (e) {
-          reject(e);
-        }
-      }
-      function step(result) {
-        result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
-      }
-      step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-  };
-  var __importStar = exports2 && exports2.__importStar || function(mod) {
-    if (mod && mod.__esModule)
-      return mod;
-    var result = {};
-    if (mod != null) {
-      for (var k in mod)
-        if (Object.hasOwnProperty.call(mod, k))
-          result[k] = mod[k];
-    }
-    result["default"] = mod;
-    return result;
-  };
-  Object.defineProperty(exports2, "__esModule", {value: true});
-  var os2 = __importStar(require("os"));
-  var events = __importStar(require("events"));
-  var child = __importStar(require("child_process"));
-  var path2 = __importStar(require("path"));
-  var io2 = __importStar(require_io());
-  var ioUtil = __importStar(require_io_util());
-  var IS_WINDOWS = process.platform === "win32";
-  var ToolRunner = class extends events.EventEmitter {
-    constructor(toolPath, args, options) {
-      super();
-      if (!toolPath) {
-        throw new Error("Parameter 'toolPath' cannot be null or empty.");
-      }
-      this.toolPath = toolPath;
-      this.args = args || [];
-      this.options = options || {};
-    }
-    _debug(message) {
-      if (this.options.listeners && this.options.listeners.debug) {
-        this.options.listeners.debug(message);
-      }
-    }
-    _getCommandString(options, noPrefix) {
-      const toolPath = this._getSpawnFileName();
-      const args = this._getSpawnArgs(options);
-      let cmd = noPrefix ? "" : "[command]";
-      if (IS_WINDOWS) {
-        if (this._isCmdFile()) {
+      _getCommandString(options, noPrefix) {
+        const toolPath = this._getSpawnFileName();
+        const args = this._getSpawnArgs(options);
+        let cmd = noPrefix ? "" : "[command]";
+        if (IS_WINDOWS) {
+          if (this._isCmdFile()) {
+            cmd += toolPath;
+            for (const a of args) {
+              cmd += ` ${a}`;
+            }
+          } else if (options.windowsVerbatimArguments) {
+            cmd += `"${toolPath}"`;
+            for (const a of args) {
+              cmd += ` ${a}`;
+            }
+          } else {
+            cmd += this._windowsQuoteCmdArg(toolPath);
+            for (const a of args) {
+              cmd += ` ${this._windowsQuoteCmdArg(a)}`;
+            }
+          }
+        } else {
           cmd += toolPath;
           for (const a of args) {
             cmd += ` ${a}`;
           }
-        } else if (options.windowsVerbatimArguments) {
-          cmd += `"${toolPath}"`;
-          for (const a of args) {
-            cmd += ` ${a}`;
+        }
+        return cmd;
+      }
+      _processLineBuffer(data, strBuffer, onLine) {
+        try {
+          let s = strBuffer + data.toString();
+          let n = s.indexOf(os2.EOL);
+          while (n > -1) {
+            const line = s.substring(0, n);
+            onLine(line);
+            s = s.substring(n + os2.EOL.length);
+            n = s.indexOf(os2.EOL);
           }
-        } else {
-          cmd += this._windowsQuoteCmdArg(toolPath);
-          for (const a of args) {
-            cmd += ` ${this._windowsQuoteCmdArg(a)}`;
+          strBuffer = s;
+        } catch (err) {
+          this._debug(`error processing line. Failed with error ${err}`);
+        }
+      }
+      _getSpawnFileName() {
+        if (IS_WINDOWS) {
+          if (this._isCmdFile()) {
+            return process.env["COMSPEC"] || "cmd.exe";
           }
         }
-      } else {
-        cmd += toolPath;
-        for (const a of args) {
-          cmd += ` ${a}`;
-        }
+        return this.toolPath;
       }
-      return cmd;
-    }
-    _processLineBuffer(data, strBuffer, onLine) {
-      try {
-        let s = strBuffer + data.toString();
-        let n = s.indexOf(os2.EOL);
-        while (n > -1) {
-          const line = s.substring(0, n);
-          onLine(line);
-          s = s.substring(n + os2.EOL.length);
-          n = s.indexOf(os2.EOL);
-        }
-        strBuffer = s;
-      } catch (err) {
-        this._debug(`error processing line. Failed with error ${err}`);
-      }
-    }
-    _getSpawnFileName() {
-      if (IS_WINDOWS) {
-        if (this._isCmdFile()) {
-          return process.env["COMSPEC"] || "cmd.exe";
-        }
-      }
-      return this.toolPath;
-    }
-    _getSpawnArgs(options) {
-      if (IS_WINDOWS) {
-        if (this._isCmdFile()) {
-          let argline = `/D /S /C "${this._windowsQuoteCmdArg(this.toolPath)}`;
-          for (const a of this.args) {
-            argline += " ";
-            argline += options.windowsVerbatimArguments ? a : this._windowsQuoteCmdArg(a);
+      _getSpawnArgs(options) {
+        if (IS_WINDOWS) {
+          if (this._isCmdFile()) {
+            let argline = `/D /S /C "${this._windowsQuoteCmdArg(this.toolPath)}`;
+            for (const a of this.args) {
+              argline += " ";
+              argline += options.windowsVerbatimArguments ? a : this._windowsQuoteCmdArg(a);
+            }
+            argline += '"';
+            return [argline];
           }
-          argline += '"';
-          return [argline];
         }
+        return this.args;
       }
-      return this.args;
-    }
-    _endsWith(str, end) {
-      return str.endsWith(end);
-    }
-    _isCmdFile() {
-      const upperToolPath = this.toolPath.toUpperCase();
-      return this._endsWith(upperToolPath, ".CMD") || this._endsWith(upperToolPath, ".BAT");
-    }
-    _windowsQuoteCmdArg(arg) {
-      if (!this._isCmdFile()) {
-        return this._uvQuoteCmdArg(arg);
+      _endsWith(str, end) {
+        return str.endsWith(end);
       }
-      if (!arg) {
-        return '""';
+      _isCmdFile() {
+        const upperToolPath = this.toolPath.toUpperCase();
+        return this._endsWith(upperToolPath, ".CMD") || this._endsWith(upperToolPath, ".BAT");
       }
-      const cmdSpecialChars = [
-        " ",
-        "	",
-        "&",
-        "(",
-        ")",
-        "[",
-        "]",
-        "{",
-        "}",
-        "^",
-        "=",
-        ";",
-        "!",
-        "'",
-        "+",
-        ",",
-        "`",
-        "~",
-        "|",
-        "<",
-        ">",
-        '"'
-      ];
-      let needsQuotes = false;
-      for (const char of arg) {
-        if (cmdSpecialChars.some((x) => x === char)) {
-          needsQuotes = true;
-          break;
+      _windowsQuoteCmdArg(arg) {
+        if (!this._isCmdFile()) {
+          return this._uvQuoteCmdArg(arg);
         }
-      }
-      if (!needsQuotes) {
-        return arg;
-      }
-      let reverse = '"';
-      let quoteHit = true;
-      for (let i = arg.length; i > 0; i--) {
-        reverse += arg[i - 1];
-        if (quoteHit && arg[i - 1] === "\\") {
-          reverse += "\\";
-        } else if (arg[i - 1] === '"') {
-          quoteHit = true;
-          reverse += '"';
-        } else {
-          quoteHit = false;
+        if (!arg) {
+          return '""';
         }
-      }
-      reverse += '"';
-      return reverse.split("").reverse().join("");
-    }
-    _uvQuoteCmdArg(arg) {
-      if (!arg) {
-        return '""';
-      }
-      if (!arg.includes(" ") && !arg.includes("	") && !arg.includes('"')) {
-        return arg;
-      }
-      if (!arg.includes('"') && !arg.includes("\\")) {
-        return `"${arg}"`;
-      }
-      let reverse = '"';
-      let quoteHit = true;
-      for (let i = arg.length; i > 0; i--) {
-        reverse += arg[i - 1];
-        if (quoteHit && arg[i - 1] === "\\") {
-          reverse += "\\";
-        } else if (arg[i - 1] === '"') {
-          quoteHit = true;
-          reverse += "\\";
-        } else {
-          quoteHit = false;
-        }
-      }
-      reverse += '"';
-      return reverse.split("").reverse().join("");
-    }
-    _cloneExecOptions(options) {
-      options = options || {};
-      const result = {
-        cwd: options.cwd || process.cwd(),
-        env: options.env || process.env,
-        silent: options.silent || false,
-        windowsVerbatimArguments: options.windowsVerbatimArguments || false,
-        failOnStdErr: options.failOnStdErr || false,
-        ignoreReturnCode: options.ignoreReturnCode || false,
-        delay: options.delay || 1e4
-      };
-      result.outStream = options.outStream || process.stdout;
-      result.errStream = options.errStream || process.stderr;
-      return result;
-    }
-    _getSpawnOptions(options, toolPath) {
-      options = options || {};
-      const result = {};
-      result.cwd = options.cwd;
-      result.env = options.env;
-      result["windowsVerbatimArguments"] = options.windowsVerbatimArguments || this._isCmdFile();
-      if (options.windowsVerbatimArguments) {
-        result.argv0 = `"${toolPath}"`;
-      }
-      return result;
-    }
-    exec() {
-      return __awaiter(this, void 0, void 0, function* () {
-        if (!ioUtil.isRooted(this.toolPath) && (this.toolPath.includes("/") || IS_WINDOWS && this.toolPath.includes("\\"))) {
-          this.toolPath = path2.resolve(process.cwd(), this.options.cwd || process.cwd(), this.toolPath);
-        }
-        this.toolPath = yield io2.which(this.toolPath, true);
-        return new Promise((resolve, reject) => {
-          this._debug(`exec tool: ${this.toolPath}`);
-          this._debug("arguments:");
-          for (const arg of this.args) {
-            this._debug(`   ${arg}`);
+        const cmdSpecialChars = [
+          " ",
+          "	",
+          "&",
+          "(",
+          ")",
+          "[",
+          "]",
+          "{",
+          "}",
+          "^",
+          "=",
+          ";",
+          "!",
+          "'",
+          "+",
+          ",",
+          "`",
+          "~",
+          "|",
+          "<",
+          ">",
+          '"'
+        ];
+        let needsQuotes = false;
+        for (const char of arg) {
+          if (cmdSpecialChars.some((x) => x === char)) {
+            needsQuotes = true;
+            break;
           }
-          const optionsNonNull = this._cloneExecOptions(this.options);
-          if (!optionsNonNull.silent && optionsNonNull.outStream) {
-            optionsNonNull.outStream.write(this._getCommandString(optionsNonNull) + os2.EOL);
+        }
+        if (!needsQuotes) {
+          return arg;
+        }
+        let reverse = '"';
+        let quoteHit = true;
+        for (let i = arg.length; i > 0; i--) {
+          reverse += arg[i - 1];
+          if (quoteHit && arg[i - 1] === "\\") {
+            reverse += "\\";
+          } else if (arg[i - 1] === '"') {
+            quoteHit = true;
+            reverse += '"';
+          } else {
+            quoteHit = false;
           }
-          const state = new ExecState(optionsNonNull, this.toolPath);
-          state.on("debug", (message) => {
-            this._debug(message);
-          });
-          const fileName = this._getSpawnFileName();
-          const cp = child.spawn(fileName, this._getSpawnArgs(optionsNonNull), this._getSpawnOptions(this.options, fileName));
-          const stdbuffer = "";
-          if (cp.stdout) {
-            cp.stdout.on("data", (data) => {
-              if (this.options.listeners && this.options.listeners.stdout) {
-                this.options.listeners.stdout(data);
-              }
-              if (!optionsNonNull.silent && optionsNonNull.outStream) {
-                optionsNonNull.outStream.write(data);
-              }
-              this._processLineBuffer(data, stdbuffer, (line) => {
-                if (this.options.listeners && this.options.listeners.stdline) {
-                  this.options.listeners.stdline(line);
-                }
-              });
+        }
+        reverse += '"';
+        return reverse.split("").reverse().join("");
+      }
+      _uvQuoteCmdArg(arg) {
+        if (!arg) {
+          return '""';
+        }
+        if (!arg.includes(" ") && !arg.includes("	") && !arg.includes('"')) {
+          return arg;
+        }
+        if (!arg.includes('"') && !arg.includes("\\")) {
+          return `"${arg}"`;
+        }
+        let reverse = '"';
+        let quoteHit = true;
+        for (let i = arg.length; i > 0; i--) {
+          reverse += arg[i - 1];
+          if (quoteHit && arg[i - 1] === "\\") {
+            reverse += "\\";
+          } else if (arg[i - 1] === '"') {
+            quoteHit = true;
+            reverse += "\\";
+          } else {
+            quoteHit = false;
+          }
+        }
+        reverse += '"';
+        return reverse.split("").reverse().join("");
+      }
+      _cloneExecOptions(options) {
+        options = options || {};
+        const result = {
+          cwd: options.cwd || process.cwd(),
+          env: options.env || process.env,
+          silent: options.silent || false,
+          windowsVerbatimArguments: options.windowsVerbatimArguments || false,
+          failOnStdErr: options.failOnStdErr || false,
+          ignoreReturnCode: options.ignoreReturnCode || false,
+          delay: options.delay || 1e4
+        };
+        result.outStream = options.outStream || process.stdout;
+        result.errStream = options.errStream || process.stderr;
+        return result;
+      }
+      _getSpawnOptions(options, toolPath) {
+        options = options || {};
+        const result = {};
+        result.cwd = options.cwd;
+        result.env = options.env;
+        result["windowsVerbatimArguments"] = options.windowsVerbatimArguments || this._isCmdFile();
+        if (options.windowsVerbatimArguments) {
+          result.argv0 = `"${toolPath}"`;
+        }
+        return result;
+      }
+      exec() {
+        return __awaiter(this, void 0, void 0, function* () {
+          if (!ioUtil.isRooted(this.toolPath) && (this.toolPath.includes("/") || IS_WINDOWS && this.toolPath.includes("\\"))) {
+            this.toolPath = path2.resolve(process.cwd(), this.options.cwd || process.cwd(), this.toolPath);
+          }
+          this.toolPath = yield io2.which(this.toolPath, true);
+          return new Promise((resolve, reject) => {
+            this._debug(`exec tool: ${this.toolPath}`);
+            this._debug("arguments:");
+            for (const arg of this.args) {
+              this._debug(`   ${arg}`);
+            }
+            const optionsNonNull = this._cloneExecOptions(this.options);
+            if (!optionsNonNull.silent && optionsNonNull.outStream) {
+              optionsNonNull.outStream.write(this._getCommandString(optionsNonNull) + os2.EOL);
+            }
+            const state = new ExecState(optionsNonNull, this.toolPath);
+            state.on("debug", (message) => {
+              this._debug(message);
             });
-          }
-          const errbuffer = "";
-          if (cp.stderr) {
-            cp.stderr.on("data", (data) => {
-              state.processStderr = true;
-              if (this.options.listeners && this.options.listeners.stderr) {
-                this.options.listeners.stderr(data);
-              }
-              if (!optionsNonNull.silent && optionsNonNull.errStream && optionsNonNull.outStream) {
-                const s = optionsNonNull.failOnStdErr ? optionsNonNull.errStream : optionsNonNull.outStream;
-                s.write(data);
-              }
-              this._processLineBuffer(data, errbuffer, (line) => {
-                if (this.options.listeners && this.options.listeners.errline) {
-                  this.options.listeners.errline(line);
+            const fileName = this._getSpawnFileName();
+            const cp = child.spawn(fileName, this._getSpawnArgs(optionsNonNull), this._getSpawnOptions(this.options, fileName));
+            const stdbuffer = "";
+            if (cp.stdout) {
+              cp.stdout.on("data", (data) => {
+                if (this.options.listeners && this.options.listeners.stdout) {
+                  this.options.listeners.stdout(data);
                 }
+                if (!optionsNonNull.silent && optionsNonNull.outStream) {
+                  optionsNonNull.outStream.write(data);
+                }
+                this._processLineBuffer(data, stdbuffer, (line) => {
+                  if (this.options.listeners && this.options.listeners.stdline) {
+                    this.options.listeners.stdline(line);
+                  }
+                });
               });
+            }
+            const errbuffer = "";
+            if (cp.stderr) {
+              cp.stderr.on("data", (data) => {
+                state.processStderr = true;
+                if (this.options.listeners && this.options.listeners.stderr) {
+                  this.options.listeners.stderr(data);
+                }
+                if (!optionsNonNull.silent && optionsNonNull.errStream && optionsNonNull.outStream) {
+                  const s = optionsNonNull.failOnStdErr ? optionsNonNull.errStream : optionsNonNull.outStream;
+                  s.write(data);
+                }
+                this._processLineBuffer(data, errbuffer, (line) => {
+                  if (this.options.listeners && this.options.listeners.errline) {
+                    this.options.listeners.errline(line);
+                  }
+                });
+              });
+            }
+            cp.on("error", (err) => {
+              state.processError = err.message;
+              state.processExited = true;
+              state.processClosed = true;
+              state.CheckComplete();
             });
-          }
-          cp.on("error", (err) => {
-            state.processError = err.message;
-            state.processExited = true;
-            state.processClosed = true;
-            state.CheckComplete();
-          });
-          cp.on("exit", (code) => {
-            state.processExitCode = code;
-            state.processExited = true;
-            this._debug(`Exit code ${code} received from tool '${this.toolPath}'`);
-            state.CheckComplete();
-          });
-          cp.on("close", (code) => {
-            state.processExitCode = code;
-            state.processExited = true;
-            state.processClosed = true;
-            this._debug(`STDIO streams have closed for tool '${this.toolPath}'`);
-            state.CheckComplete();
-          });
-          state.on("done", (error, exitCode) => {
-            if (stdbuffer.length > 0) {
-              this.emit("stdline", stdbuffer);
+            cp.on("exit", (code) => {
+              state.processExitCode = code;
+              state.processExited = true;
+              this._debug(`Exit code ${code} received from tool '${this.toolPath}'`);
+              state.CheckComplete();
+            });
+            cp.on("close", (code) => {
+              state.processExitCode = code;
+              state.processExited = true;
+              state.processClosed = true;
+              this._debug(`STDIO streams have closed for tool '${this.toolPath}'`);
+              state.CheckComplete();
+            });
+            state.on("done", (error, exitCode) => {
+              if (stdbuffer.length > 0) {
+                this.emit("stdline", stdbuffer);
+              }
+              if (errbuffer.length > 0) {
+                this.emit("errline", errbuffer);
+              }
+              cp.removeAllListeners();
+              if (error) {
+                reject(error);
+              } else {
+                resolve(exitCode);
+              }
+            });
+            if (this.options.input) {
+              if (!cp.stdin) {
+                throw new Error("child process missing stdin");
+              }
+              cp.stdin.end(this.options.input);
             }
-            if (errbuffer.length > 0) {
-              this.emit("errline", errbuffer);
-            }
-            cp.removeAllListeners();
-            if (error) {
-              reject(error);
-            } else {
-              resolve(exitCode);
-            }
           });
-          if (this.options.input) {
-            if (!cp.stdin) {
-              throw new Error("child process missing stdin");
-            }
-            cp.stdin.end(this.options.input);
-          }
         });
-      });
-    }
-  };
-  exports2.ToolRunner = ToolRunner;
-  function argStringToArray(argString) {
-    const args = [];
-    let inQuotes = false;
-    let escaped = false;
-    let arg = "";
-    function append(c) {
-      if (escaped && c !== '"') {
-        arg += "\\";
       }
-      arg += c;
-      escaped = false;
-    }
-    for (let i = 0; i < argString.length; i++) {
-      const c = argString.charAt(i);
-      if (c === '"') {
-        if (!escaped) {
-          inQuotes = !inQuotes;
-        } else {
+    };
+    exports2.ToolRunner = ToolRunner;
+    function argStringToArray(argString) {
+      const args = [];
+      let inQuotes = false;
+      let escaped = false;
+      let arg = "";
+      function append(c) {
+        if (escaped && c !== '"') {
+          arg += "\\";
+        }
+        arg += c;
+        escaped = false;
+      }
+      for (let i = 0; i < argString.length; i++) {
+        const c = argString.charAt(i);
+        if (c === '"') {
+          if (!escaped) {
+            inQuotes = !inQuotes;
+          } else {
+            append(c);
+          }
+          continue;
+        }
+        if (c === "\\" && escaped) {
           append(c);
+          continue;
         }
-        continue;
-      }
-      if (c === "\\" && escaped) {
+        if (c === "\\" && inQuotes) {
+          escaped = true;
+          continue;
+        }
+        if (c === " " && !inQuotes) {
+          if (arg.length > 0) {
+            args.push(arg);
+            arg = "";
+          }
+          continue;
+        }
         append(c);
-        continue;
       }
-      if (c === "\\" && inQuotes) {
-        escaped = true;
-        continue;
+      if (arg.length > 0) {
+        args.push(arg.trim());
       }
-      if (c === " " && !inQuotes) {
-        if (arg.length > 0) {
-          args.push(arg);
-          arg = "";
-        }
-        continue;
-      }
-      append(c);
+      return args;
     }
-    if (arg.length > 0) {
-      args.push(arg.trim());
-    }
-    return args;
-  }
-  exports2.argStringToArray = argStringToArray;
-  var ExecState = class extends events.EventEmitter {
-    constructor(options, toolPath) {
-      super();
-      this.processClosed = false;
-      this.processError = "";
-      this.processExitCode = 0;
-      this.processExited = false;
-      this.processStderr = false;
-      this.delay = 1e4;
-      this.done = false;
-      this.timeout = null;
-      if (!toolPath) {
-        throw new Error("toolPath must not be empty");
-      }
-      this.options = options;
-      this.toolPath = toolPath;
-      if (options.delay) {
-        this.delay = options.delay;
-      }
-    }
-    CheckComplete() {
-      if (this.done) {
-        return;
-      }
-      if (this.processClosed) {
-        this._setResult();
-      } else if (this.processExited) {
-        this.timeout = setTimeout(ExecState.HandleTimeout, this.delay, this);
-      }
-    }
-    _debug(message) {
-      this.emit("debug", message);
-    }
-    _setResult() {
-      let error;
-      if (this.processExited) {
-        if (this.processError) {
-          error = new Error(`There was an error when attempting to execute the process '${this.toolPath}'. This may indicate the process failed to start. Error: ${this.processError}`);
-        } else if (this.processExitCode !== 0 && !this.options.ignoreReturnCode) {
-          error = new Error(`The process '${this.toolPath}' failed with exit code ${this.processExitCode}`);
-        } else if (this.processStderr && this.options.failOnStdErr) {
-          error = new Error(`The process '${this.toolPath}' failed because one or more lines were written to the STDERR stream`);
-        }
-      }
-      if (this.timeout) {
-        clearTimeout(this.timeout);
+    exports2.argStringToArray = argStringToArray;
+    var ExecState = class extends events.EventEmitter {
+      constructor(options, toolPath) {
+        super();
+        this.processClosed = false;
+        this.processError = "";
+        this.processExitCode = 0;
+        this.processExited = false;
+        this.processStderr = false;
+        this.delay = 1e4;
+        this.done = false;
         this.timeout = null;
+        if (!toolPath) {
+          throw new Error("toolPath must not be empty");
+        }
+        this.options = options;
+        this.toolPath = toolPath;
+        if (options.delay) {
+          this.delay = options.delay;
+        }
       }
-      this.done = true;
-      this.emit("done", error, this.processExitCode);
-    }
-    static HandleTimeout(state) {
-      if (state.done) {
-        return;
+      CheckComplete() {
+        if (this.done) {
+          return;
+        }
+        if (this.processClosed) {
+          this._setResult();
+        } else if (this.processExited) {
+          this.timeout = setTimeout(ExecState.HandleTimeout, this.delay, this);
+        }
       }
-      if (!state.processClosed && state.processExited) {
-        const message = `The STDIO streams did not close within ${state.delay / 1e3} seconds of the exit event from process '${state.toolPath}'. This may indicate a child process inherited the STDIO streams and has not yet exited.`;
-        state._debug(message);
+      _debug(message) {
+        this.emit("debug", message);
       }
-      state._setResult();
-    }
-  };
+      _setResult() {
+        let error;
+        if (this.processExited) {
+          if (this.processError) {
+            error = new Error(`There was an error when attempting to execute the process '${this.toolPath}'. This may indicate the process failed to start. Error: ${this.processError}`);
+          } else if (this.processExitCode !== 0 && !this.options.ignoreReturnCode) {
+            error = new Error(`The process '${this.toolPath}' failed with exit code ${this.processExitCode}`);
+          } else if (this.processStderr && this.options.failOnStdErr) {
+            error = new Error(`The process '${this.toolPath}' failed because one or more lines were written to the STDERR stream`);
+          }
+        }
+        if (this.timeout) {
+          clearTimeout(this.timeout);
+          this.timeout = null;
+        }
+        this.done = true;
+        this.emit("done", error, this.processExitCode);
+      }
+      static HandleTimeout(state) {
+        if (state.done) {
+          return;
+        }
+        if (!state.processClosed && state.processExited) {
+          const message = `The STDIO streams did not close within ${state.delay / 1e3} seconds of the exit event from process '${state.toolPath}'. This may indicate a child process inherited the STDIO streams and has not yet exited.`;
+          state._debug(message);
+        }
+        state._setResult();
+      }
+    };
+  }
 });
 
 // node_modules/@actions/exec/lib/exec.js
-var require_exec = __commonJS((exports2) => {
-  "use strict";
-  var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
-    function adopt(value) {
-      return value instanceof P ? value : new P(function(resolve) {
-        resolve(value);
+var require_exec = __commonJS({
+  "node_modules/@actions/exec/lib/exec.js"(exports2) {
+    "use strict";
+    var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve) {
+          resolve(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+      });
+    };
+    var __importStar = exports2 && exports2.__importStar || function(mod) {
+      if (mod && mod.__esModule)
+        return mod;
+      var result = {};
+      if (mod != null) {
+        for (var k in mod)
+          if (Object.hasOwnProperty.call(mod, k))
+            result[k] = mod[k];
+      }
+      result["default"] = mod;
+      return result;
+    };
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    var tr = __importStar(require_toolrunner());
+    function exec3(commandLine, args, options) {
+      return __awaiter(this, void 0, void 0, function* () {
+        const commandArgs = tr.argStringToArray(commandLine);
+        if (commandArgs.length === 0) {
+          throw new Error(`Parameter 'commandLine' cannot be null or empty.`);
+        }
+        const toolPath = commandArgs[0];
+        args = commandArgs.slice(1).concat(args || []);
+        const runner = new tr.ToolRunner(toolPath, args, options);
+        return runner.exec();
       });
     }
-    return new (P || (P = Promise))(function(resolve, reject) {
-      function fulfilled(value) {
-        try {
-          step(generator.next(value));
-        } catch (e) {
-          reject(e);
-        }
-      }
-      function rejected(value) {
-        try {
-          step(generator["throw"](value));
-        } catch (e) {
-          reject(e);
-        }
-      }
-      function step(result) {
-        result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
-      }
-      step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-  };
-  var __importStar = exports2 && exports2.__importStar || function(mod) {
-    if (mod && mod.__esModule)
-      return mod;
-    var result = {};
-    if (mod != null) {
-      for (var k in mod)
-        if (Object.hasOwnProperty.call(mod, k))
-          result[k] = mod[k];
-    }
-    result["default"] = mod;
-    return result;
-  };
-  Object.defineProperty(exports2, "__esModule", {value: true});
-  var tr = __importStar(require_toolrunner());
-  function exec3(commandLine, args, options) {
-    return __awaiter(this, void 0, void 0, function* () {
-      const commandArgs = tr.argStringToArray(commandLine);
-      if (commandArgs.length === 0) {
-        throw new Error(`Parameter 'commandLine' cannot be null or empty.`);
-      }
-      const toolPath = commandArgs[0];
-      args = commandArgs.slice(1).concat(args || []);
-      const runner = new tr.ToolRunner(toolPath, args, options);
-      return runner.exec();
-    });
+    exports2.exec = exec3;
   }
-  exports2.exec = exec3;
+});
+
+// node_modules/@actions/io/lib/io-util.js
+var require_io_util2 = __commonJS({
+  "node_modules/@actions/io/lib/io-util.js"(exports2) {
+    "use strict";
+    var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve) {
+          resolve(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+      });
+    };
+    var _a;
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    var assert_1 = require("assert");
+    var fs = require("fs");
+    var path2 = require("path");
+    _a = fs.promises, exports2.chmod = _a.chmod, exports2.copyFile = _a.copyFile, exports2.lstat = _a.lstat, exports2.mkdir = _a.mkdir, exports2.readdir = _a.readdir, exports2.readlink = _a.readlink, exports2.rename = _a.rename, exports2.rmdir = _a.rmdir, exports2.stat = _a.stat, exports2.symlink = _a.symlink, exports2.unlink = _a.unlink;
+    exports2.IS_WINDOWS = process.platform === "win32";
+    function exists(fsPath) {
+      return __awaiter(this, void 0, void 0, function* () {
+        try {
+          yield exports2.stat(fsPath);
+        } catch (err) {
+          if (err.code === "ENOENT") {
+            return false;
+          }
+          throw err;
+        }
+        return true;
+      });
+    }
+    exports2.exists = exists;
+    function isDirectory(fsPath, useStat = false) {
+      return __awaiter(this, void 0, void 0, function* () {
+        const stats = useStat ? yield exports2.stat(fsPath) : yield exports2.lstat(fsPath);
+        return stats.isDirectory();
+      });
+    }
+    exports2.isDirectory = isDirectory;
+    function isRooted(p) {
+      p = normalizeSeparators(p);
+      if (!p) {
+        throw new Error('isRooted() parameter "p" cannot be empty');
+      }
+      if (exports2.IS_WINDOWS) {
+        return p.startsWith("\\") || /^[A-Z]:/i.test(p);
+      }
+      return p.startsWith("/");
+    }
+    exports2.isRooted = isRooted;
+    function mkdirP(fsPath, maxDepth = 1e3, depth = 1) {
+      return __awaiter(this, void 0, void 0, function* () {
+        assert_1.ok(fsPath, "a path argument must be provided");
+        fsPath = path2.resolve(fsPath);
+        if (depth >= maxDepth)
+          return exports2.mkdir(fsPath);
+        try {
+          yield exports2.mkdir(fsPath);
+          return;
+        } catch (err) {
+          switch (err.code) {
+            case "ENOENT": {
+              yield mkdirP(path2.dirname(fsPath), maxDepth, depth + 1);
+              yield exports2.mkdir(fsPath);
+              return;
+            }
+            default: {
+              let stats;
+              try {
+                stats = yield exports2.stat(fsPath);
+              } catch (err2) {
+                throw err;
+              }
+              if (!stats.isDirectory())
+                throw err;
+            }
+          }
+        }
+      });
+    }
+    exports2.mkdirP = mkdirP;
+    function tryGetExecutablePath(filePath, extensions) {
+      return __awaiter(this, void 0, void 0, function* () {
+        let stats = void 0;
+        try {
+          stats = yield exports2.stat(filePath);
+        } catch (err) {
+          if (err.code !== "ENOENT") {
+            console.log(`Unexpected error attempting to determine if executable file exists '${filePath}': ${err}`);
+          }
+        }
+        if (stats && stats.isFile()) {
+          if (exports2.IS_WINDOWS) {
+            const upperExt = path2.extname(filePath).toUpperCase();
+            if (extensions.some((validExt) => validExt.toUpperCase() === upperExt)) {
+              return filePath;
+            }
+          } else {
+            if (isUnixExecutable(stats)) {
+              return filePath;
+            }
+          }
+        }
+        const originalFilePath = filePath;
+        for (const extension of extensions) {
+          filePath = originalFilePath + extension;
+          stats = void 0;
+          try {
+            stats = yield exports2.stat(filePath);
+          } catch (err) {
+            if (err.code !== "ENOENT") {
+              console.log(`Unexpected error attempting to determine if executable file exists '${filePath}': ${err}`);
+            }
+          }
+          if (stats && stats.isFile()) {
+            if (exports2.IS_WINDOWS) {
+              try {
+                const directory = path2.dirname(filePath);
+                const upperName = path2.basename(filePath).toUpperCase();
+                for (const actualName of yield exports2.readdir(directory)) {
+                  if (upperName === actualName.toUpperCase()) {
+                    filePath = path2.join(directory, actualName);
+                    break;
+                  }
+                }
+              } catch (err) {
+                console.log(`Unexpected error attempting to determine the actual case of the file '${filePath}': ${err}`);
+              }
+              return filePath;
+            } else {
+              if (isUnixExecutable(stats)) {
+                return filePath;
+              }
+            }
+          }
+        }
+        return "";
+      });
+    }
+    exports2.tryGetExecutablePath = tryGetExecutablePath;
+    function normalizeSeparators(p) {
+      p = p || "";
+      if (exports2.IS_WINDOWS) {
+        p = p.replace(/\//g, "\\");
+        return p.replace(/\\\\+/g, "\\");
+      }
+      return p.replace(/\/\/+/g, "/");
+    }
+    function isUnixExecutable(stats) {
+      return (stats.mode & 1) > 0 || (stats.mode & 8) > 0 && stats.gid === process.getgid() || (stats.mode & 64) > 0 && stats.uid === process.getuid();
+    }
+  }
+});
+
+// node_modules/@actions/io/lib/io.js
+var require_io2 = __commonJS({
+  "node_modules/@actions/io/lib/io.js"(exports2) {
+    "use strict";
+    var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve) {
+          resolve(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+      });
+    };
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    var childProcess = require("child_process");
+    var path2 = require("path");
+    var util_1 = require("util");
+    var ioUtil = require_io_util2();
+    var exec3 = util_1.promisify(childProcess.exec);
+    function cp(source, dest, options = {}) {
+      return __awaiter(this, void 0, void 0, function* () {
+        const { force, recursive } = readCopyOptions(options);
+        const destStat = (yield ioUtil.exists(dest)) ? yield ioUtil.stat(dest) : null;
+        if (destStat && destStat.isFile() && !force) {
+          return;
+        }
+        const newDest = destStat && destStat.isDirectory() ? path2.join(dest, path2.basename(source)) : dest;
+        if (!(yield ioUtil.exists(source))) {
+          throw new Error(`no such file or directory: ${source}`);
+        }
+        const sourceStat = yield ioUtil.stat(source);
+        if (sourceStat.isDirectory()) {
+          if (!recursive) {
+            throw new Error(`Failed to copy. ${source} is a directory, but tried to copy without recursive flag.`);
+          } else {
+            yield cpDirRecursive(source, newDest, 0, force);
+          }
+        } else {
+          if (path2.relative(source, newDest) === "") {
+            throw new Error(`'${newDest}' and '${source}' are the same file`);
+          }
+          yield copyFile(source, newDest, force);
+        }
+      });
+    }
+    exports2.cp = cp;
+    function mv(source, dest, options = {}) {
+      return __awaiter(this, void 0, void 0, function* () {
+        if (yield ioUtil.exists(dest)) {
+          let destExists = true;
+          if (yield ioUtil.isDirectory(dest)) {
+            dest = path2.join(dest, path2.basename(source));
+            destExists = yield ioUtil.exists(dest);
+          }
+          if (destExists) {
+            if (options.force == null || options.force) {
+              yield rmRF(dest);
+            } else {
+              throw new Error("Destination already exists");
+            }
+          }
+        }
+        yield mkdirP(path2.dirname(dest));
+        yield ioUtil.rename(source, dest);
+      });
+    }
+    exports2.mv = mv;
+    function rmRF(inputPath) {
+      return __awaiter(this, void 0, void 0, function* () {
+        if (ioUtil.IS_WINDOWS) {
+          try {
+            if (yield ioUtil.isDirectory(inputPath, true)) {
+              yield exec3(`rd /s /q "${inputPath}"`);
+            } else {
+              yield exec3(`del /f /a "${inputPath}"`);
+            }
+          } catch (err) {
+            if (err.code !== "ENOENT")
+              throw err;
+          }
+          try {
+            yield ioUtil.unlink(inputPath);
+          } catch (err) {
+            if (err.code !== "ENOENT")
+              throw err;
+          }
+        } else {
+          let isDir = false;
+          try {
+            isDir = yield ioUtil.isDirectory(inputPath);
+          } catch (err) {
+            if (err.code !== "ENOENT")
+              throw err;
+            return;
+          }
+          if (isDir) {
+            yield exec3(`rm -rf "${inputPath}"`);
+          } else {
+            yield ioUtil.unlink(inputPath);
+          }
+        }
+      });
+    }
+    exports2.rmRF = rmRF;
+    function mkdirP(fsPath) {
+      return __awaiter(this, void 0, void 0, function* () {
+        yield ioUtil.mkdirP(fsPath);
+      });
+    }
+    exports2.mkdirP = mkdirP;
+    function which2(tool, check) {
+      return __awaiter(this, void 0, void 0, function* () {
+        if (!tool) {
+          throw new Error("parameter 'tool' is required");
+        }
+        if (check) {
+          const result = yield which2(tool, false);
+          if (!result) {
+            if (ioUtil.IS_WINDOWS) {
+              throw new Error(`Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also verify the file has a valid extension for an executable file.`);
+            } else {
+              throw new Error(`Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also check the file mode to verify the file is executable.`);
+            }
+          }
+        }
+        try {
+          const extensions = [];
+          if (ioUtil.IS_WINDOWS && process.env.PATHEXT) {
+            for (const extension of process.env.PATHEXT.split(path2.delimiter)) {
+              if (extension) {
+                extensions.push(extension);
+              }
+            }
+          }
+          if (ioUtil.isRooted(tool)) {
+            const filePath = yield ioUtil.tryGetExecutablePath(tool, extensions);
+            if (filePath) {
+              return filePath;
+            }
+            return "";
+          }
+          if (tool.includes("/") || ioUtil.IS_WINDOWS && tool.includes("\\")) {
+            return "";
+          }
+          const directories = [];
+          if (process.env.PATH) {
+            for (const p of process.env.PATH.split(path2.delimiter)) {
+              if (p) {
+                directories.push(p);
+              }
+            }
+          }
+          for (const directory of directories) {
+            const filePath = yield ioUtil.tryGetExecutablePath(directory + path2.sep + tool, extensions);
+            if (filePath) {
+              return filePath;
+            }
+          }
+          return "";
+        } catch (err) {
+          throw new Error(`which failed with message ${err.message}`);
+        }
+      });
+    }
+    exports2.which = which2;
+    function readCopyOptions(options) {
+      const force = options.force == null ? true : options.force;
+      const recursive = Boolean(options.recursive);
+      return { force, recursive };
+    }
+    function cpDirRecursive(sourceDir, destDir, currentDepth, force) {
+      return __awaiter(this, void 0, void 0, function* () {
+        if (currentDepth >= 255)
+          return;
+        currentDepth++;
+        yield mkdirP(destDir);
+        const files = yield ioUtil.readdir(sourceDir);
+        for (const fileName of files) {
+          const srcFile = `${sourceDir}/${fileName}`;
+          const destFile = `${destDir}/${fileName}`;
+          const srcFileStat = yield ioUtil.lstat(srcFile);
+          if (srcFileStat.isDirectory()) {
+            yield cpDirRecursive(srcFile, destFile, currentDepth, force);
+          } else {
+            yield copyFile(srcFile, destFile, force);
+          }
+        }
+        yield ioUtil.chmod(destDir, (yield ioUtil.stat(sourceDir)).mode);
+      });
+    }
+    function copyFile(srcFile, destFile, force) {
+      return __awaiter(this, void 0, void 0, function* () {
+        if ((yield ioUtil.lstat(srcFile)).isSymbolicLink()) {
+          try {
+            yield ioUtil.lstat(destFile);
+            yield ioUtil.unlink(destFile);
+          } catch (e) {
+            if (e.code === "EPERM") {
+              yield ioUtil.chmod(destFile, "0666");
+              yield ioUtil.unlink(destFile);
+            }
+          }
+          const symlinkFull = yield ioUtil.readlink(srcFile);
+          yield ioUtil.symlink(symlinkFull, destFile, ioUtil.IS_WINDOWS ? "junction" : null);
+        } else if (!(yield ioUtil.exists(destFile)) || force) {
+          yield ioUtil.copyFile(srcFile, destFile);
+        }
+      });
+    }
+  }
 });
 
 // lib/setup/main.ts
@@ -1217,7 +1684,7 @@ var core2 = __toModule(require_core());
 // lib/setup/index.ts
 var core = __toModule(require_core());
 var exec = __toModule(require_exec());
-var io = __toModule(require_io());
+var io = __toModule(require_io2());
 var os = __toModule(require("os"));
 var path = __toModule(require("path"));
 async function setupAsdf() {
@@ -1231,7 +1698,7 @@ async function setupAsdf() {
   core.addPath(`${asdfDir}/bin`);
   core.addPath(`${asdfDir}/shims`);
   core.info(`Cloning asdf into ASDF_DIR: ${asdfDir}`);
-  const branch = core.getInput("asdf_branch", {required: true});
+  const branch = core.getInput("asdf_branch", { required: true });
   await exec.exec("git", [
     "clone",
     "--depth",

--- a/setup/main.js
+++ b/setup/main.js
@@ -1,403 +1,424 @@
 var __create = Object.create;
 var __defProp = Object.defineProperty;
-var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
-var __getOwnPropNames = Object.getOwnPropertyNames;
 var __getProtoOf = Object.getPrototypeOf;
 var __hasOwnProp = Object.prototype.hasOwnProperty;
-var __markAsModule = (target) => __defProp(target, "__esModule", { value: true });
-var __commonJS = (cb, mod) => function __require() {
-  return mod || (0, cb[Object.keys(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __markAsModule = (target) => __defProp(target, "__esModule", {value: true});
+var __commonJS = (callback, module2) => () => {
+  if (!module2) {
+    module2 = {exports: {}};
+    callback(module2.exports, module2);
+  }
+  return module2.exports;
 };
-var __reExport = (target, module2, desc) => {
+var __exportStar = (target, module2, desc) => {
+  __markAsModule(target);
   if (module2 && typeof module2 === "object" || typeof module2 === "function") {
     for (let key of __getOwnPropNames(module2))
       if (!__hasOwnProp.call(target, key) && key !== "default")
-        __defProp(target, key, { get: () => module2[key], enumerable: !(desc = __getOwnPropDesc(module2, key)) || desc.enumerable });
+        __defProp(target, key, {get: () => module2[key], enumerable: !(desc = __getOwnPropDesc(module2, key)) || desc.enumerable});
   }
   return target;
 };
 var __toModule = (module2) => {
-  return __reExport(__markAsModule(__defProp(module2 != null ? __create(__getProtoOf(module2)) : {}, "default", module2 && module2.__esModule && "default" in module2 ? { get: () => module2.default, enumerable: true } : { value: module2, enumerable: true })), module2);
+  if (module2 && module2.__esModule)
+    return module2;
+  return __exportStar(__defProp(module2 != null ? __create(__getProtoOf(module2)) : {}, "default", {value: module2, enumerable: true}), module2);
 };
 
 // node_modules/@actions/core/lib/utils.js
-var require_utils = __commonJS({
-  "node_modules/@actions/core/lib/utils.js"(exports2) {
-    "use strict";
-    Object.defineProperty(exports2, "__esModule", { value: true });
-    function toCommandValue(input) {
-      if (input === null || input === void 0) {
-        return "";
-      } else if (typeof input === "string" || input instanceof String) {
-        return input;
-      }
-      return JSON.stringify(input);
+var require_utils = __commonJS((exports2) => {
+  "use strict";
+  Object.defineProperty(exports2, "__esModule", {value: true});
+  function toCommandValue(input) {
+    if (input === null || input === void 0) {
+      return "";
+    } else if (typeof input === "string" || input instanceof String) {
+      return input;
     }
-    exports2.toCommandValue = toCommandValue;
+    return JSON.stringify(input);
   }
+  exports2.toCommandValue = toCommandValue;
 });
 
 // node_modules/@actions/core/lib/command.js
-var require_command = __commonJS({
-  "node_modules/@actions/core/lib/command.js"(exports2) {
-    "use strict";
-    var __importStar = exports2 && exports2.__importStar || function(mod) {
-      if (mod && mod.__esModule)
-        return mod;
-      var result = {};
-      if (mod != null) {
-        for (var k in mod)
-          if (Object.hasOwnProperty.call(mod, k))
-            result[k] = mod[k];
-      }
-      result["default"] = mod;
-      return result;
-    };
-    Object.defineProperty(exports2, "__esModule", { value: true });
-    var os2 = __importStar(require("os"));
-    var utils_1 = require_utils();
-    function issueCommand(command, properties, message) {
-      const cmd = new Command(command, properties, message);
-      process.stdout.write(cmd.toString() + os2.EOL);
+var require_command = __commonJS((exports2) => {
+  "use strict";
+  var __importStar = exports2 && exports2.__importStar || function(mod) {
+    if (mod && mod.__esModule)
+      return mod;
+    var result = {};
+    if (mod != null) {
+      for (var k in mod)
+        if (Object.hasOwnProperty.call(mod, k))
+          result[k] = mod[k];
     }
-    exports2.issueCommand = issueCommand;
-    function issue(name, message = "") {
-      issueCommand(name, {}, message);
-    }
-    exports2.issue = issue;
-    var CMD_STRING = "::";
-    var Command = class {
-      constructor(command, properties, message) {
-        if (!command) {
-          command = "missing.command";
-        }
-        this.command = command;
-        this.properties = properties;
-        this.message = message;
+    result["default"] = mod;
+    return result;
+  };
+  Object.defineProperty(exports2, "__esModule", {value: true});
+  var os2 = __importStar(require("os"));
+  var utils_1 = require_utils();
+  function issueCommand(command, properties, message) {
+    const cmd = new Command(command, properties, message);
+    process.stdout.write(cmd.toString() + os2.EOL);
+  }
+  exports2.issueCommand = issueCommand;
+  function issue(name, message = "") {
+    issueCommand(name, {}, message);
+  }
+  exports2.issue = issue;
+  var CMD_STRING = "::";
+  var Command = class {
+    constructor(command, properties, message) {
+      if (!command) {
+        command = "missing.command";
       }
-      toString() {
-        let cmdStr = CMD_STRING + this.command;
-        if (this.properties && Object.keys(this.properties).length > 0) {
-          cmdStr += " ";
-          let first = true;
-          for (const key in this.properties) {
-            if (this.properties.hasOwnProperty(key)) {
-              const val = this.properties[key];
-              if (val) {
-                if (first) {
-                  first = false;
-                } else {
-                  cmdStr += ",";
-                }
-                cmdStr += `${key}=${escapeProperty(val)}`;
+      this.command = command;
+      this.properties = properties;
+      this.message = message;
+    }
+    toString() {
+      let cmdStr = CMD_STRING + this.command;
+      if (this.properties && Object.keys(this.properties).length > 0) {
+        cmdStr += " ";
+        let first = true;
+        for (const key in this.properties) {
+          if (this.properties.hasOwnProperty(key)) {
+            const val = this.properties[key];
+            if (val) {
+              if (first) {
+                first = false;
+              } else {
+                cmdStr += ",";
               }
+              cmdStr += `${key}=${escapeProperty(val)}`;
             }
           }
         }
-        cmdStr += `${CMD_STRING}${escapeData(this.message)}`;
-        return cmdStr;
       }
-    };
-    function escapeData(s) {
-      return utils_1.toCommandValue(s).replace(/%/g, "%25").replace(/\r/g, "%0D").replace(/\n/g, "%0A");
+      cmdStr += `${CMD_STRING}${escapeData(this.message)}`;
+      return cmdStr;
     }
-    function escapeProperty(s) {
-      return utils_1.toCommandValue(s).replace(/%/g, "%25").replace(/\r/g, "%0D").replace(/\n/g, "%0A").replace(/:/g, "%3A").replace(/,/g, "%2C");
-    }
+  };
+  function escapeData(s) {
+    return utils_1.toCommandValue(s).replace(/%/g, "%25").replace(/\r/g, "%0D").replace(/\n/g, "%0A");
+  }
+  function escapeProperty(s) {
+    return utils_1.toCommandValue(s).replace(/%/g, "%25").replace(/\r/g, "%0D").replace(/\n/g, "%0A").replace(/:/g, "%3A").replace(/,/g, "%2C");
   }
 });
 
 // node_modules/@actions/core/lib/file-command.js
-var require_file_command = __commonJS({
-  "node_modules/@actions/core/lib/file-command.js"(exports2) {
-    "use strict";
-    var __importStar = exports2 && exports2.__importStar || function(mod) {
-      if (mod && mod.__esModule)
-        return mod;
-      var result = {};
-      if (mod != null) {
-        for (var k in mod)
-          if (Object.hasOwnProperty.call(mod, k))
-            result[k] = mod[k];
-      }
-      result["default"] = mod;
-      return result;
-    };
-    Object.defineProperty(exports2, "__esModule", { value: true });
-    var fs = __importStar(require("fs"));
-    var os2 = __importStar(require("os"));
-    var utils_1 = require_utils();
-    function issueCommand(command, message) {
-      const filePath = process.env[`GITHUB_${command}`];
-      if (!filePath) {
-        throw new Error(`Unable to find environment variable for file command ${command}`);
-      }
-      if (!fs.existsSync(filePath)) {
-        throw new Error(`Missing file at path: ${filePath}`);
-      }
-      fs.appendFileSync(filePath, `${utils_1.toCommandValue(message)}${os2.EOL}`, {
-        encoding: "utf8"
-      });
+var require_file_command = __commonJS((exports2) => {
+  "use strict";
+  var __importStar = exports2 && exports2.__importStar || function(mod) {
+    if (mod && mod.__esModule)
+      return mod;
+    var result = {};
+    if (mod != null) {
+      for (var k in mod)
+        if (Object.hasOwnProperty.call(mod, k))
+          result[k] = mod[k];
     }
-    exports2.issueCommand = issueCommand;
+    result["default"] = mod;
+    return result;
+  };
+  Object.defineProperty(exports2, "__esModule", {value: true});
+  var fs = __importStar(require("fs"));
+  var os2 = __importStar(require("os"));
+  var utils_1 = require_utils();
+  function issueCommand(command, message) {
+    const filePath = process.env[`GITHUB_${command}`];
+    if (!filePath) {
+      throw new Error(`Unable to find environment variable for file command ${command}`);
+    }
+    if (!fs.existsSync(filePath)) {
+      throw new Error(`Missing file at path: ${filePath}`);
+    }
+    fs.appendFileSync(filePath, `${utils_1.toCommandValue(message)}${os2.EOL}`, {
+      encoding: "utf8"
+    });
   }
+  exports2.issueCommand = issueCommand;
 });
 
 // node_modules/@actions/core/lib/core.js
-var require_core = __commonJS({
-  "node_modules/@actions/core/lib/core.js"(exports2) {
-    "use strict";
-    var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
-      function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve) {
-          resolve(value);
-        });
-      }
-      return new (P || (P = Promise))(function(resolve, reject) {
-        function fulfilled(value) {
-          try {
-            step(generator.next(value));
-          } catch (e) {
-            reject(e);
-          }
-        }
-        function rejected(value) {
-          try {
-            step(generator["throw"](value));
-          } catch (e) {
-            reject(e);
-          }
-        }
-        function step(result) {
-          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
-        }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
+var require_core = __commonJS((exports2) => {
+  "use strict";
+  var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+    function adopt(value) {
+      return value instanceof P ? value : new P(function(resolve) {
+        resolve(value);
       });
-    };
-    var __importStar = exports2 && exports2.__importStar || function(mod) {
-      if (mod && mod.__esModule)
-        return mod;
-      var result = {};
-      if (mod != null) {
-        for (var k in mod)
-          if (Object.hasOwnProperty.call(mod, k))
-            result[k] = mod[k];
-      }
-      result["default"] = mod;
-      return result;
-    };
-    Object.defineProperty(exports2, "__esModule", { value: true });
-    var command_1 = require_command();
-    var file_command_1 = require_file_command();
-    var utils_1 = require_utils();
-    var os2 = __importStar(require("os"));
-    var path2 = __importStar(require("path"));
-    var ExitCode;
-    (function(ExitCode2) {
-      ExitCode2[ExitCode2["Success"] = 0] = "Success";
-      ExitCode2[ExitCode2["Failure"] = 1] = "Failure";
-    })(ExitCode = exports2.ExitCode || (exports2.ExitCode = {}));
-    function exportVariable2(name, val) {
-      const convertedVal = utils_1.toCommandValue(val);
-      process.env[name] = convertedVal;
-      const filePath = process.env["GITHUB_ENV"] || "";
-      if (filePath) {
-        const delimiter = "_GitHubActionsFileCommandDelimeter_";
-        const commandValue = `${name}<<${delimiter}${os2.EOL}${convertedVal}${os2.EOL}${delimiter}`;
-        file_command_1.issueCommand("ENV", commandValue);
-      } else {
-        command_1.issueCommand("set-env", { name }, convertedVal);
-      }
     }
-    exports2.exportVariable = exportVariable2;
-    function setSecret(secret) {
-      command_1.issueCommand("add-mask", {}, secret);
-    }
-    exports2.setSecret = setSecret;
-    function addPath2(inputPath) {
-      const filePath = process.env["GITHUB_PATH"] || "";
-      if (filePath) {
-        file_command_1.issueCommand("PATH", inputPath);
-      } else {
-        command_1.issueCommand("add-path", {}, inputPath);
-      }
-      process.env["PATH"] = `${inputPath}${path2.delimiter}${process.env["PATH"]}`;
-    }
-    exports2.addPath = addPath2;
-    function getInput2(name, options) {
-      const val = process.env[`INPUT_${name.replace(/ /g, "_").toUpperCase()}`] || "";
-      if (options && options.required && !val) {
-        throw new Error(`Input required and not supplied: ${name}`);
-      }
-      return val.trim();
-    }
-    exports2.getInput = getInput2;
-    function setOutput(name, value) {
-      command_1.issueCommand("set-output", { name }, value);
-    }
-    exports2.setOutput = setOutput;
-    function setCommandEcho(enabled) {
-      command_1.issue("echo", enabled ? "on" : "off");
-    }
-    exports2.setCommandEcho = setCommandEcho;
-    function setFailed2(message) {
-      process.exitCode = ExitCode.Failure;
-      error(message);
-    }
-    exports2.setFailed = setFailed2;
-    function isDebug() {
-      return process.env["RUNNER_DEBUG"] === "1";
-    }
-    exports2.isDebug = isDebug;
-    function debug(message) {
-      command_1.issueCommand("debug", {}, message);
-    }
-    exports2.debug = debug;
-    function error(message) {
-      command_1.issue("error", message instanceof Error ? message.toString() : message);
-    }
-    exports2.error = error;
-    function warning(message) {
-      command_1.issue("warning", message instanceof Error ? message.toString() : message);
-    }
-    exports2.warning = warning;
-    function info2(message) {
-      process.stdout.write(message + os2.EOL);
-    }
-    exports2.info = info2;
-    function startGroup(name) {
-      command_1.issue("group", name);
-    }
-    exports2.startGroup = startGroup;
-    function endGroup() {
-      command_1.issue("endgroup");
-    }
-    exports2.endGroup = endGroup;
-    function group(name, fn) {
-      return __awaiter(this, void 0, void 0, function* () {
-        startGroup(name);
-        let result;
+    return new (P || (P = Promise))(function(resolve, reject) {
+      function fulfilled(value) {
         try {
-          result = yield fn();
-        } finally {
-          endGroup();
+          step(generator.next(value));
+        } catch (e) {
+          reject(e);
         }
-        return result;
-      });
+      }
+      function rejected(value) {
+        try {
+          step(generator["throw"](value));
+        } catch (e) {
+          reject(e);
+        }
+      }
+      function step(result) {
+        result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+      }
+      step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+  };
+  var __importStar = exports2 && exports2.__importStar || function(mod) {
+    if (mod && mod.__esModule)
+      return mod;
+    var result = {};
+    if (mod != null) {
+      for (var k in mod)
+        if (Object.hasOwnProperty.call(mod, k))
+          result[k] = mod[k];
     }
-    exports2.group = group;
-    function saveState(name, value) {
-      command_1.issueCommand("save-state", { name }, value);
+    result["default"] = mod;
+    return result;
+  };
+  Object.defineProperty(exports2, "__esModule", {value: true});
+  var command_1 = require_command();
+  var file_command_1 = require_file_command();
+  var utils_1 = require_utils();
+  var os2 = __importStar(require("os"));
+  var path2 = __importStar(require("path"));
+  var ExitCode;
+  (function(ExitCode2) {
+    ExitCode2[ExitCode2["Success"] = 0] = "Success";
+    ExitCode2[ExitCode2["Failure"] = 1] = "Failure";
+  })(ExitCode = exports2.ExitCode || (exports2.ExitCode = {}));
+  function exportVariable2(name, val) {
+    const convertedVal = utils_1.toCommandValue(val);
+    process.env[name] = convertedVal;
+    const filePath = process.env["GITHUB_ENV"] || "";
+    if (filePath) {
+      const delimiter = "_GitHubActionsFileCommandDelimeter_";
+      const commandValue = `${name}<<${delimiter}${os2.EOL}${convertedVal}${os2.EOL}${delimiter}`;
+      file_command_1.issueCommand("ENV", commandValue);
+    } else {
+      command_1.issueCommand("set-env", {name}, convertedVal);
     }
-    exports2.saveState = saveState;
-    function getState(name) {
-      return process.env[`STATE_${name}`] || "";
-    }
-    exports2.getState = getState;
   }
+  exports2.exportVariable = exportVariable2;
+  function setSecret(secret) {
+    command_1.issueCommand("add-mask", {}, secret);
+  }
+  exports2.setSecret = setSecret;
+  function addPath2(inputPath) {
+    const filePath = process.env["GITHUB_PATH"] || "";
+    if (filePath) {
+      file_command_1.issueCommand("PATH", inputPath);
+    } else {
+      command_1.issueCommand("add-path", {}, inputPath);
+    }
+    process.env["PATH"] = `${inputPath}${path2.delimiter}${process.env["PATH"]}`;
+  }
+  exports2.addPath = addPath2;
+  function getInput2(name, options) {
+    const val = process.env[`INPUT_${name.replace(/ /g, "_").toUpperCase()}`] || "";
+    if (options && options.required && !val) {
+      throw new Error(`Input required and not supplied: ${name}`);
+    }
+    return val.trim();
+  }
+  exports2.getInput = getInput2;
+  function setOutput(name, value) {
+    command_1.issueCommand("set-output", {name}, value);
+  }
+  exports2.setOutput = setOutput;
+  function setCommandEcho(enabled) {
+    command_1.issue("echo", enabled ? "on" : "off");
+  }
+  exports2.setCommandEcho = setCommandEcho;
+  function setFailed2(message) {
+    process.exitCode = ExitCode.Failure;
+    error(message);
+  }
+  exports2.setFailed = setFailed2;
+  function isDebug() {
+    return process.env["RUNNER_DEBUG"] === "1";
+  }
+  exports2.isDebug = isDebug;
+  function debug(message) {
+    command_1.issueCommand("debug", {}, message);
+  }
+  exports2.debug = debug;
+  function error(message) {
+    command_1.issue("error", message instanceof Error ? message.toString() : message);
+  }
+  exports2.error = error;
+  function warning(message) {
+    command_1.issue("warning", message instanceof Error ? message.toString() : message);
+  }
+  exports2.warning = warning;
+  function info2(message) {
+    process.stdout.write(message + os2.EOL);
+  }
+  exports2.info = info2;
+  function startGroup(name) {
+    command_1.issue("group", name);
+  }
+  exports2.startGroup = startGroup;
+  function endGroup() {
+    command_1.issue("endgroup");
+  }
+  exports2.endGroup = endGroup;
+  function group(name, fn) {
+    return __awaiter(this, void 0, void 0, function* () {
+      startGroup(name);
+      let result;
+      try {
+        result = yield fn();
+      } finally {
+        endGroup();
+      }
+      return result;
+    });
+  }
+  exports2.group = group;
+  function saveState(name, value) {
+    command_1.issueCommand("save-state", {name}, value);
+  }
+  exports2.saveState = saveState;
+  function getState(name) {
+    return process.env[`STATE_${name}`] || "";
+  }
+  exports2.getState = getState;
 });
 
 // node_modules/@actions/exec/node_modules/@actions/io/lib/io-util.js
-var require_io_util = __commonJS({
-  "node_modules/@actions/exec/node_modules/@actions/io/lib/io-util.js"(exports2) {
-    "use strict";
-    var __createBinding = exports2 && exports2.__createBinding || (Object.create ? function(o, m, k, k2) {
-      if (k2 === void 0)
-        k2 = k;
-      Object.defineProperty(o, k2, { enumerable: true, get: function() {
-        return m[k];
-      } });
-    } : function(o, m, k, k2) {
-      if (k2 === void 0)
-        k2 = k;
-      o[k2] = m[k];
-    });
-    var __setModuleDefault = exports2 && exports2.__setModuleDefault || (Object.create ? function(o, v) {
-      Object.defineProperty(o, "default", { enumerable: true, value: v });
-    } : function(o, v) {
-      o["default"] = v;
-    });
-    var __importStar = exports2 && exports2.__importStar || function(mod) {
-      if (mod && mod.__esModule)
-        return mod;
-      var result = {};
-      if (mod != null) {
-        for (var k in mod)
-          if (k !== "default" && Object.hasOwnProperty.call(mod, k))
-            __createBinding(result, mod, k);
-      }
-      __setModuleDefault(result, mod);
-      return result;
-    };
-    var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
-      function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve) {
-          resolve(value);
-        });
-      }
-      return new (P || (P = Promise))(function(resolve, reject) {
-        function fulfilled(value) {
-          try {
-            step(generator.next(value));
-          } catch (e) {
-            reject(e);
-          }
-        }
-        function rejected(value) {
-          try {
-            step(generator["throw"](value));
-          } catch (e) {
-            reject(e);
-          }
-        }
-        function step(result) {
-          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
-        }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
+var require_io_util = __commonJS((exports2) => {
+  "use strict";
+  var __createBinding = exports2 && exports2.__createBinding || (Object.create ? function(o, m, k, k2) {
+    if (k2 === void 0)
+      k2 = k;
+    Object.defineProperty(o, k2, {enumerable: true, get: function() {
+      return m[k];
+    }});
+  } : function(o, m, k, k2) {
+    if (k2 === void 0)
+      k2 = k;
+    o[k2] = m[k];
+  });
+  var __setModuleDefault = exports2 && exports2.__setModuleDefault || (Object.create ? function(o, v) {
+    Object.defineProperty(o, "default", {enumerable: true, value: v});
+  } : function(o, v) {
+    o["default"] = v;
+  });
+  var __importStar = exports2 && exports2.__importStar || function(mod) {
+    if (mod && mod.__esModule)
+      return mod;
+    var result = {};
+    if (mod != null) {
+      for (var k in mod)
+        if (k !== "default" && Object.hasOwnProperty.call(mod, k))
+          __createBinding(result, mod, k);
+    }
+    __setModuleDefault(result, mod);
+    return result;
+  };
+  var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+    function adopt(value) {
+      return value instanceof P ? value : new P(function(resolve) {
+        resolve(value);
       });
-    };
-    var _a;
-    Object.defineProperty(exports2, "__esModule", { value: true });
-    exports2.getCmdPath = exports2.tryGetExecutablePath = exports2.isRooted = exports2.isDirectory = exports2.exists = exports2.IS_WINDOWS = exports2.unlink = exports2.symlink = exports2.stat = exports2.rmdir = exports2.rename = exports2.readlink = exports2.readdir = exports2.mkdir = exports2.lstat = exports2.copyFile = exports2.chmod = void 0;
-    var fs = __importStar(require("fs"));
-    var path2 = __importStar(require("path"));
-    _a = fs.promises, exports2.chmod = _a.chmod, exports2.copyFile = _a.copyFile, exports2.lstat = _a.lstat, exports2.mkdir = _a.mkdir, exports2.readdir = _a.readdir, exports2.readlink = _a.readlink, exports2.rename = _a.rename, exports2.rmdir = _a.rmdir, exports2.stat = _a.stat, exports2.symlink = _a.symlink, exports2.unlink = _a.unlink;
-    exports2.IS_WINDOWS = process.platform === "win32";
-    function exists(fsPath) {
-      return __awaiter(this, void 0, void 0, function* () {
+    }
+    return new (P || (P = Promise))(function(resolve, reject) {
+      function fulfilled(value) {
         try {
-          yield exports2.stat(fsPath);
-        } catch (err) {
-          if (err.code === "ENOENT") {
-            return false;
-          }
-          throw err;
+          step(generator.next(value));
+        } catch (e) {
+          reject(e);
         }
-        return true;
-      });
-    }
-    exports2.exists = exists;
-    function isDirectory(fsPath, useStat = false) {
-      return __awaiter(this, void 0, void 0, function* () {
-        const stats = useStat ? yield exports2.stat(fsPath) : yield exports2.lstat(fsPath);
-        return stats.isDirectory();
-      });
-    }
-    exports2.isDirectory = isDirectory;
-    function isRooted(p) {
-      p = normalizeSeparators(p);
-      if (!p) {
-        throw new Error('isRooted() parameter "p" cannot be empty');
       }
-      if (exports2.IS_WINDOWS) {
-        return p.startsWith("\\") || /^[A-Z]:/i.test(p);
+      function rejected(value) {
+        try {
+          step(generator["throw"](value));
+        } catch (e) {
+          reject(e);
+        }
       }
-      return p.startsWith("/");
+      function step(result) {
+        result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+      }
+      step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+  };
+  var _a;
+  Object.defineProperty(exports2, "__esModule", {value: true});
+  exports2.getCmdPath = exports2.tryGetExecutablePath = exports2.isRooted = exports2.isDirectory = exports2.exists = exports2.IS_WINDOWS = exports2.unlink = exports2.symlink = exports2.stat = exports2.rmdir = exports2.rename = exports2.readlink = exports2.readdir = exports2.mkdir = exports2.lstat = exports2.copyFile = exports2.chmod = void 0;
+  var fs = __importStar(require("fs"));
+  var path2 = __importStar(require("path"));
+  _a = fs.promises, exports2.chmod = _a.chmod, exports2.copyFile = _a.copyFile, exports2.lstat = _a.lstat, exports2.mkdir = _a.mkdir, exports2.readdir = _a.readdir, exports2.readlink = _a.readlink, exports2.rename = _a.rename, exports2.rmdir = _a.rmdir, exports2.stat = _a.stat, exports2.symlink = _a.symlink, exports2.unlink = _a.unlink;
+  exports2.IS_WINDOWS = process.platform === "win32";
+  function exists(fsPath) {
+    return __awaiter(this, void 0, void 0, function* () {
+      try {
+        yield exports2.stat(fsPath);
+      } catch (err) {
+        if (err.code === "ENOENT") {
+          return false;
+        }
+        throw err;
+      }
+      return true;
+    });
+  }
+  exports2.exists = exists;
+  function isDirectory(fsPath, useStat = false) {
+    return __awaiter(this, void 0, void 0, function* () {
+      const stats = useStat ? yield exports2.stat(fsPath) : yield exports2.lstat(fsPath);
+      return stats.isDirectory();
+    });
+  }
+  exports2.isDirectory = isDirectory;
+  function isRooted(p) {
+    p = normalizeSeparators(p);
+    if (!p) {
+      throw new Error('isRooted() parameter "p" cannot be empty');
     }
-    exports2.isRooted = isRooted;
-    function tryGetExecutablePath(filePath, extensions) {
-      return __awaiter(this, void 0, void 0, function* () {
-        let stats = void 0;
+    if (exports2.IS_WINDOWS) {
+      return p.startsWith("\\") || /^[A-Z]:/i.test(p);
+    }
+    return p.startsWith("/");
+  }
+  exports2.isRooted = isRooted;
+  function tryGetExecutablePath(filePath, extensions) {
+    return __awaiter(this, void 0, void 0, function* () {
+      let stats = void 0;
+      try {
+        stats = yield exports2.stat(filePath);
+      } catch (err) {
+        if (err.code !== "ENOENT") {
+          console.log(`Unexpected error attempting to determine if executable file exists '${filePath}': ${err}`);
+        }
+      }
+      if (stats && stats.isFile()) {
+        if (exports2.IS_WINDOWS) {
+          const upperExt = path2.extname(filePath).toUpperCase();
+          if (extensions.some((validExt) => validExt.toUpperCase() === upperExt)) {
+            return filePath;
+          }
+        } else {
+          if (isUnixExecutable(stats)) {
+            return filePath;
+          }
+        }
+      }
+      const originalFilePath = filePath;
+      for (const extension of extensions) {
+        filePath = originalFilePath + extension;
+        stats = void 0;
         try {
           stats = yield exports2.stat(filePath);
         } catch (err) {
@@ -407,272 +428,1161 @@ var require_io_util = __commonJS({
         }
         if (stats && stats.isFile()) {
           if (exports2.IS_WINDOWS) {
-            const upperExt = path2.extname(filePath).toUpperCase();
-            if (extensions.some((validExt) => validExt.toUpperCase() === upperExt)) {
-              return filePath;
+            try {
+              const directory = path2.dirname(filePath);
+              const upperName = path2.basename(filePath).toUpperCase();
+              for (const actualName of yield exports2.readdir(directory)) {
+                if (upperName === actualName.toUpperCase()) {
+                  filePath = path2.join(directory, actualName);
+                  break;
+                }
+              }
+            } catch (err) {
+              console.log(`Unexpected error attempting to determine the actual case of the file '${filePath}': ${err}`);
             }
+            return filePath;
           } else {
             if (isUnixExecutable(stats)) {
               return filePath;
             }
           }
         }
-        const originalFilePath = filePath;
-        for (const extension of extensions) {
-          filePath = originalFilePath + extension;
-          stats = void 0;
-          try {
-            stats = yield exports2.stat(filePath);
-          } catch (err) {
-            if (err.code !== "ENOENT") {
-              console.log(`Unexpected error attempting to determine if executable file exists '${filePath}': ${err}`);
-            }
-          }
-          if (stats && stats.isFile()) {
-            if (exports2.IS_WINDOWS) {
-              try {
-                const directory = path2.dirname(filePath);
-                const upperName = path2.basename(filePath).toUpperCase();
-                for (const actualName of yield exports2.readdir(directory)) {
-                  if (upperName === actualName.toUpperCase()) {
-                    filePath = path2.join(directory, actualName);
-                    break;
-                  }
-                }
-              } catch (err) {
-                console.log(`Unexpected error attempting to determine the actual case of the file '${filePath}': ${err}`);
-              }
-              return filePath;
-            } else {
-              if (isUnixExecutable(stats)) {
-                return filePath;
-              }
-            }
-          }
-        }
-        return "";
-      });
-    }
-    exports2.tryGetExecutablePath = tryGetExecutablePath;
-    function normalizeSeparators(p) {
-      p = p || "";
-      if (exports2.IS_WINDOWS) {
-        p = p.replace(/\//g, "\\");
-        return p.replace(/\\\\+/g, "\\");
       }
-      return p.replace(/\/\/+/g, "/");
-    }
-    function isUnixExecutable(stats) {
-      return (stats.mode & 1) > 0 || (stats.mode & 8) > 0 && stats.gid === process.getgid() || (stats.mode & 64) > 0 && stats.uid === process.getuid();
-    }
-    function getCmdPath() {
-      var _a2;
-      return (_a2 = process.env["COMSPEC"]) !== null && _a2 !== void 0 ? _a2 : `cmd.exe`;
-    }
-    exports2.getCmdPath = getCmdPath;
+      return "";
+    });
   }
+  exports2.tryGetExecutablePath = tryGetExecutablePath;
+  function normalizeSeparators(p) {
+    p = p || "";
+    if (exports2.IS_WINDOWS) {
+      p = p.replace(/\//g, "\\");
+      return p.replace(/\\\\+/g, "\\");
+    }
+    return p.replace(/\/\/+/g, "/");
+  }
+  function isUnixExecutable(stats) {
+    return (stats.mode & 1) > 0 || (stats.mode & 8) > 0 && stats.gid === process.getgid() || (stats.mode & 64) > 0 && stats.uid === process.getuid();
+  }
+  function getCmdPath() {
+    var _a2;
+    return (_a2 = process.env["COMSPEC"]) !== null && _a2 !== void 0 ? _a2 : `cmd.exe`;
+  }
+  exports2.getCmdPath = getCmdPath;
 });
 
 // node_modules/@actions/exec/node_modules/@actions/io/lib/io.js
-var require_io = __commonJS({
-  "node_modules/@actions/exec/node_modules/@actions/io/lib/io.js"(exports2) {
-    "use strict";
-    var __createBinding = exports2 && exports2.__createBinding || (Object.create ? function(o, m, k, k2) {
-      if (k2 === void 0)
-        k2 = k;
-      Object.defineProperty(o, k2, { enumerable: true, get: function() {
-        return m[k];
-      } });
-    } : function(o, m, k, k2) {
-      if (k2 === void 0)
-        k2 = k;
-      o[k2] = m[k];
-    });
-    var __setModuleDefault = exports2 && exports2.__setModuleDefault || (Object.create ? function(o, v) {
-      Object.defineProperty(o, "default", { enumerable: true, value: v });
-    } : function(o, v) {
-      o["default"] = v;
-    });
-    var __importStar = exports2 && exports2.__importStar || function(mod) {
-      if (mod && mod.__esModule)
-        return mod;
-      var result = {};
-      if (mod != null) {
-        for (var k in mod)
-          if (k !== "default" && Object.hasOwnProperty.call(mod, k))
-            __createBinding(result, mod, k);
-      }
-      __setModuleDefault(result, mod);
-      return result;
-    };
-    var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
-      function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve) {
-          resolve(value);
-        });
-      }
-      return new (P || (P = Promise))(function(resolve, reject) {
-        function fulfilled(value) {
-          try {
-            step(generator.next(value));
-          } catch (e) {
-            reject(e);
-          }
-        }
-        function rejected(value) {
-          try {
-            step(generator["throw"](value));
-          } catch (e) {
-            reject(e);
-          }
-        }
-        function step(result) {
-          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
-        }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
+var require_io = __commonJS((exports2) => {
+  "use strict";
+  var __createBinding = exports2 && exports2.__createBinding || (Object.create ? function(o, m, k, k2) {
+    if (k2 === void 0)
+      k2 = k;
+    Object.defineProperty(o, k2, {enumerable: true, get: function() {
+      return m[k];
+    }});
+  } : function(o, m, k, k2) {
+    if (k2 === void 0)
+      k2 = k;
+    o[k2] = m[k];
+  });
+  var __setModuleDefault = exports2 && exports2.__setModuleDefault || (Object.create ? function(o, v) {
+    Object.defineProperty(o, "default", {enumerable: true, value: v});
+  } : function(o, v) {
+    o["default"] = v;
+  });
+  var __importStar = exports2 && exports2.__importStar || function(mod) {
+    if (mod && mod.__esModule)
+      return mod;
+    var result = {};
+    if (mod != null) {
+      for (var k in mod)
+        if (k !== "default" && Object.hasOwnProperty.call(mod, k))
+          __createBinding(result, mod, k);
+    }
+    __setModuleDefault(result, mod);
+    return result;
+  };
+  var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+    function adopt(value) {
+      return value instanceof P ? value : new P(function(resolve) {
+        resolve(value);
       });
-    };
-    Object.defineProperty(exports2, "__esModule", { value: true });
-    exports2.findInPath = exports2.which = exports2.mkdirP = exports2.rmRF = exports2.mv = exports2.cp = void 0;
-    var assert_1 = require("assert");
-    var childProcess = __importStar(require("child_process"));
-    var path2 = __importStar(require("path"));
-    var util_1 = require("util");
-    var ioUtil = __importStar(require_io_util());
-    var exec3 = util_1.promisify(childProcess.exec);
-    var execFile = util_1.promisify(childProcess.execFile);
-    function cp(source, dest, options = {}) {
-      return __awaiter(this, void 0, void 0, function* () {
-        const { force, recursive, copySourceDirectory } = readCopyOptions(options);
-        const destStat = (yield ioUtil.exists(dest)) ? yield ioUtil.stat(dest) : null;
-        if (destStat && destStat.isFile() && !force) {
+    }
+    return new (P || (P = Promise))(function(resolve, reject) {
+      function fulfilled(value) {
+        try {
+          step(generator.next(value));
+        } catch (e) {
+          reject(e);
+        }
+      }
+      function rejected(value) {
+        try {
+          step(generator["throw"](value));
+        } catch (e) {
+          reject(e);
+        }
+      }
+      function step(result) {
+        result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+      }
+      step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+  };
+  Object.defineProperty(exports2, "__esModule", {value: true});
+  exports2.findInPath = exports2.which = exports2.mkdirP = exports2.rmRF = exports2.mv = exports2.cp = void 0;
+  var assert_1 = require("assert");
+  var childProcess = __importStar(require("child_process"));
+  var path2 = __importStar(require("path"));
+  var util_1 = require("util");
+  var ioUtil = __importStar(require_io_util());
+  var exec3 = util_1.promisify(childProcess.exec);
+  var execFile = util_1.promisify(childProcess.execFile);
+  function cp(source, dest, options = {}) {
+    return __awaiter(this, void 0, void 0, function* () {
+      const {force, recursive, copySourceDirectory} = readCopyOptions(options);
+      const destStat = (yield ioUtil.exists(dest)) ? yield ioUtil.stat(dest) : null;
+      if (destStat && destStat.isFile() && !force) {
+        return;
+      }
+      const newDest = destStat && destStat.isDirectory() && copySourceDirectory ? path2.join(dest, path2.basename(source)) : dest;
+      if (!(yield ioUtil.exists(source))) {
+        throw new Error(`no such file or directory: ${source}`);
+      }
+      const sourceStat = yield ioUtil.stat(source);
+      if (sourceStat.isDirectory()) {
+        if (!recursive) {
+          throw new Error(`Failed to copy. ${source} is a directory, but tried to copy without recursive flag.`);
+        } else {
+          yield cpDirRecursive(source, newDest, 0, force);
+        }
+      } else {
+        if (path2.relative(source, newDest) === "") {
+          throw new Error(`'${newDest}' and '${source}' are the same file`);
+        }
+        yield copyFile(source, newDest, force);
+      }
+    });
+  }
+  exports2.cp = cp;
+  function mv(source, dest, options = {}) {
+    return __awaiter(this, void 0, void 0, function* () {
+      if (yield ioUtil.exists(dest)) {
+        let destExists = true;
+        if (yield ioUtil.isDirectory(dest)) {
+          dest = path2.join(dest, path2.basename(source));
+          destExists = yield ioUtil.exists(dest);
+        }
+        if (destExists) {
+          if (options.force == null || options.force) {
+            yield rmRF(dest);
+          } else {
+            throw new Error("Destination already exists");
+          }
+        }
+      }
+      yield mkdirP(path2.dirname(dest));
+      yield ioUtil.rename(source, dest);
+    });
+  }
+  exports2.mv = mv;
+  function rmRF(inputPath) {
+    return __awaiter(this, void 0, void 0, function* () {
+      if (ioUtil.IS_WINDOWS) {
+        if (/[*"<>|]/.test(inputPath)) {
+          throw new Error('File path must not contain `*`, `"`, `<`, `>` or `|` on Windows');
+        }
+        try {
+          const cmdPath = ioUtil.getCmdPath();
+          if (yield ioUtil.isDirectory(inputPath, true)) {
+            yield exec3(`${cmdPath} /s /c "rd /s /q "%inputPath%""`, {
+              env: {inputPath}
+            });
+          } else {
+            yield exec3(`${cmdPath} /s /c "del /f /a "%inputPath%""`, {
+              env: {inputPath}
+            });
+          }
+        } catch (err) {
+          if (err.code !== "ENOENT")
+            throw err;
+        }
+        try {
+          yield ioUtil.unlink(inputPath);
+        } catch (err) {
+          if (err.code !== "ENOENT")
+            throw err;
+        }
+      } else {
+        let isDir = false;
+        try {
+          isDir = yield ioUtil.isDirectory(inputPath);
+        } catch (err) {
+          if (err.code !== "ENOENT")
+            throw err;
           return;
         }
-        const newDest = destStat && destStat.isDirectory() && copySourceDirectory ? path2.join(dest, path2.basename(source)) : dest;
-        if (!(yield ioUtil.exists(source))) {
-          throw new Error(`no such file or directory: ${source}`);
+        if (isDir) {
+          yield execFile(`rm`, [`-rf`, `${inputPath}`]);
+        } else {
+          yield ioUtil.unlink(inputPath);
         }
-        const sourceStat = yield ioUtil.stat(source);
-        if (sourceStat.isDirectory()) {
-          if (!recursive) {
-            throw new Error(`Failed to copy. ${source} is a directory, but tried to copy without recursive flag.`);
+      }
+    });
+  }
+  exports2.rmRF = rmRF;
+  function mkdirP(fsPath) {
+    return __awaiter(this, void 0, void 0, function* () {
+      assert_1.ok(fsPath, "a path argument must be provided");
+      yield ioUtil.mkdir(fsPath, {recursive: true});
+    });
+  }
+  exports2.mkdirP = mkdirP;
+  function which2(tool, check) {
+    return __awaiter(this, void 0, void 0, function* () {
+      if (!tool) {
+        throw new Error("parameter 'tool' is required");
+      }
+      if (check) {
+        const result = yield which2(tool, false);
+        if (!result) {
+          if (ioUtil.IS_WINDOWS) {
+            throw new Error(`Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also verify the file has a valid extension for an executable file.`);
           } else {
-            yield cpDirRecursive(source, newDest, 0, force);
-          }
-        } else {
-          if (path2.relative(source, newDest) === "") {
-            throw new Error(`'${newDest}' and '${source}' are the same file`);
-          }
-          yield copyFile(source, newDest, force);
-        }
-      });
-    }
-    exports2.cp = cp;
-    function mv(source, dest, options = {}) {
-      return __awaiter(this, void 0, void 0, function* () {
-        if (yield ioUtil.exists(dest)) {
-          let destExists = true;
-          if (yield ioUtil.isDirectory(dest)) {
-            dest = path2.join(dest, path2.basename(source));
-            destExists = yield ioUtil.exists(dest);
-          }
-          if (destExists) {
-            if (options.force == null || options.force) {
-              yield rmRF(dest);
-            } else {
-              throw new Error("Destination already exists");
-            }
+            throw new Error(`Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also check the file mode to verify the file is executable.`);
           }
         }
-        yield mkdirP(path2.dirname(dest));
-        yield ioUtil.rename(source, dest);
+        return result;
+      }
+      const matches = yield findInPath(tool);
+      if (matches && matches.length > 0) {
+        return matches[0];
+      }
+      return "";
+    });
+  }
+  exports2.which = which2;
+  function findInPath(tool) {
+    return __awaiter(this, void 0, void 0, function* () {
+      if (!tool) {
+        throw new Error("parameter 'tool' is required");
+      }
+      const extensions = [];
+      if (ioUtil.IS_WINDOWS && process.env["PATHEXT"]) {
+        for (const extension of process.env["PATHEXT"].split(path2.delimiter)) {
+          if (extension) {
+            extensions.push(extension);
+          }
+        }
+      }
+      if (ioUtil.isRooted(tool)) {
+        const filePath = yield ioUtil.tryGetExecutablePath(tool, extensions);
+        if (filePath) {
+          return [filePath];
+        }
+        return [];
+      }
+      if (tool.includes(path2.sep)) {
+        return [];
+      }
+      const directories = [];
+      if (process.env.PATH) {
+        for (const p of process.env.PATH.split(path2.delimiter)) {
+          if (p) {
+            directories.push(p);
+          }
+        }
+      }
+      const matches = [];
+      for (const directory of directories) {
+        const filePath = yield ioUtil.tryGetExecutablePath(path2.join(directory, tool), extensions);
+        if (filePath) {
+          matches.push(filePath);
+        }
+      }
+      return matches;
+    });
+  }
+  exports2.findInPath = findInPath;
+  function readCopyOptions(options) {
+    const force = options.force == null ? true : options.force;
+    const recursive = Boolean(options.recursive);
+    const copySourceDirectory = options.copySourceDirectory == null ? true : Boolean(options.copySourceDirectory);
+    return {force, recursive, copySourceDirectory};
+  }
+  function cpDirRecursive(sourceDir, destDir, currentDepth, force) {
+    return __awaiter(this, void 0, void 0, function* () {
+      if (currentDepth >= 255)
+        return;
+      currentDepth++;
+      yield mkdirP(destDir);
+      const files = yield ioUtil.readdir(sourceDir);
+      for (const fileName of files) {
+        const srcFile = `${sourceDir}/${fileName}`;
+        const destFile = `${destDir}/${fileName}`;
+        const srcFileStat = yield ioUtil.lstat(srcFile);
+        if (srcFileStat.isDirectory()) {
+          yield cpDirRecursive(srcFile, destFile, currentDepth, force);
+        } else {
+          yield copyFile(srcFile, destFile, force);
+        }
+      }
+      yield ioUtil.chmod(destDir, (yield ioUtil.stat(sourceDir)).mode);
+    });
+  }
+  function copyFile(srcFile, destFile, force) {
+    return __awaiter(this, void 0, void 0, function* () {
+      if ((yield ioUtil.lstat(srcFile)).isSymbolicLink()) {
+        try {
+          yield ioUtil.lstat(destFile);
+          yield ioUtil.unlink(destFile);
+        } catch (e) {
+          if (e.code === "EPERM") {
+            yield ioUtil.chmod(destFile, "0666");
+            yield ioUtil.unlink(destFile);
+          }
+        }
+        const symlinkFull = yield ioUtil.readlink(srcFile);
+        yield ioUtil.symlink(symlinkFull, destFile, ioUtil.IS_WINDOWS ? "junction" : null);
+      } else if (!(yield ioUtil.exists(destFile)) || force) {
+        yield ioUtil.copyFile(srcFile, destFile);
+      }
+    });
+  }
+});
+
+// node_modules/@actions/exec/lib/toolrunner.js
+var require_toolrunner = __commonJS((exports2) => {
+  "use strict";
+  var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+    function adopt(value) {
+      return value instanceof P ? value : new P(function(resolve) {
+        resolve(value);
       });
     }
-    exports2.mv = mv;
-    function rmRF(inputPath) {
-      return __awaiter(this, void 0, void 0, function* () {
-        if (ioUtil.IS_WINDOWS) {
-          if (/[*"<>|]/.test(inputPath)) {
-            throw new Error('File path must not contain `*`, `"`, `<`, `>` or `|` on Windows');
+    return new (P || (P = Promise))(function(resolve, reject) {
+      function fulfilled(value) {
+        try {
+          step(generator.next(value));
+        } catch (e) {
+          reject(e);
+        }
+      }
+      function rejected(value) {
+        try {
+          step(generator["throw"](value));
+        } catch (e) {
+          reject(e);
+        }
+      }
+      function step(result) {
+        result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+      }
+      step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+  };
+  var __importStar = exports2 && exports2.__importStar || function(mod) {
+    if (mod && mod.__esModule)
+      return mod;
+    var result = {};
+    if (mod != null) {
+      for (var k in mod)
+        if (Object.hasOwnProperty.call(mod, k))
+          result[k] = mod[k];
+    }
+    result["default"] = mod;
+    return result;
+  };
+  Object.defineProperty(exports2, "__esModule", {value: true});
+  var os2 = __importStar(require("os"));
+  var events = __importStar(require("events"));
+  var child = __importStar(require("child_process"));
+  var path2 = __importStar(require("path"));
+  var io2 = __importStar(require_io());
+  var ioUtil = __importStar(require_io_util());
+  var IS_WINDOWS = process.platform === "win32";
+  var ToolRunner = class extends events.EventEmitter {
+    constructor(toolPath, args, options) {
+      super();
+      if (!toolPath) {
+        throw new Error("Parameter 'toolPath' cannot be null or empty.");
+      }
+      this.toolPath = toolPath;
+      this.args = args || [];
+      this.options = options || {};
+    }
+    _debug(message) {
+      if (this.options.listeners && this.options.listeners.debug) {
+        this.options.listeners.debug(message);
+      }
+    }
+    _getCommandString(options, noPrefix) {
+      const toolPath = this._getSpawnFileName();
+      const args = this._getSpawnArgs(options);
+      let cmd = noPrefix ? "" : "[command]";
+      if (IS_WINDOWS) {
+        if (this._isCmdFile()) {
+          cmd += toolPath;
+          for (const a of args) {
+            cmd += ` ${a}`;
           }
-          try {
-            const cmdPath = ioUtil.getCmdPath();
-            if (yield ioUtil.isDirectory(inputPath, true)) {
-              yield exec3(`${cmdPath} /s /c "rd /s /q "%inputPath%""`, {
-                env: { inputPath }
-              });
-            } else {
-              yield exec3(`${cmdPath} /s /c "del /f /a "%inputPath%""`, {
-                env: { inputPath }
-              });
-            }
-          } catch (err) {
-            if (err.code !== "ENOENT")
-              throw err;
-          }
-          try {
-            yield ioUtil.unlink(inputPath);
-          } catch (err) {
-            if (err.code !== "ENOENT")
-              throw err;
+        } else if (options.windowsVerbatimArguments) {
+          cmd += `"${toolPath}"`;
+          for (const a of args) {
+            cmd += ` ${a}`;
           }
         } else {
-          let isDir = false;
-          try {
-            isDir = yield ioUtil.isDirectory(inputPath);
-          } catch (err) {
-            if (err.code !== "ENOENT")
-              throw err;
+          cmd += this._windowsQuoteCmdArg(toolPath);
+          for (const a of args) {
+            cmd += ` ${this._windowsQuoteCmdArg(a)}`;
+          }
+        }
+      } else {
+        cmd += toolPath;
+        for (const a of args) {
+          cmd += ` ${a}`;
+        }
+      }
+      return cmd;
+    }
+    _processLineBuffer(data, strBuffer, onLine) {
+      try {
+        let s = strBuffer + data.toString();
+        let n = s.indexOf(os2.EOL);
+        while (n > -1) {
+          const line = s.substring(0, n);
+          onLine(line);
+          s = s.substring(n + os2.EOL.length);
+          n = s.indexOf(os2.EOL);
+        }
+        strBuffer = s;
+      } catch (err) {
+        this._debug(`error processing line. Failed with error ${err}`);
+      }
+    }
+    _getSpawnFileName() {
+      if (IS_WINDOWS) {
+        if (this._isCmdFile()) {
+          return process.env["COMSPEC"] || "cmd.exe";
+        }
+      }
+      return this.toolPath;
+    }
+    _getSpawnArgs(options) {
+      if (IS_WINDOWS) {
+        if (this._isCmdFile()) {
+          let argline = `/D /S /C "${this._windowsQuoteCmdArg(this.toolPath)}`;
+          for (const a of this.args) {
+            argline += " ";
+            argline += options.windowsVerbatimArguments ? a : this._windowsQuoteCmdArg(a);
+          }
+          argline += '"';
+          return [argline];
+        }
+      }
+      return this.args;
+    }
+    _endsWith(str, end) {
+      return str.endsWith(end);
+    }
+    _isCmdFile() {
+      const upperToolPath = this.toolPath.toUpperCase();
+      return this._endsWith(upperToolPath, ".CMD") || this._endsWith(upperToolPath, ".BAT");
+    }
+    _windowsQuoteCmdArg(arg) {
+      if (!this._isCmdFile()) {
+        return this._uvQuoteCmdArg(arg);
+      }
+      if (!arg) {
+        return '""';
+      }
+      const cmdSpecialChars = [
+        " ",
+        "	",
+        "&",
+        "(",
+        ")",
+        "[",
+        "]",
+        "{",
+        "}",
+        "^",
+        "=",
+        ";",
+        "!",
+        "'",
+        "+",
+        ",",
+        "`",
+        "~",
+        "|",
+        "<",
+        ">",
+        '"'
+      ];
+      let needsQuotes = false;
+      for (const char of arg) {
+        if (cmdSpecialChars.some((x) => x === char)) {
+          needsQuotes = true;
+          break;
+        }
+      }
+      if (!needsQuotes) {
+        return arg;
+      }
+      let reverse = '"';
+      let quoteHit = true;
+      for (let i = arg.length; i > 0; i--) {
+        reverse += arg[i - 1];
+        if (quoteHit && arg[i - 1] === "\\") {
+          reverse += "\\";
+        } else if (arg[i - 1] === '"') {
+          quoteHit = true;
+          reverse += '"';
+        } else {
+          quoteHit = false;
+        }
+      }
+      reverse += '"';
+      return reverse.split("").reverse().join("");
+    }
+    _uvQuoteCmdArg(arg) {
+      if (!arg) {
+        return '""';
+      }
+      if (!arg.includes(" ") && !arg.includes("	") && !arg.includes('"')) {
+        return arg;
+      }
+      if (!arg.includes('"') && !arg.includes("\\")) {
+        return `"${arg}"`;
+      }
+      let reverse = '"';
+      let quoteHit = true;
+      for (let i = arg.length; i > 0; i--) {
+        reverse += arg[i - 1];
+        if (quoteHit && arg[i - 1] === "\\") {
+          reverse += "\\";
+        } else if (arg[i - 1] === '"') {
+          quoteHit = true;
+          reverse += "\\";
+        } else {
+          quoteHit = false;
+        }
+      }
+      reverse += '"';
+      return reverse.split("").reverse().join("");
+    }
+    _cloneExecOptions(options) {
+      options = options || {};
+      const result = {
+        cwd: options.cwd || process.cwd(),
+        env: options.env || process.env,
+        silent: options.silent || false,
+        windowsVerbatimArguments: options.windowsVerbatimArguments || false,
+        failOnStdErr: options.failOnStdErr || false,
+        ignoreReturnCode: options.ignoreReturnCode || false,
+        delay: options.delay || 1e4
+      };
+      result.outStream = options.outStream || process.stdout;
+      result.errStream = options.errStream || process.stderr;
+      return result;
+    }
+    _getSpawnOptions(options, toolPath) {
+      options = options || {};
+      const result = {};
+      result.cwd = options.cwd;
+      result.env = options.env;
+      result["windowsVerbatimArguments"] = options.windowsVerbatimArguments || this._isCmdFile();
+      if (options.windowsVerbatimArguments) {
+        result.argv0 = `"${toolPath}"`;
+      }
+      return result;
+    }
+    exec() {
+      return __awaiter(this, void 0, void 0, function* () {
+        if (!ioUtil.isRooted(this.toolPath) && (this.toolPath.includes("/") || IS_WINDOWS && this.toolPath.includes("\\"))) {
+          this.toolPath = path2.resolve(process.cwd(), this.options.cwd || process.cwd(), this.toolPath);
+        }
+        this.toolPath = yield io2.which(this.toolPath, true);
+        return new Promise((resolve, reject) => {
+          this._debug(`exec tool: ${this.toolPath}`);
+          this._debug("arguments:");
+          for (const arg of this.args) {
+            this._debug(`   ${arg}`);
+          }
+          const optionsNonNull = this._cloneExecOptions(this.options);
+          if (!optionsNonNull.silent && optionsNonNull.outStream) {
+            optionsNonNull.outStream.write(this._getCommandString(optionsNonNull) + os2.EOL);
+          }
+          const state = new ExecState(optionsNonNull, this.toolPath);
+          state.on("debug", (message) => {
+            this._debug(message);
+          });
+          const fileName = this._getSpawnFileName();
+          const cp = child.spawn(fileName, this._getSpawnArgs(optionsNonNull), this._getSpawnOptions(this.options, fileName));
+          const stdbuffer = "";
+          if (cp.stdout) {
+            cp.stdout.on("data", (data) => {
+              if (this.options.listeners && this.options.listeners.stdout) {
+                this.options.listeners.stdout(data);
+              }
+              if (!optionsNonNull.silent && optionsNonNull.outStream) {
+                optionsNonNull.outStream.write(data);
+              }
+              this._processLineBuffer(data, stdbuffer, (line) => {
+                if (this.options.listeners && this.options.listeners.stdline) {
+                  this.options.listeners.stdline(line);
+                }
+              });
+            });
+          }
+          const errbuffer = "";
+          if (cp.stderr) {
+            cp.stderr.on("data", (data) => {
+              state.processStderr = true;
+              if (this.options.listeners && this.options.listeners.stderr) {
+                this.options.listeners.stderr(data);
+              }
+              if (!optionsNonNull.silent && optionsNonNull.errStream && optionsNonNull.outStream) {
+                const s = optionsNonNull.failOnStdErr ? optionsNonNull.errStream : optionsNonNull.outStream;
+                s.write(data);
+              }
+              this._processLineBuffer(data, errbuffer, (line) => {
+                if (this.options.listeners && this.options.listeners.errline) {
+                  this.options.listeners.errline(line);
+                }
+              });
+            });
+          }
+          cp.on("error", (err) => {
+            state.processError = err.message;
+            state.processExited = true;
+            state.processClosed = true;
+            state.CheckComplete();
+          });
+          cp.on("exit", (code) => {
+            state.processExitCode = code;
+            state.processExited = true;
+            this._debug(`Exit code ${code} received from tool '${this.toolPath}'`);
+            state.CheckComplete();
+          });
+          cp.on("close", (code) => {
+            state.processExitCode = code;
+            state.processExited = true;
+            state.processClosed = true;
+            this._debug(`STDIO streams have closed for tool '${this.toolPath}'`);
+            state.CheckComplete();
+          });
+          state.on("done", (error, exitCode) => {
+            if (stdbuffer.length > 0) {
+              this.emit("stdline", stdbuffer);
+            }
+            if (errbuffer.length > 0) {
+              this.emit("errline", errbuffer);
+            }
+            cp.removeAllListeners();
+            if (error) {
+              reject(error);
+            } else {
+              resolve(exitCode);
+            }
+          });
+          if (this.options.input) {
+            if (!cp.stdin) {
+              throw new Error("child process missing stdin");
+            }
+            cp.stdin.end(this.options.input);
+          }
+        });
+      });
+    }
+  };
+  exports2.ToolRunner = ToolRunner;
+  function argStringToArray(argString) {
+    const args = [];
+    let inQuotes = false;
+    let escaped = false;
+    let arg = "";
+    function append(c) {
+      if (escaped && c !== '"') {
+        arg += "\\";
+      }
+      arg += c;
+      escaped = false;
+    }
+    for (let i = 0; i < argString.length; i++) {
+      const c = argString.charAt(i);
+      if (c === '"') {
+        if (!escaped) {
+          inQuotes = !inQuotes;
+        } else {
+          append(c);
+        }
+        continue;
+      }
+      if (c === "\\" && escaped) {
+        append(c);
+        continue;
+      }
+      if (c === "\\" && inQuotes) {
+        escaped = true;
+        continue;
+      }
+      if (c === " " && !inQuotes) {
+        if (arg.length > 0) {
+          args.push(arg);
+          arg = "";
+        }
+        continue;
+      }
+      append(c);
+    }
+    if (arg.length > 0) {
+      args.push(arg.trim());
+    }
+    return args;
+  }
+  exports2.argStringToArray = argStringToArray;
+  var ExecState = class extends events.EventEmitter {
+    constructor(options, toolPath) {
+      super();
+      this.processClosed = false;
+      this.processError = "";
+      this.processExitCode = 0;
+      this.processExited = false;
+      this.processStderr = false;
+      this.delay = 1e4;
+      this.done = false;
+      this.timeout = null;
+      if (!toolPath) {
+        throw new Error("toolPath must not be empty");
+      }
+      this.options = options;
+      this.toolPath = toolPath;
+      if (options.delay) {
+        this.delay = options.delay;
+      }
+    }
+    CheckComplete() {
+      if (this.done) {
+        return;
+      }
+      if (this.processClosed) {
+        this._setResult();
+      } else if (this.processExited) {
+        this.timeout = setTimeout(ExecState.HandleTimeout, this.delay, this);
+      }
+    }
+    _debug(message) {
+      this.emit("debug", message);
+    }
+    _setResult() {
+      let error;
+      if (this.processExited) {
+        if (this.processError) {
+          error = new Error(`There was an error when attempting to execute the process '${this.toolPath}'. This may indicate the process failed to start. Error: ${this.processError}`);
+        } else if (this.processExitCode !== 0 && !this.options.ignoreReturnCode) {
+          error = new Error(`The process '${this.toolPath}' failed with exit code ${this.processExitCode}`);
+        } else if (this.processStderr && this.options.failOnStdErr) {
+          error = new Error(`The process '${this.toolPath}' failed because one or more lines were written to the STDERR stream`);
+        }
+      }
+      if (this.timeout) {
+        clearTimeout(this.timeout);
+        this.timeout = null;
+      }
+      this.done = true;
+      this.emit("done", error, this.processExitCode);
+    }
+    static HandleTimeout(state) {
+      if (state.done) {
+        return;
+      }
+      if (!state.processClosed && state.processExited) {
+        const message = `The STDIO streams did not close within ${state.delay / 1e3} seconds of the exit event from process '${state.toolPath}'. This may indicate a child process inherited the STDIO streams and has not yet exited.`;
+        state._debug(message);
+      }
+      state._setResult();
+    }
+  };
+});
+
+// node_modules/@actions/exec/lib/exec.js
+var require_exec = __commonJS((exports2) => {
+  "use strict";
+  var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+    function adopt(value) {
+      return value instanceof P ? value : new P(function(resolve) {
+        resolve(value);
+      });
+    }
+    return new (P || (P = Promise))(function(resolve, reject) {
+      function fulfilled(value) {
+        try {
+          step(generator.next(value));
+        } catch (e) {
+          reject(e);
+        }
+      }
+      function rejected(value) {
+        try {
+          step(generator["throw"](value));
+        } catch (e) {
+          reject(e);
+        }
+      }
+      function step(result) {
+        result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+      }
+      step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+  };
+  var __importStar = exports2 && exports2.__importStar || function(mod) {
+    if (mod && mod.__esModule)
+      return mod;
+    var result = {};
+    if (mod != null) {
+      for (var k in mod)
+        if (Object.hasOwnProperty.call(mod, k))
+          result[k] = mod[k];
+    }
+    result["default"] = mod;
+    return result;
+  };
+  Object.defineProperty(exports2, "__esModule", {value: true});
+  var tr = __importStar(require_toolrunner());
+  function exec3(commandLine, args, options) {
+    return __awaiter(this, void 0, void 0, function* () {
+      const commandArgs = tr.argStringToArray(commandLine);
+      if (commandArgs.length === 0) {
+        throw new Error(`Parameter 'commandLine' cannot be null or empty.`);
+      }
+      const toolPath = commandArgs[0];
+      args = commandArgs.slice(1).concat(args || []);
+      const runner = new tr.ToolRunner(toolPath, args, options);
+      return runner.exec();
+    });
+  }
+  exports2.exec = exec3;
+});
+
+// node_modules/@actions/io/lib/io-util.js
+var require_io_util2 = __commonJS((exports2) => {
+  "use strict";
+  var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+    function adopt(value) {
+      return value instanceof P ? value : new P(function(resolve) {
+        resolve(value);
+      });
+    }
+    return new (P || (P = Promise))(function(resolve, reject) {
+      function fulfilled(value) {
+        try {
+          step(generator.next(value));
+        } catch (e) {
+          reject(e);
+        }
+      }
+      function rejected(value) {
+        try {
+          step(generator["throw"](value));
+        } catch (e) {
+          reject(e);
+        }
+      }
+      function step(result) {
+        result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+      }
+      step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+  };
+  var _a;
+  Object.defineProperty(exports2, "__esModule", {value: true});
+  var assert_1 = require("assert");
+  var fs = require("fs");
+  var path2 = require("path");
+  _a = fs.promises, exports2.chmod = _a.chmod, exports2.copyFile = _a.copyFile, exports2.lstat = _a.lstat, exports2.mkdir = _a.mkdir, exports2.readdir = _a.readdir, exports2.readlink = _a.readlink, exports2.rename = _a.rename, exports2.rmdir = _a.rmdir, exports2.stat = _a.stat, exports2.symlink = _a.symlink, exports2.unlink = _a.unlink;
+  exports2.IS_WINDOWS = process.platform === "win32";
+  function exists(fsPath) {
+    return __awaiter(this, void 0, void 0, function* () {
+      try {
+        yield exports2.stat(fsPath);
+      } catch (err) {
+        if (err.code === "ENOENT") {
+          return false;
+        }
+        throw err;
+      }
+      return true;
+    });
+  }
+  exports2.exists = exists;
+  function isDirectory(fsPath, useStat = false) {
+    return __awaiter(this, void 0, void 0, function* () {
+      const stats = useStat ? yield exports2.stat(fsPath) : yield exports2.lstat(fsPath);
+      return stats.isDirectory();
+    });
+  }
+  exports2.isDirectory = isDirectory;
+  function isRooted(p) {
+    p = normalizeSeparators(p);
+    if (!p) {
+      throw new Error('isRooted() parameter "p" cannot be empty');
+    }
+    if (exports2.IS_WINDOWS) {
+      return p.startsWith("\\") || /^[A-Z]:/i.test(p);
+    }
+    return p.startsWith("/");
+  }
+  exports2.isRooted = isRooted;
+  function mkdirP(fsPath, maxDepth = 1e3, depth = 1) {
+    return __awaiter(this, void 0, void 0, function* () {
+      assert_1.ok(fsPath, "a path argument must be provided");
+      fsPath = path2.resolve(fsPath);
+      if (depth >= maxDepth)
+        return exports2.mkdir(fsPath);
+      try {
+        yield exports2.mkdir(fsPath);
+        return;
+      } catch (err) {
+        switch (err.code) {
+          case "ENOENT": {
+            yield mkdirP(path2.dirname(fsPath), maxDepth, depth + 1);
+            yield exports2.mkdir(fsPath);
             return;
           }
-          if (isDir) {
-            yield execFile(`rm`, [`-rf`, `${inputPath}`]);
-          } else {
-            yield ioUtil.unlink(inputPath);
+          default: {
+            let stats;
+            try {
+              stats = yield exports2.stat(fsPath);
+            } catch (err2) {
+              throw err;
+            }
+            if (!stats.isDirectory())
+              throw err;
           }
         }
-      });
-    }
-    exports2.rmRF = rmRF;
-    function mkdirP(fsPath) {
-      return __awaiter(this, void 0, void 0, function* () {
-        assert_1.ok(fsPath, "a path argument must be provided");
-        yield ioUtil.mkdir(fsPath, { recursive: true });
-      });
-    }
-    exports2.mkdirP = mkdirP;
-    function which2(tool, check) {
-      return __awaiter(this, void 0, void 0, function* () {
-        if (!tool) {
-          throw new Error("parameter 'tool' is required");
+      }
+    });
+  }
+  exports2.mkdirP = mkdirP;
+  function tryGetExecutablePath(filePath, extensions) {
+    return __awaiter(this, void 0, void 0, function* () {
+      let stats = void 0;
+      try {
+        stats = yield exports2.stat(filePath);
+      } catch (err) {
+        if (err.code !== "ENOENT") {
+          console.log(`Unexpected error attempting to determine if executable file exists '${filePath}': ${err}`);
         }
-        if (check) {
-          const result = yield which2(tool, false);
-          if (!result) {
-            if (ioUtil.IS_WINDOWS) {
-              throw new Error(`Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also verify the file has a valid extension for an executable file.`);
-            } else {
-              throw new Error(`Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also check the file mode to verify the file is executable.`);
+      }
+      if (stats && stats.isFile()) {
+        if (exports2.IS_WINDOWS) {
+          const upperExt = path2.extname(filePath).toUpperCase();
+          if (extensions.some((validExt) => validExt.toUpperCase() === upperExt)) {
+            return filePath;
+          }
+        } else {
+          if (isUnixExecutable(stats)) {
+            return filePath;
+          }
+        }
+      }
+      const originalFilePath = filePath;
+      for (const extension of extensions) {
+        filePath = originalFilePath + extension;
+        stats = void 0;
+        try {
+          stats = yield exports2.stat(filePath);
+        } catch (err) {
+          if (err.code !== "ENOENT") {
+            console.log(`Unexpected error attempting to determine if executable file exists '${filePath}': ${err}`);
+          }
+        }
+        if (stats && stats.isFile()) {
+          if (exports2.IS_WINDOWS) {
+            try {
+              const directory = path2.dirname(filePath);
+              const upperName = path2.basename(filePath).toUpperCase();
+              for (const actualName of yield exports2.readdir(directory)) {
+                if (upperName === actualName.toUpperCase()) {
+                  filePath = path2.join(directory, actualName);
+                  break;
+                }
+              }
+            } catch (err) {
+              console.log(`Unexpected error attempting to determine the actual case of the file '${filePath}': ${err}`);
+            }
+            return filePath;
+          } else {
+            if (isUnixExecutable(stats)) {
+              return filePath;
             }
           }
-          return result;
         }
-        const matches = yield findInPath(tool);
-        if (matches && matches.length > 0) {
-          return matches[0];
-        }
-        return "";
+      }
+      return "";
+    });
+  }
+  exports2.tryGetExecutablePath = tryGetExecutablePath;
+  function normalizeSeparators(p) {
+    p = p || "";
+    if (exports2.IS_WINDOWS) {
+      p = p.replace(/\//g, "\\");
+      return p.replace(/\\\\+/g, "\\");
+    }
+    return p.replace(/\/\/+/g, "/");
+  }
+  function isUnixExecutable(stats) {
+    return (stats.mode & 1) > 0 || (stats.mode & 8) > 0 && stats.gid === process.getgid() || (stats.mode & 64) > 0 && stats.uid === process.getuid();
+  }
+});
+
+// node_modules/@actions/io/lib/io.js
+var require_io2 = __commonJS((exports2) => {
+  "use strict";
+  var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+    function adopt(value) {
+      return value instanceof P ? value : new P(function(resolve) {
+        resolve(value);
       });
     }
-    exports2.which = which2;
-    function findInPath(tool) {
-      return __awaiter(this, void 0, void 0, function* () {
-        if (!tool) {
-          throw new Error("parameter 'tool' is required");
+    return new (P || (P = Promise))(function(resolve, reject) {
+      function fulfilled(value) {
+        try {
+          step(generator.next(value));
+        } catch (e) {
+          reject(e);
         }
+      }
+      function rejected(value) {
+        try {
+          step(generator["throw"](value));
+        } catch (e) {
+          reject(e);
+        }
+      }
+      function step(result) {
+        result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+      }
+      step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+  };
+  Object.defineProperty(exports2, "__esModule", {value: true});
+  var childProcess = require("child_process");
+  var path2 = require("path");
+  var util_1 = require("util");
+  var ioUtil = require_io_util2();
+  var exec3 = util_1.promisify(childProcess.exec);
+  function cp(source, dest, options = {}) {
+    return __awaiter(this, void 0, void 0, function* () {
+      const {force, recursive} = readCopyOptions(options);
+      const destStat = (yield ioUtil.exists(dest)) ? yield ioUtil.stat(dest) : null;
+      if (destStat && destStat.isFile() && !force) {
+        return;
+      }
+      const newDest = destStat && destStat.isDirectory() ? path2.join(dest, path2.basename(source)) : dest;
+      if (!(yield ioUtil.exists(source))) {
+        throw new Error(`no such file or directory: ${source}`);
+      }
+      const sourceStat = yield ioUtil.stat(source);
+      if (sourceStat.isDirectory()) {
+        if (!recursive) {
+          throw new Error(`Failed to copy. ${source} is a directory, but tried to copy without recursive flag.`);
+        } else {
+          yield cpDirRecursive(source, newDest, 0, force);
+        }
+      } else {
+        if (path2.relative(source, newDest) === "") {
+          throw new Error(`'${newDest}' and '${source}' are the same file`);
+        }
+        yield copyFile(source, newDest, force);
+      }
+    });
+  }
+  exports2.cp = cp;
+  function mv(source, dest, options = {}) {
+    return __awaiter(this, void 0, void 0, function* () {
+      if (yield ioUtil.exists(dest)) {
+        let destExists = true;
+        if (yield ioUtil.isDirectory(dest)) {
+          dest = path2.join(dest, path2.basename(source));
+          destExists = yield ioUtil.exists(dest);
+        }
+        if (destExists) {
+          if (options.force == null || options.force) {
+            yield rmRF(dest);
+          } else {
+            throw new Error("Destination already exists");
+          }
+        }
+      }
+      yield mkdirP(path2.dirname(dest));
+      yield ioUtil.rename(source, dest);
+    });
+  }
+  exports2.mv = mv;
+  function rmRF(inputPath) {
+    return __awaiter(this, void 0, void 0, function* () {
+      if (ioUtil.IS_WINDOWS) {
+        try {
+          if (yield ioUtil.isDirectory(inputPath, true)) {
+            yield exec3(`rd /s /q "${inputPath}"`);
+          } else {
+            yield exec3(`del /f /a "${inputPath}"`);
+          }
+        } catch (err) {
+          if (err.code !== "ENOENT")
+            throw err;
+        }
+        try {
+          yield ioUtil.unlink(inputPath);
+        } catch (err) {
+          if (err.code !== "ENOENT")
+            throw err;
+        }
+      } else {
+        let isDir = false;
+        try {
+          isDir = yield ioUtil.isDirectory(inputPath);
+        } catch (err) {
+          if (err.code !== "ENOENT")
+            throw err;
+          return;
+        }
+        if (isDir) {
+          yield exec3(`rm -rf "${inputPath}"`);
+        } else {
+          yield ioUtil.unlink(inputPath);
+        }
+      }
+    });
+  }
+  exports2.rmRF = rmRF;
+  function mkdirP(fsPath) {
+    return __awaiter(this, void 0, void 0, function* () {
+      yield ioUtil.mkdirP(fsPath);
+    });
+  }
+  exports2.mkdirP = mkdirP;
+  function which2(tool, check) {
+    return __awaiter(this, void 0, void 0, function* () {
+      if (!tool) {
+        throw new Error("parameter 'tool' is required");
+      }
+      if (check) {
+        const result = yield which2(tool, false);
+        if (!result) {
+          if (ioUtil.IS_WINDOWS) {
+            throw new Error(`Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also verify the file has a valid extension for an executable file.`);
+          } else {
+            throw new Error(`Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also check the file mode to verify the file is executable.`);
+          }
+        }
+      }
+      try {
         const extensions = [];
-        if (ioUtil.IS_WINDOWS && process.env["PATHEXT"]) {
-          for (const extension of process.env["PATHEXT"].split(path2.delimiter)) {
+        if (ioUtil.IS_WINDOWS && process.env.PATHEXT) {
+          for (const extension of process.env.PATHEXT.split(path2.delimiter)) {
             if (extension) {
               extensions.push(extension);
             }
@@ -681,12 +1591,12 @@ var require_io = __commonJS({
         if (ioUtil.isRooted(tool)) {
           const filePath = yield ioUtil.tryGetExecutablePath(tool, extensions);
           if (filePath) {
-            return [filePath];
+            return filePath;
           }
-          return [];
+          return "";
         }
-        if (tool.includes(path2.sep)) {
-          return [];
+        if (tool.includes("/") || ioUtil.IS_WINDOWS && tool.includes("\\")) {
+          return "";
         }
         const directories = [];
         if (process.env.PATH) {
@@ -696,985 +1606,62 @@ var require_io = __commonJS({
             }
           }
         }
-        const matches = [];
         for (const directory of directories) {
-          const filePath = yield ioUtil.tryGetExecutablePath(path2.join(directory, tool), extensions);
+          const filePath = yield ioUtil.tryGetExecutablePath(directory + path2.sep + tool, extensions);
           if (filePath) {
-            matches.push(filePath);
-          }
-        }
-        return matches;
-      });
-    }
-    exports2.findInPath = findInPath;
-    function readCopyOptions(options) {
-      const force = options.force == null ? true : options.force;
-      const recursive = Boolean(options.recursive);
-      const copySourceDirectory = options.copySourceDirectory == null ? true : Boolean(options.copySourceDirectory);
-      return { force, recursive, copySourceDirectory };
-    }
-    function cpDirRecursive(sourceDir, destDir, currentDepth, force) {
-      return __awaiter(this, void 0, void 0, function* () {
-        if (currentDepth >= 255)
-          return;
-        currentDepth++;
-        yield mkdirP(destDir);
-        const files = yield ioUtil.readdir(sourceDir);
-        for (const fileName of files) {
-          const srcFile = `${sourceDir}/${fileName}`;
-          const destFile = `${destDir}/${fileName}`;
-          const srcFileStat = yield ioUtil.lstat(srcFile);
-          if (srcFileStat.isDirectory()) {
-            yield cpDirRecursive(srcFile, destFile, currentDepth, force);
-          } else {
-            yield copyFile(srcFile, destFile, force);
-          }
-        }
-        yield ioUtil.chmod(destDir, (yield ioUtil.stat(sourceDir)).mode);
-      });
-    }
-    function copyFile(srcFile, destFile, force) {
-      return __awaiter(this, void 0, void 0, function* () {
-        if ((yield ioUtil.lstat(srcFile)).isSymbolicLink()) {
-          try {
-            yield ioUtil.lstat(destFile);
-            yield ioUtil.unlink(destFile);
-          } catch (e) {
-            if (e.code === "EPERM") {
-              yield ioUtil.chmod(destFile, "0666");
-              yield ioUtil.unlink(destFile);
-            }
-          }
-          const symlinkFull = yield ioUtil.readlink(srcFile);
-          yield ioUtil.symlink(symlinkFull, destFile, ioUtil.IS_WINDOWS ? "junction" : null);
-        } else if (!(yield ioUtil.exists(destFile)) || force) {
-          yield ioUtil.copyFile(srcFile, destFile);
-        }
-      });
-    }
-  }
-});
-
-// node_modules/@actions/exec/lib/toolrunner.js
-var require_toolrunner = __commonJS({
-  "node_modules/@actions/exec/lib/toolrunner.js"(exports2) {
-    "use strict";
-    var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
-      function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve) {
-          resolve(value);
-        });
-      }
-      return new (P || (P = Promise))(function(resolve, reject) {
-        function fulfilled(value) {
-          try {
-            step(generator.next(value));
-          } catch (e) {
-            reject(e);
-          }
-        }
-        function rejected(value) {
-          try {
-            step(generator["throw"](value));
-          } catch (e) {
-            reject(e);
-          }
-        }
-        function step(result) {
-          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
-        }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-      });
-    };
-    var __importStar = exports2 && exports2.__importStar || function(mod) {
-      if (mod && mod.__esModule)
-        return mod;
-      var result = {};
-      if (mod != null) {
-        for (var k in mod)
-          if (Object.hasOwnProperty.call(mod, k))
-            result[k] = mod[k];
-      }
-      result["default"] = mod;
-      return result;
-    };
-    Object.defineProperty(exports2, "__esModule", { value: true });
-    var os2 = __importStar(require("os"));
-    var events = __importStar(require("events"));
-    var child = __importStar(require("child_process"));
-    var path2 = __importStar(require("path"));
-    var io2 = __importStar(require_io());
-    var ioUtil = __importStar(require_io_util());
-    var IS_WINDOWS = process.platform === "win32";
-    var ToolRunner = class extends events.EventEmitter {
-      constructor(toolPath, args, options) {
-        super();
-        if (!toolPath) {
-          throw new Error("Parameter 'toolPath' cannot be null or empty.");
-        }
-        this.toolPath = toolPath;
-        this.args = args || [];
-        this.options = options || {};
-      }
-      _debug(message) {
-        if (this.options.listeners && this.options.listeners.debug) {
-          this.options.listeners.debug(message);
-        }
-      }
-      _getCommandString(options, noPrefix) {
-        const toolPath = this._getSpawnFileName();
-        const args = this._getSpawnArgs(options);
-        let cmd = noPrefix ? "" : "[command]";
-        if (IS_WINDOWS) {
-          if (this._isCmdFile()) {
-            cmd += toolPath;
-            for (const a of args) {
-              cmd += ` ${a}`;
-            }
-          } else if (options.windowsVerbatimArguments) {
-            cmd += `"${toolPath}"`;
-            for (const a of args) {
-              cmd += ` ${a}`;
-            }
-          } else {
-            cmd += this._windowsQuoteCmdArg(toolPath);
-            for (const a of args) {
-              cmd += ` ${this._windowsQuoteCmdArg(a)}`;
-            }
-          }
-        } else {
-          cmd += toolPath;
-          for (const a of args) {
-            cmd += ` ${a}`;
-          }
-        }
-        return cmd;
-      }
-      _processLineBuffer(data, strBuffer, onLine) {
-        try {
-          let s = strBuffer + data.toString();
-          let n = s.indexOf(os2.EOL);
-          while (n > -1) {
-            const line = s.substring(0, n);
-            onLine(line);
-            s = s.substring(n + os2.EOL.length);
-            n = s.indexOf(os2.EOL);
-          }
-          strBuffer = s;
-        } catch (err) {
-          this._debug(`error processing line. Failed with error ${err}`);
-        }
-      }
-      _getSpawnFileName() {
-        if (IS_WINDOWS) {
-          if (this._isCmdFile()) {
-            return process.env["COMSPEC"] || "cmd.exe";
-          }
-        }
-        return this.toolPath;
-      }
-      _getSpawnArgs(options) {
-        if (IS_WINDOWS) {
-          if (this._isCmdFile()) {
-            let argline = `/D /S /C "${this._windowsQuoteCmdArg(this.toolPath)}`;
-            for (const a of this.args) {
-              argline += " ";
-              argline += options.windowsVerbatimArguments ? a : this._windowsQuoteCmdArg(a);
-            }
-            argline += '"';
-            return [argline];
-          }
-        }
-        return this.args;
-      }
-      _endsWith(str, end) {
-        return str.endsWith(end);
-      }
-      _isCmdFile() {
-        const upperToolPath = this.toolPath.toUpperCase();
-        return this._endsWith(upperToolPath, ".CMD") || this._endsWith(upperToolPath, ".BAT");
-      }
-      _windowsQuoteCmdArg(arg) {
-        if (!this._isCmdFile()) {
-          return this._uvQuoteCmdArg(arg);
-        }
-        if (!arg) {
-          return '""';
-        }
-        const cmdSpecialChars = [
-          " ",
-          "	",
-          "&",
-          "(",
-          ")",
-          "[",
-          "]",
-          "{",
-          "}",
-          "^",
-          "=",
-          ";",
-          "!",
-          "'",
-          "+",
-          ",",
-          "`",
-          "~",
-          "|",
-          "<",
-          ">",
-          '"'
-        ];
-        let needsQuotes = false;
-        for (const char of arg) {
-          if (cmdSpecialChars.some((x) => x === char)) {
-            needsQuotes = true;
-            break;
-          }
-        }
-        if (!needsQuotes) {
-          return arg;
-        }
-        let reverse = '"';
-        let quoteHit = true;
-        for (let i = arg.length; i > 0; i--) {
-          reverse += arg[i - 1];
-          if (quoteHit && arg[i - 1] === "\\") {
-            reverse += "\\";
-          } else if (arg[i - 1] === '"') {
-            quoteHit = true;
-            reverse += '"';
-          } else {
-            quoteHit = false;
-          }
-        }
-        reverse += '"';
-        return reverse.split("").reverse().join("");
-      }
-      _uvQuoteCmdArg(arg) {
-        if (!arg) {
-          return '""';
-        }
-        if (!arg.includes(" ") && !arg.includes("	") && !arg.includes('"')) {
-          return arg;
-        }
-        if (!arg.includes('"') && !arg.includes("\\")) {
-          return `"${arg}"`;
-        }
-        let reverse = '"';
-        let quoteHit = true;
-        for (let i = arg.length; i > 0; i--) {
-          reverse += arg[i - 1];
-          if (quoteHit && arg[i - 1] === "\\") {
-            reverse += "\\";
-          } else if (arg[i - 1] === '"') {
-            quoteHit = true;
-            reverse += "\\";
-          } else {
-            quoteHit = false;
-          }
-        }
-        reverse += '"';
-        return reverse.split("").reverse().join("");
-      }
-      _cloneExecOptions(options) {
-        options = options || {};
-        const result = {
-          cwd: options.cwd || process.cwd(),
-          env: options.env || process.env,
-          silent: options.silent || false,
-          windowsVerbatimArguments: options.windowsVerbatimArguments || false,
-          failOnStdErr: options.failOnStdErr || false,
-          ignoreReturnCode: options.ignoreReturnCode || false,
-          delay: options.delay || 1e4
-        };
-        result.outStream = options.outStream || process.stdout;
-        result.errStream = options.errStream || process.stderr;
-        return result;
-      }
-      _getSpawnOptions(options, toolPath) {
-        options = options || {};
-        const result = {};
-        result.cwd = options.cwd;
-        result.env = options.env;
-        result["windowsVerbatimArguments"] = options.windowsVerbatimArguments || this._isCmdFile();
-        if (options.windowsVerbatimArguments) {
-          result.argv0 = `"${toolPath}"`;
-        }
-        return result;
-      }
-      exec() {
-        return __awaiter(this, void 0, void 0, function* () {
-          if (!ioUtil.isRooted(this.toolPath) && (this.toolPath.includes("/") || IS_WINDOWS && this.toolPath.includes("\\"))) {
-            this.toolPath = path2.resolve(process.cwd(), this.options.cwd || process.cwd(), this.toolPath);
-          }
-          this.toolPath = yield io2.which(this.toolPath, true);
-          return new Promise((resolve, reject) => {
-            this._debug(`exec tool: ${this.toolPath}`);
-            this._debug("arguments:");
-            for (const arg of this.args) {
-              this._debug(`   ${arg}`);
-            }
-            const optionsNonNull = this._cloneExecOptions(this.options);
-            if (!optionsNonNull.silent && optionsNonNull.outStream) {
-              optionsNonNull.outStream.write(this._getCommandString(optionsNonNull) + os2.EOL);
-            }
-            const state = new ExecState(optionsNonNull, this.toolPath);
-            state.on("debug", (message) => {
-              this._debug(message);
-            });
-            const fileName = this._getSpawnFileName();
-            const cp = child.spawn(fileName, this._getSpawnArgs(optionsNonNull), this._getSpawnOptions(this.options, fileName));
-            const stdbuffer = "";
-            if (cp.stdout) {
-              cp.stdout.on("data", (data) => {
-                if (this.options.listeners && this.options.listeners.stdout) {
-                  this.options.listeners.stdout(data);
-                }
-                if (!optionsNonNull.silent && optionsNonNull.outStream) {
-                  optionsNonNull.outStream.write(data);
-                }
-                this._processLineBuffer(data, stdbuffer, (line) => {
-                  if (this.options.listeners && this.options.listeners.stdline) {
-                    this.options.listeners.stdline(line);
-                  }
-                });
-              });
-            }
-            const errbuffer = "";
-            if (cp.stderr) {
-              cp.stderr.on("data", (data) => {
-                state.processStderr = true;
-                if (this.options.listeners && this.options.listeners.stderr) {
-                  this.options.listeners.stderr(data);
-                }
-                if (!optionsNonNull.silent && optionsNonNull.errStream && optionsNonNull.outStream) {
-                  const s = optionsNonNull.failOnStdErr ? optionsNonNull.errStream : optionsNonNull.outStream;
-                  s.write(data);
-                }
-                this._processLineBuffer(data, errbuffer, (line) => {
-                  if (this.options.listeners && this.options.listeners.errline) {
-                    this.options.listeners.errline(line);
-                  }
-                });
-              });
-            }
-            cp.on("error", (err) => {
-              state.processError = err.message;
-              state.processExited = true;
-              state.processClosed = true;
-              state.CheckComplete();
-            });
-            cp.on("exit", (code) => {
-              state.processExitCode = code;
-              state.processExited = true;
-              this._debug(`Exit code ${code} received from tool '${this.toolPath}'`);
-              state.CheckComplete();
-            });
-            cp.on("close", (code) => {
-              state.processExitCode = code;
-              state.processExited = true;
-              state.processClosed = true;
-              this._debug(`STDIO streams have closed for tool '${this.toolPath}'`);
-              state.CheckComplete();
-            });
-            state.on("done", (error, exitCode) => {
-              if (stdbuffer.length > 0) {
-                this.emit("stdline", stdbuffer);
-              }
-              if (errbuffer.length > 0) {
-                this.emit("errline", errbuffer);
-              }
-              cp.removeAllListeners();
-              if (error) {
-                reject(error);
-              } else {
-                resolve(exitCode);
-              }
-            });
-            if (this.options.input) {
-              if (!cp.stdin) {
-                throw new Error("child process missing stdin");
-              }
-              cp.stdin.end(this.options.input);
-            }
-          });
-        });
-      }
-    };
-    exports2.ToolRunner = ToolRunner;
-    function argStringToArray(argString) {
-      const args = [];
-      let inQuotes = false;
-      let escaped = false;
-      let arg = "";
-      function append(c) {
-        if (escaped && c !== '"') {
-          arg += "\\";
-        }
-        arg += c;
-        escaped = false;
-      }
-      for (let i = 0; i < argString.length; i++) {
-        const c = argString.charAt(i);
-        if (c === '"') {
-          if (!escaped) {
-            inQuotes = !inQuotes;
-          } else {
-            append(c);
-          }
-          continue;
-        }
-        if (c === "\\" && escaped) {
-          append(c);
-          continue;
-        }
-        if (c === "\\" && inQuotes) {
-          escaped = true;
-          continue;
-        }
-        if (c === " " && !inQuotes) {
-          if (arg.length > 0) {
-            args.push(arg);
-            arg = "";
-          }
-          continue;
-        }
-        append(c);
-      }
-      if (arg.length > 0) {
-        args.push(arg.trim());
-      }
-      return args;
-    }
-    exports2.argStringToArray = argStringToArray;
-    var ExecState = class extends events.EventEmitter {
-      constructor(options, toolPath) {
-        super();
-        this.processClosed = false;
-        this.processError = "";
-        this.processExitCode = 0;
-        this.processExited = false;
-        this.processStderr = false;
-        this.delay = 1e4;
-        this.done = false;
-        this.timeout = null;
-        if (!toolPath) {
-          throw new Error("toolPath must not be empty");
-        }
-        this.options = options;
-        this.toolPath = toolPath;
-        if (options.delay) {
-          this.delay = options.delay;
-        }
-      }
-      CheckComplete() {
-        if (this.done) {
-          return;
-        }
-        if (this.processClosed) {
-          this._setResult();
-        } else if (this.processExited) {
-          this.timeout = setTimeout(ExecState.HandleTimeout, this.delay, this);
-        }
-      }
-      _debug(message) {
-        this.emit("debug", message);
-      }
-      _setResult() {
-        let error;
-        if (this.processExited) {
-          if (this.processError) {
-            error = new Error(`There was an error when attempting to execute the process '${this.toolPath}'. This may indicate the process failed to start. Error: ${this.processError}`);
-          } else if (this.processExitCode !== 0 && !this.options.ignoreReturnCode) {
-            error = new Error(`The process '${this.toolPath}' failed with exit code ${this.processExitCode}`);
-          } else if (this.processStderr && this.options.failOnStdErr) {
-            error = new Error(`The process '${this.toolPath}' failed because one or more lines were written to the STDERR stream`);
-          }
-        }
-        if (this.timeout) {
-          clearTimeout(this.timeout);
-          this.timeout = null;
-        }
-        this.done = true;
-        this.emit("done", error, this.processExitCode);
-      }
-      static HandleTimeout(state) {
-        if (state.done) {
-          return;
-        }
-        if (!state.processClosed && state.processExited) {
-          const message = `The STDIO streams did not close within ${state.delay / 1e3} seconds of the exit event from process '${state.toolPath}'. This may indicate a child process inherited the STDIO streams and has not yet exited.`;
-          state._debug(message);
-        }
-        state._setResult();
-      }
-    };
-  }
-});
-
-// node_modules/@actions/exec/lib/exec.js
-var require_exec = __commonJS({
-  "node_modules/@actions/exec/lib/exec.js"(exports2) {
-    "use strict";
-    var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
-      function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve) {
-          resolve(value);
-        });
-      }
-      return new (P || (P = Promise))(function(resolve, reject) {
-        function fulfilled(value) {
-          try {
-            step(generator.next(value));
-          } catch (e) {
-            reject(e);
-          }
-        }
-        function rejected(value) {
-          try {
-            step(generator["throw"](value));
-          } catch (e) {
-            reject(e);
-          }
-        }
-        function step(result) {
-          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
-        }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-      });
-    };
-    var __importStar = exports2 && exports2.__importStar || function(mod) {
-      if (mod && mod.__esModule)
-        return mod;
-      var result = {};
-      if (mod != null) {
-        for (var k in mod)
-          if (Object.hasOwnProperty.call(mod, k))
-            result[k] = mod[k];
-      }
-      result["default"] = mod;
-      return result;
-    };
-    Object.defineProperty(exports2, "__esModule", { value: true });
-    var tr = __importStar(require_toolrunner());
-    function exec3(commandLine, args, options) {
-      return __awaiter(this, void 0, void 0, function* () {
-        const commandArgs = tr.argStringToArray(commandLine);
-        if (commandArgs.length === 0) {
-          throw new Error(`Parameter 'commandLine' cannot be null or empty.`);
-        }
-        const toolPath = commandArgs[0];
-        args = commandArgs.slice(1).concat(args || []);
-        const runner = new tr.ToolRunner(toolPath, args, options);
-        return runner.exec();
-      });
-    }
-    exports2.exec = exec3;
-  }
-});
-
-// node_modules/@actions/io/lib/io-util.js
-var require_io_util2 = __commonJS({
-  "node_modules/@actions/io/lib/io-util.js"(exports2) {
-    "use strict";
-    var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
-      function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve) {
-          resolve(value);
-        });
-      }
-      return new (P || (P = Promise))(function(resolve, reject) {
-        function fulfilled(value) {
-          try {
-            step(generator.next(value));
-          } catch (e) {
-            reject(e);
-          }
-        }
-        function rejected(value) {
-          try {
-            step(generator["throw"](value));
-          } catch (e) {
-            reject(e);
-          }
-        }
-        function step(result) {
-          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
-        }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-      });
-    };
-    var _a;
-    Object.defineProperty(exports2, "__esModule", { value: true });
-    var assert_1 = require("assert");
-    var fs = require("fs");
-    var path2 = require("path");
-    _a = fs.promises, exports2.chmod = _a.chmod, exports2.copyFile = _a.copyFile, exports2.lstat = _a.lstat, exports2.mkdir = _a.mkdir, exports2.readdir = _a.readdir, exports2.readlink = _a.readlink, exports2.rename = _a.rename, exports2.rmdir = _a.rmdir, exports2.stat = _a.stat, exports2.symlink = _a.symlink, exports2.unlink = _a.unlink;
-    exports2.IS_WINDOWS = process.platform === "win32";
-    function exists(fsPath) {
-      return __awaiter(this, void 0, void 0, function* () {
-        try {
-          yield exports2.stat(fsPath);
-        } catch (err) {
-          if (err.code === "ENOENT") {
-            return false;
-          }
-          throw err;
-        }
-        return true;
-      });
-    }
-    exports2.exists = exists;
-    function isDirectory(fsPath, useStat = false) {
-      return __awaiter(this, void 0, void 0, function* () {
-        const stats = useStat ? yield exports2.stat(fsPath) : yield exports2.lstat(fsPath);
-        return stats.isDirectory();
-      });
-    }
-    exports2.isDirectory = isDirectory;
-    function isRooted(p) {
-      p = normalizeSeparators(p);
-      if (!p) {
-        throw new Error('isRooted() parameter "p" cannot be empty');
-      }
-      if (exports2.IS_WINDOWS) {
-        return p.startsWith("\\") || /^[A-Z]:/i.test(p);
-      }
-      return p.startsWith("/");
-    }
-    exports2.isRooted = isRooted;
-    function mkdirP(fsPath, maxDepth = 1e3, depth = 1) {
-      return __awaiter(this, void 0, void 0, function* () {
-        assert_1.ok(fsPath, "a path argument must be provided");
-        fsPath = path2.resolve(fsPath);
-        if (depth >= maxDepth)
-          return exports2.mkdir(fsPath);
-        try {
-          yield exports2.mkdir(fsPath);
-          return;
-        } catch (err) {
-          switch (err.code) {
-            case "ENOENT": {
-              yield mkdirP(path2.dirname(fsPath), maxDepth, depth + 1);
-              yield exports2.mkdir(fsPath);
-              return;
-            }
-            default: {
-              let stats;
-              try {
-                stats = yield exports2.stat(fsPath);
-              } catch (err2) {
-                throw err;
-              }
-              if (!stats.isDirectory())
-                throw err;
-            }
-          }
-        }
-      });
-    }
-    exports2.mkdirP = mkdirP;
-    function tryGetExecutablePath(filePath, extensions) {
-      return __awaiter(this, void 0, void 0, function* () {
-        let stats = void 0;
-        try {
-          stats = yield exports2.stat(filePath);
-        } catch (err) {
-          if (err.code !== "ENOENT") {
-            console.log(`Unexpected error attempting to determine if executable file exists '${filePath}': ${err}`);
-          }
-        }
-        if (stats && stats.isFile()) {
-          if (exports2.IS_WINDOWS) {
-            const upperExt = path2.extname(filePath).toUpperCase();
-            if (extensions.some((validExt) => validExt.toUpperCase() === upperExt)) {
-              return filePath;
-            }
-          } else {
-            if (isUnixExecutable(stats)) {
-              return filePath;
-            }
-          }
-        }
-        const originalFilePath = filePath;
-        for (const extension of extensions) {
-          filePath = originalFilePath + extension;
-          stats = void 0;
-          try {
-            stats = yield exports2.stat(filePath);
-          } catch (err) {
-            if (err.code !== "ENOENT") {
-              console.log(`Unexpected error attempting to determine if executable file exists '${filePath}': ${err}`);
-            }
-          }
-          if (stats && stats.isFile()) {
-            if (exports2.IS_WINDOWS) {
-              try {
-                const directory = path2.dirname(filePath);
-                const upperName = path2.basename(filePath).toUpperCase();
-                for (const actualName of yield exports2.readdir(directory)) {
-                  if (upperName === actualName.toUpperCase()) {
-                    filePath = path2.join(directory, actualName);
-                    break;
-                  }
-                }
-              } catch (err) {
-                console.log(`Unexpected error attempting to determine the actual case of the file '${filePath}': ${err}`);
-              }
-              return filePath;
-            } else {
-              if (isUnixExecutable(stats)) {
-                return filePath;
-              }
-            }
+            return filePath;
           }
         }
         return "";
-      });
-    }
-    exports2.tryGetExecutablePath = tryGetExecutablePath;
-    function normalizeSeparators(p) {
-      p = p || "";
-      if (exports2.IS_WINDOWS) {
-        p = p.replace(/\//g, "\\");
-        return p.replace(/\\\\+/g, "\\");
+      } catch (err) {
+        throw new Error(`which failed with message ${err.message}`);
       }
-      return p.replace(/\/\/+/g, "/");
-    }
-    function isUnixExecutable(stats) {
-      return (stats.mode & 1) > 0 || (stats.mode & 8) > 0 && stats.gid === process.getgid() || (stats.mode & 64) > 0 && stats.uid === process.getuid();
-    }
+    });
   }
-});
-
-// node_modules/@actions/io/lib/io.js
-var require_io2 = __commonJS({
-  "node_modules/@actions/io/lib/io.js"(exports2) {
-    "use strict";
-    var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
-      function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve) {
-          resolve(value);
-        });
+  exports2.which = which2;
+  function readCopyOptions(options) {
+    const force = options.force == null ? true : options.force;
+    const recursive = Boolean(options.recursive);
+    return {force, recursive};
+  }
+  function cpDirRecursive(sourceDir, destDir, currentDepth, force) {
+    return __awaiter(this, void 0, void 0, function* () {
+      if (currentDepth >= 255)
+        return;
+      currentDepth++;
+      yield mkdirP(destDir);
+      const files = yield ioUtil.readdir(sourceDir);
+      for (const fileName of files) {
+        const srcFile = `${sourceDir}/${fileName}`;
+        const destFile = `${destDir}/${fileName}`;
+        const srcFileStat = yield ioUtil.lstat(srcFile);
+        if (srcFileStat.isDirectory()) {
+          yield cpDirRecursive(srcFile, destFile, currentDepth, force);
+        } else {
+          yield copyFile(srcFile, destFile, force);
+        }
       }
-      return new (P || (P = Promise))(function(resolve, reject) {
-        function fulfilled(value) {
-          try {
-            step(generator.next(value));
-          } catch (e) {
-            reject(e);
-          }
-        }
-        function rejected(value) {
-          try {
-            step(generator["throw"](value));
-          } catch (e) {
-            reject(e);
-          }
-        }
-        function step(result) {
-          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
-        }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-      });
-    };
-    Object.defineProperty(exports2, "__esModule", { value: true });
-    var childProcess = require("child_process");
-    var path2 = require("path");
-    var util_1 = require("util");
-    var ioUtil = require_io_util2();
-    var exec3 = util_1.promisify(childProcess.exec);
-    function cp(source, dest, options = {}) {
-      return __awaiter(this, void 0, void 0, function* () {
-        const { force, recursive } = readCopyOptions(options);
-        const destStat = (yield ioUtil.exists(dest)) ? yield ioUtil.stat(dest) : null;
-        if (destStat && destStat.isFile() && !force) {
-          return;
-        }
-        const newDest = destStat && destStat.isDirectory() ? path2.join(dest, path2.basename(source)) : dest;
-        if (!(yield ioUtil.exists(source))) {
-          throw new Error(`no such file or directory: ${source}`);
-        }
-        const sourceStat = yield ioUtil.stat(source);
-        if (sourceStat.isDirectory()) {
-          if (!recursive) {
-            throw new Error(`Failed to copy. ${source} is a directory, but tried to copy without recursive flag.`);
-          } else {
-            yield cpDirRecursive(source, newDest, 0, force);
-          }
-        } else {
-          if (path2.relative(source, newDest) === "") {
-            throw new Error(`'${newDest}' and '${source}' are the same file`);
-          }
-          yield copyFile(source, newDest, force);
-        }
-      });
-    }
-    exports2.cp = cp;
-    function mv(source, dest, options = {}) {
-      return __awaiter(this, void 0, void 0, function* () {
-        if (yield ioUtil.exists(dest)) {
-          let destExists = true;
-          if (yield ioUtil.isDirectory(dest)) {
-            dest = path2.join(dest, path2.basename(source));
-            destExists = yield ioUtil.exists(dest);
-          }
-          if (destExists) {
-            if (options.force == null || options.force) {
-              yield rmRF(dest);
-            } else {
-              throw new Error("Destination already exists");
-            }
-          }
-        }
-        yield mkdirP(path2.dirname(dest));
-        yield ioUtil.rename(source, dest);
-      });
-    }
-    exports2.mv = mv;
-    function rmRF(inputPath) {
-      return __awaiter(this, void 0, void 0, function* () {
-        if (ioUtil.IS_WINDOWS) {
-          try {
-            if (yield ioUtil.isDirectory(inputPath, true)) {
-              yield exec3(`rd /s /q "${inputPath}"`);
-            } else {
-              yield exec3(`del /f /a "${inputPath}"`);
-            }
-          } catch (err) {
-            if (err.code !== "ENOENT")
-              throw err;
-          }
-          try {
-            yield ioUtil.unlink(inputPath);
-          } catch (err) {
-            if (err.code !== "ENOENT")
-              throw err;
-          }
-        } else {
-          let isDir = false;
-          try {
-            isDir = yield ioUtil.isDirectory(inputPath);
-          } catch (err) {
-            if (err.code !== "ENOENT")
-              throw err;
-            return;
-          }
-          if (isDir) {
-            yield exec3(`rm -rf "${inputPath}"`);
-          } else {
-            yield ioUtil.unlink(inputPath);
-          }
-        }
-      });
-    }
-    exports2.rmRF = rmRF;
-    function mkdirP(fsPath) {
-      return __awaiter(this, void 0, void 0, function* () {
-        yield ioUtil.mkdirP(fsPath);
-      });
-    }
-    exports2.mkdirP = mkdirP;
-    function which2(tool, check) {
-      return __awaiter(this, void 0, void 0, function* () {
-        if (!tool) {
-          throw new Error("parameter 'tool' is required");
-        }
-        if (check) {
-          const result = yield which2(tool, false);
-          if (!result) {
-            if (ioUtil.IS_WINDOWS) {
-              throw new Error(`Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also verify the file has a valid extension for an executable file.`);
-            } else {
-              throw new Error(`Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also check the file mode to verify the file is executable.`);
-            }
-          }
-        }
+      yield ioUtil.chmod(destDir, (yield ioUtil.stat(sourceDir)).mode);
+    });
+  }
+  function copyFile(srcFile, destFile, force) {
+    return __awaiter(this, void 0, void 0, function* () {
+      if ((yield ioUtil.lstat(srcFile)).isSymbolicLink()) {
         try {
-          const extensions = [];
-          if (ioUtil.IS_WINDOWS && process.env.PATHEXT) {
-            for (const extension of process.env.PATHEXT.split(path2.delimiter)) {
-              if (extension) {
-                extensions.push(extension);
-              }
-            }
-          }
-          if (ioUtil.isRooted(tool)) {
-            const filePath = yield ioUtil.tryGetExecutablePath(tool, extensions);
-            if (filePath) {
-              return filePath;
-            }
-            return "";
-          }
-          if (tool.includes("/") || ioUtil.IS_WINDOWS && tool.includes("\\")) {
-            return "";
-          }
-          const directories = [];
-          if (process.env.PATH) {
-            for (const p of process.env.PATH.split(path2.delimiter)) {
-              if (p) {
-                directories.push(p);
-              }
-            }
-          }
-          for (const directory of directories) {
-            const filePath = yield ioUtil.tryGetExecutablePath(directory + path2.sep + tool, extensions);
-            if (filePath) {
-              return filePath;
-            }
-          }
-          return "";
-        } catch (err) {
-          throw new Error(`which failed with message ${err.message}`);
-        }
-      });
-    }
-    exports2.which = which2;
-    function readCopyOptions(options) {
-      const force = options.force == null ? true : options.force;
-      const recursive = Boolean(options.recursive);
-      return { force, recursive };
-    }
-    function cpDirRecursive(sourceDir, destDir, currentDepth, force) {
-      return __awaiter(this, void 0, void 0, function* () {
-        if (currentDepth >= 255)
-          return;
-        currentDepth++;
-        yield mkdirP(destDir);
-        const files = yield ioUtil.readdir(sourceDir);
-        for (const fileName of files) {
-          const srcFile = `${sourceDir}/${fileName}`;
-          const destFile = `${destDir}/${fileName}`;
-          const srcFileStat = yield ioUtil.lstat(srcFile);
-          if (srcFileStat.isDirectory()) {
-            yield cpDirRecursive(srcFile, destFile, currentDepth, force);
-          } else {
-            yield copyFile(srcFile, destFile, force);
-          }
-        }
-        yield ioUtil.chmod(destDir, (yield ioUtil.stat(sourceDir)).mode);
-      });
-    }
-    function copyFile(srcFile, destFile, force) {
-      return __awaiter(this, void 0, void 0, function* () {
-        if ((yield ioUtil.lstat(srcFile)).isSymbolicLink()) {
-          try {
-            yield ioUtil.lstat(destFile);
+          yield ioUtil.lstat(destFile);
+          yield ioUtil.unlink(destFile);
+        } catch (e) {
+          if (e.code === "EPERM") {
+            yield ioUtil.chmod(destFile, "0666");
             yield ioUtil.unlink(destFile);
-          } catch (e) {
-            if (e.code === "EPERM") {
-              yield ioUtil.chmod(destFile, "0666");
-              yield ioUtil.unlink(destFile);
-            }
           }
-          const symlinkFull = yield ioUtil.readlink(srcFile);
-          yield ioUtil.symlink(symlinkFull, destFile, ioUtil.IS_WINDOWS ? "junction" : null);
-        } else if (!(yield ioUtil.exists(destFile)) || force) {
-          yield ioUtil.copyFile(srcFile, destFile);
         }
-      });
-    }
+        const symlinkFull = yield ioUtil.readlink(srcFile);
+        yield ioUtil.symlink(symlinkFull, destFile, ioUtil.IS_WINDOWS ? "junction" : null);
+      } else if (!(yield ioUtil.exists(destFile)) || force) {
+        yield ioUtil.copyFile(srcFile, destFile);
+      }
+    });
   }
 });
 
@@ -1698,7 +1685,7 @@ async function setupAsdf() {
   core.addPath(`${asdfDir}/bin`);
   core.addPath(`${asdfDir}/shims`);
   core.info(`Cloning asdf into ASDF_DIR: ${asdfDir}`);
-  const branch = core.getInput("asdf_branch", { required: true });
+  const branch = core.getInput("asdf_branch", {required: true});
   await exec.exec("git", [
     "clone",
     "--depth",


### PR DESCRIPTION
- add a new `directory` option for asdf-install action
- fix yaml for install action so it's valid

should 
/fixes https://github.com/asdf-vm/actions/issues/83
IMO also solves https://github.com/asdf-vm/actions/issues/84 as you can just call it multiple times

Use case: have k8s deploy manifests+tooling living with the code. Don't need to install the dev tooling to deploy it in CI (or locally), and devs don't need to install the deploy tooling just to work with the code (since it automatically deploys on merge).

complete example:
```yaml
on: push
name: lint
jobs:
  lint:
    name: k8s lint manifests
    runs-on: ubuntu-latest
    strategy:
      matrix:
        include:
          - stage: dev
            cluster: platform-development
          - stage: prod
            cluster: platform-production
    defaults:
      run:
        working-directory: ./deploy
    steps:
      - name: Checkout
        uses: actions/checkout@v2

      - name: Install CD tools from .tool-versions
        if: steps.asdf-cache.outputs.cache-hit != 'true'
        uses: FATMAP/asdf-vm-actions/install@2021-06-16-chdir
        with:
          directory: ./deploy # << :tada: 

      - name: kustomize
        env:
          CLUSTER: ${{ matrix.cluster }}
          STAGE: ${{ matrix.stage }}
        run: |
          kustomize build --load-restrictor=LoadRestrictionsNone clusters/$STAGE/$CLUSTER > ./manifest.yaml

      - name: lint
        uses: instrumenta/kubeval-action@master
        with:
          files: deploy/manifest.yaml
```
