### PR TITLE
fix: add stdout/err to plugin test action

### DIFF
--- a/lib/plugin-test/index.ts
+++ b/lib/plugin-test/index.ts
@@ -2,6 +2,10 @@ import * as core from "@actions/core";
 import * as exec from "@actions/exec";
 import { setupAsdf } from "../setup";
 
+const stdoutLines: string[] = [];
+const stderrLines: string[] = [];
+const debugLines: string[] = [];
+
 export async function pluginTest(): Promise<void> {
   await setupAsdf();
   const command = core.getInput("command", { required: true });
@@ -11,6 +15,18 @@ export async function pluginTest(): Promise<void> {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     process.env.GITHUB_REPOSITORY!.split("/")[1]
   ).replace("asdf-", "");
+  const options: exec.ExecOptions = {};
+  options.listeners = {
+    stdline: (line: string) => {
+      stdoutLines.push(line.replace(/(?:\r\n|\r|\n)/g, ""));
+    },
+    errline: (line: string) => {
+      stderrLines.push(line.replace(/(?:\r\n|\r|\n)/g, ""));
+    },
+    debug: (line: string) => {
+      debugLines.push(line.replace(/(?:\r\n|\r|\n)/g, ""));
+    },
+  };
   const giturl =
     core.getInput("giturl", { required: false }) ||
     `https://github.com/${process.env.GITHUB_REPOSITORY}`;
@@ -26,7 +42,8 @@ export async function pluginTest(): Promise<void> {
     "--asdf-plugin-gitref",
     gitref,
     command,
-  ]);
+  ],
+    options);
 }
 
 export async function pluginTestAll(): Promise<void> {
@@ -34,5 +51,8 @@ export async function pluginTestAll(): Promise<void> {
   core.exportVariable("GITHUB_API_TOKEN", githubToken);
   core.startGroup("Test plugin");
   await pluginTest();
+  core.setOutput("stdout", { lines: stdoutLines });
+  core.setOutput("stderr", { lines: stderrLines });
+  core.setOutput("debug", { lines: debugLines });
   core.endGroup();
 }

--- a/plugin-test/action.yml
+++ b/plugin-test/action.yml
@@ -6,8 +6,7 @@ runs:
   main: main.js
 inputs:
   command:
-    description:
-      Command used to test your plugin tool. Something with --version or --help
+    description: Command used to test your plugin tool. Something with --version or --help
     required: true
   plugin:
     description: Plugin name to use. Defaults to repository name without asdf-
@@ -20,8 +19,7 @@ inputs:
     description: Plugin repository. Defaults to current github repository
     required: false
   gitref:
-    description:
-      Branch or commit from repository to test. Defaults to current commit.
+    description: Branch or commit from repository to test. Defaults to current commit.
     required: false
   asdf_branch:
     description: asdf branch to clone
@@ -31,3 +29,11 @@ inputs:
     description: Token used to avoid rate limit when asdf calls the GitHub API
     required: false
     default: ${{ github.token }}
+
+outputs:
+  stdout:
+    description: "An array of stdout lines the test command"
+  stderr:
+    description: "An array of stderr of the test command"
+  debug:
+    description: "An array of debug lines of the test command"


### PR DESCRIPTION
Adds output to the `plugin-test` action, which could be used as part of the workflow to evaluate the plugin-test results.


fix: #330 