### PR TITLE
install/main.js: check existence of asdfDir and remove it before git clone

### DIFF
--- a/install/main.js
+++ b/install/main.js
@@ -1235,6 +1235,9 @@ async function setupAsdf() {
     return;
   }
   const asdfDir = path.join(os.homedir(), ".asdf");
+  if (fs.existsSync(asdfDir)) {
+      await exec.exec("rm", ["-rf", asdfDir])
+  }
   core.exportVariable("ASDF_DIR", asdfDir);
   core.exportVariable("ASDF_DATA_DIR", asdfDir);
   core.addPath(`${asdfDir}/bin`);


### PR DESCRIPTION
Occasionally a self-hosted runner [does not get restarted and refreshed](https://github.com/actions-runner-controller/actions-runner-controller/issues/720). When this happens, if there is an `asdf/install` action in the workflow, it will fail because `git clone` will fail if the directory exists. I made an attempt with this PR to have the function check for the existence of `asdfDir` and remove it if it exists prior to running the `git clone`, which should avoid the problem. My JS is very shaky, so if there's a better way to do what I'm trying to do here, please let me know.