### PR TITLE
feat: allow to update existing asdf

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ChangeListManager">
+    <list default="true" id="e8490d6f-4aef-47eb-907f-7c4ac77aaadc" name="Changes" comment="" />
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="Git.Settings">
+    <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
+  </component>
+  <component name="ProjectId" id="227PG9Kb8ACATqLQYJGMq9O9gtD" />
+  <component name="ProjectLevelVcsManager" settingsEditedManually="true" />
+  <component name="ProjectViewState">
+    <option name="hideEmptyMiddlePackages" value="true" />
+    <option name="showLibraryContents" value="true" />
+  </component>
+  <component name="PropertiesComponent">
+    <property name="RunOnceActivity.OpenProjectViewOnStart" value="true" />
+    <property name="RunOnceActivity.ShowReadmeOnStart" value="true" />
+    <property name="WebServerToolWindowFactoryState" value="false" />
+    <property name="last_opened_file_path" value="$PROJECT_DIR$" />
+    <property name="node.js.detected.package.eslint" value="true" />
+    <property name="node.js.selected.package.eslint" value="(autodetect)" />
+    <property name="nodejs_package_manager_path" value="yarn" />
+    <property name="ts.external.directory.path" value="$PROJECT_DIR$/node_modules/typescript/lib" />
+    <property name="vue.rearranger.settings.migration" value="true" />
+  </component>
+  <component name="SpellCheckerSettings" RuntimeDictionaries="0" Folders="0" CustomDictionaries="0" DefaultDictionary="application-level" UseSingleDictionary="true" transferred="true" />
+  <component name="TaskManager">
+    <task active="true" id="Default" summary="Default task">
+      <changelist id="e8490d6f-4aef-47eb-907f-7c4ac77aaadc" name="Changes" comment="" />
+      <created>1639185553690</created>
+      <option name="number" value="Default" />
+      <option name="presentableId" value="Default" />
+      <updated>1639185553690</updated>
+      <workItem from="1639185558148" duration="4436000" />
+      <workItem from="1639610591256" duration="8000" />
+      <workItem from="1639610633071" duration="7000" />
+    </task>
+    <servers />
+  </component>
+  <component name="TypeScriptGeneratedFilesManager">
+    <option name="version" value="3" />
+  </component>
+</project>

--- a/install/main.js
+++ b/install/main.js
@@ -126,7 +126,7 @@ var require_file_command = __commonJS((exports2) => {
     return result;
   };
   Object.defineProperty(exports2, "__esModule", {value: true});
-  var fs2 = __importStar(require("fs"));
+  var fs3 = __importStar(require("fs"));
   var os2 = __importStar(require("os"));
   var utils_1 = require_utils();
   function issueCommand(command, message) {
@@ -134,10 +134,10 @@ var require_file_command = __commonJS((exports2) => {
     if (!filePath) {
       throw new Error(`Unable to find environment variable for file command ${command}`);
     }
-    if (!fs2.existsSync(filePath)) {
+    if (!fs3.existsSync(filePath)) {
       throw new Error(`Missing file at path: ${filePath}`);
     }
-    fs2.appendFileSync(filePath, `${utils_1.toCommandValue(message)}${os2.EOL}`, {
+    fs3.appendFileSync(filePath, `${utils_1.toCommandValue(message)}${os2.EOL}`, {
       encoding: "utf8"
     });
   }
@@ -329,9 +329,9 @@ var require_io_util = __commonJS((exports2) => {
   var _a;
   Object.defineProperty(exports2, "__esModule", {value: true});
   var assert_1 = require("assert");
-  var fs2 = require("fs");
+  var fs3 = require("fs");
   var path2 = require("path");
-  _a = fs2.promises, exports2.chmod = _a.chmod, exports2.copyFile = _a.copyFile, exports2.lstat = _a.lstat, exports2.mkdir = _a.mkdir, exports2.readdir = _a.readdir, exports2.readlink = _a.readlink, exports2.rename = _a.rename, exports2.rmdir = _a.rmdir, exports2.stat = _a.stat, exports2.symlink = _a.symlink, exports2.unlink = _a.unlink;
+  _a = fs3.promises, exports2.chmod = _a.chmod, exports2.copyFile = _a.copyFile, exports2.lstat = _a.lstat, exports2.mkdir = _a.mkdir, exports2.readdir = _a.readdir, exports2.readlink = _a.readlink, exports2.rename = _a.rename, exports2.rmdir = _a.rmdir, exports2.stat = _a.stat, exports2.symlink = _a.symlink, exports2.unlink = _a.unlink;
   exports2.IS_WINDOWS = process.platform === "win32";
   function exists(fsPath) {
     return __awaiter(this, void 0, void 0, function* () {
@@ -1221,12 +1221,13 @@ var exec5 = __toModule(require_exec());
 // lib/plugins-add/index.ts
 var core2 = __toModule(require_core());
 var exec3 = __toModule(require_exec());
-var fs = __toModule(require("fs"));
+var fs2 = __toModule(require("fs"));
 
 // lib/setup/index.ts
 var core = __toModule(require_core());
 var exec = __toModule(require_exec());
 var io = __toModule(require_io());
+var fs = __toModule(require("fs"));
 var os = __toModule(require("os"));
 var path = __toModule(require("path"));
 async function setupAsdf() {
@@ -1239,17 +1240,25 @@ async function setupAsdf() {
   core.exportVariable("ASDF_DATA_DIR", asdfDir);
   core.addPath(`${asdfDir}/bin`);
   core.addPath(`${asdfDir}/shims`);
-  core.info(`Cloning asdf into ASDF_DIR: ${asdfDir}`);
   const branch = core.getInput("asdf_branch", {required: true});
-  await exec.exec("git", [
-    "clone",
-    "--depth",
-    "1",
-    "--branch",
-    branch,
-    "https://github.com/asdf-vm/asdf.git",
-    asdfDir
-  ]);
+  if (fs.existsSync(asdfDir)) {
+    core.info(`Updating asdf on ASDF_DIR: ${asdfDir}`);
+    await exec.exec("git", ["fetch", "--depth", "1"], {cwd: asdfDir});
+    await exec.exec("git", ["checkout", "-B", branch, "origin"], {
+      cwd: asdfDir
+    });
+  } else {
+    core.info(`Cloning asdf into ASDF_DIR: ${asdfDir}`);
+    await exec.exec("git", [
+      "clone",
+      "--depth",
+      "1",
+      "--branch",
+      branch,
+      "https://github.com/asdf-vm/asdf.git",
+      asdfDir
+    ]);
+  }
 }
 
 // lib/plugins-add/index.ts
@@ -1279,11 +1288,11 @@ async function pluginsAdd() {
   await setupAsdf();
   let toolVersions = core2.getInput("tool_versions", {required: false});
   if (toolVersions) {
-    await fs.promises.writeFile(".tool-versions", toolVersions, {
+    await fs2.promises.writeFile(".tool-versions", toolVersions, {
       encoding: "utf8"
     });
   } else {
-    toolVersions = await fs.promises.readFile(".tool-versions", {
+    toolVersions = await fs2.promises.readFile(".tool-versions", {
       encoding: "utf8"
     });
   }

--- a/lib/setup/index.ts
+++ b/lib/setup/index.ts
@@ -1,6 +1,7 @@
 import * as core from "@actions/core";
 import * as exec from "@actions/exec";
 import * as io from "@actions/io";
+import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
 
@@ -14,15 +15,23 @@ export async function setupAsdf(): Promise<void> {
   core.exportVariable("ASDF_DATA_DIR", asdfDir);
   core.addPath(`${asdfDir}/bin`);
   core.addPath(`${asdfDir}/shims`);
-  core.info(`Cloning asdf into ASDF_DIR: ${asdfDir}`);
   const branch = core.getInput("asdf_branch", { required: true });
-  await exec.exec("git", [
-    "clone",
-    "--depth",
-    "1",
-    "--branch",
-    branch,
-    "https://github.com/asdf-vm/asdf.git",
-    asdfDir,
-  ]);
+  if (fs.existsSync(asdfDir)) {
+    core.info(`Updating asdf on ASDF_DIR: ${asdfDir}`);
+    await exec.exec("git", ["fetch", "--depth", "1"], { cwd: asdfDir });
+    await exec.exec("git", ["checkout", "-B", branch, "origin"], {
+      cwd: asdfDir,
+    });
+  } else {
+    core.info(`Cloning asdf into ASDF_DIR: ${asdfDir}`);
+    await exec.exec("git", [
+      "clone",
+      "--depth",
+      "1",
+      "--branch",
+      branch,
+      "https://github.com/asdf-vm/asdf.git",
+      asdfDir,
+    ]);
+  }
 }

--- a/plugin-test/main.js
+++ b/plugin-test/main.js
@@ -126,7 +126,7 @@ var require_file_command = __commonJS((exports2) => {
     return result;
   };
   Object.defineProperty(exports2, "__esModule", {value: true});
-  var fs = __importStar(require("fs"));
+  var fs2 = __importStar(require("fs"));
   var os2 = __importStar(require("os"));
   var utils_1 = require_utils();
   function issueCommand(command, message) {
@@ -134,10 +134,10 @@ var require_file_command = __commonJS((exports2) => {
     if (!filePath) {
       throw new Error(`Unable to find environment variable for file command ${command}`);
     }
-    if (!fs.existsSync(filePath)) {
+    if (!fs2.existsSync(filePath)) {
       throw new Error(`Missing file at path: ${filePath}`);
     }
-    fs.appendFileSync(filePath, `${utils_1.toCommandValue(message)}${os2.EOL}`, {
+    fs2.appendFileSync(filePath, `${utils_1.toCommandValue(message)}${os2.EOL}`, {
       encoding: "utf8"
     });
   }
@@ -329,9 +329,9 @@ var require_io_util = __commonJS((exports2) => {
   var _a;
   Object.defineProperty(exports2, "__esModule", {value: true});
   var assert_1 = require("assert");
-  var fs = require("fs");
+  var fs2 = require("fs");
   var path2 = require("path");
-  _a = fs.promises, exports2.chmod = _a.chmod, exports2.copyFile = _a.copyFile, exports2.lstat = _a.lstat, exports2.mkdir = _a.mkdir, exports2.readdir = _a.readdir, exports2.readlink = _a.readlink, exports2.rename = _a.rename, exports2.rmdir = _a.rmdir, exports2.stat = _a.stat, exports2.symlink = _a.symlink, exports2.unlink = _a.unlink;
+  _a = fs2.promises, exports2.chmod = _a.chmod, exports2.copyFile = _a.copyFile, exports2.lstat = _a.lstat, exports2.mkdir = _a.mkdir, exports2.readdir = _a.readdir, exports2.readlink = _a.readlink, exports2.rename = _a.rename, exports2.rmdir = _a.rmdir, exports2.stat = _a.stat, exports2.symlink = _a.symlink, exports2.unlink = _a.unlink;
   exports2.IS_WINDOWS = process.platform === "win32";
   function exists(fsPath) {
     return __awaiter(this, void 0, void 0, function* () {
@@ -1222,6 +1222,7 @@ var exec3 = __toModule(require_exec());
 var core = __toModule(require_core());
 var exec = __toModule(require_exec());
 var io = __toModule(require_io());
+var fs = __toModule(require("fs"));
 var os = __toModule(require("os"));
 var path = __toModule(require("path"));
 async function setupAsdf() {
@@ -1234,17 +1235,25 @@ async function setupAsdf() {
   core.exportVariable("ASDF_DATA_DIR", asdfDir);
   core.addPath(`${asdfDir}/bin`);
   core.addPath(`${asdfDir}/shims`);
-  core.info(`Cloning asdf into ASDF_DIR: ${asdfDir}`);
   const branch = core.getInput("asdf_branch", {required: true});
-  await exec.exec("git", [
-    "clone",
-    "--depth",
-    "1",
-    "--branch",
-    branch,
-    "https://github.com/asdf-vm/asdf.git",
-    asdfDir
-  ]);
+  if (fs.existsSync(asdfDir)) {
+    core.info(`Updating asdf on ASDF_DIR: ${asdfDir}`);
+    await exec.exec("git", ["fetch", "--depth", "1"], {cwd: asdfDir});
+    await exec.exec("git", ["checkout", "-B", branch, "origin"], {
+      cwd: asdfDir
+    });
+  } else {
+    core.info(`Cloning asdf into ASDF_DIR: ${asdfDir}`);
+    await exec.exec("git", [
+      "clone",
+      "--depth",
+      "1",
+      "--branch",
+      branch,
+      "https://github.com/asdf-vm/asdf.git",
+      asdfDir
+    ]);
+  }
 }
 
 // lib/plugin-test/index.ts

--- a/plugins-add/main.js
+++ b/plugins-add/main.js
@@ -126,7 +126,7 @@ var require_file_command = __commonJS((exports2) => {
     return result;
   };
   Object.defineProperty(exports2, "__esModule", {value: true});
-  var fs2 = __importStar(require("fs"));
+  var fs3 = __importStar(require("fs"));
   var os2 = __importStar(require("os"));
   var utils_1 = require_utils();
   function issueCommand(command, message) {
@@ -134,10 +134,10 @@ var require_file_command = __commonJS((exports2) => {
     if (!filePath) {
       throw new Error(`Unable to find environment variable for file command ${command}`);
     }
-    if (!fs2.existsSync(filePath)) {
+    if (!fs3.existsSync(filePath)) {
       throw new Error(`Missing file at path: ${filePath}`);
     }
-    fs2.appendFileSync(filePath, `${utils_1.toCommandValue(message)}${os2.EOL}`, {
+    fs3.appendFileSync(filePath, `${utils_1.toCommandValue(message)}${os2.EOL}`, {
       encoding: "utf8"
     });
   }
@@ -329,9 +329,9 @@ var require_io_util = __commonJS((exports2) => {
   var _a;
   Object.defineProperty(exports2, "__esModule", {value: true});
   var assert_1 = require("assert");
-  var fs2 = require("fs");
+  var fs3 = require("fs");
   var path2 = require("path");
-  _a = fs2.promises, exports2.chmod = _a.chmod, exports2.copyFile = _a.copyFile, exports2.lstat = _a.lstat, exports2.mkdir = _a.mkdir, exports2.readdir = _a.readdir, exports2.readlink = _a.readlink, exports2.rename = _a.rename, exports2.rmdir = _a.rmdir, exports2.stat = _a.stat, exports2.symlink = _a.symlink, exports2.unlink = _a.unlink;
+  _a = fs3.promises, exports2.chmod = _a.chmod, exports2.copyFile = _a.copyFile, exports2.lstat = _a.lstat, exports2.mkdir = _a.mkdir, exports2.readdir = _a.readdir, exports2.readlink = _a.readlink, exports2.rename = _a.rename, exports2.rmdir = _a.rmdir, exports2.stat = _a.stat, exports2.symlink = _a.symlink, exports2.unlink = _a.unlink;
   exports2.IS_WINDOWS = process.platform === "win32";
   function exists(fsPath) {
     return __awaiter(this, void 0, void 0, function* () {
@@ -1217,12 +1217,13 @@ var core3 = __toModule(require_core());
 // lib/plugins-add/index.ts
 var core2 = __toModule(require_core());
 var exec3 = __toModule(require_exec());
-var fs = __toModule(require("fs"));
+var fs2 = __toModule(require("fs"));
 
 // lib/setup/index.ts
 var core = __toModule(require_core());
 var exec = __toModule(require_exec());
 var io = __toModule(require_io());
+var fs = __toModule(require("fs"));
 var os = __toModule(require("os"));
 var path = __toModule(require("path"));
 async function setupAsdf() {
@@ -1235,17 +1236,25 @@ async function setupAsdf() {
   core.exportVariable("ASDF_DATA_DIR", asdfDir);
   core.addPath(`${asdfDir}/bin`);
   core.addPath(`${asdfDir}/shims`);
-  core.info(`Cloning asdf into ASDF_DIR: ${asdfDir}`);
   const branch = core.getInput("asdf_branch", {required: true});
-  await exec.exec("git", [
-    "clone",
-    "--depth",
-    "1",
-    "--branch",
-    branch,
-    "https://github.com/asdf-vm/asdf.git",
-    asdfDir
-  ]);
+  if (fs.existsSync(asdfDir)) {
+    core.info(`Updating asdf on ASDF_DIR: ${asdfDir}`);
+    await exec.exec("git", ["fetch", "--depth", "1"], {cwd: asdfDir});
+    await exec.exec("git", ["checkout", "-B", branch, "origin"], {
+      cwd: asdfDir
+    });
+  } else {
+    core.info(`Cloning asdf into ASDF_DIR: ${asdfDir}`);
+    await exec.exec("git", [
+      "clone",
+      "--depth",
+      "1",
+      "--branch",
+      branch,
+      "https://github.com/asdf-vm/asdf.git",
+      asdfDir
+    ]);
+  }
 }
 
 // lib/plugins-add/index.ts
@@ -1275,11 +1284,11 @@ async function pluginsAdd() {
   await setupAsdf();
   let toolVersions = core2.getInput("tool_versions", {required: false});
   if (toolVersions) {
-    await fs.promises.writeFile(".tool-versions", toolVersions, {
+    await fs2.promises.writeFile(".tool-versions", toolVersions, {
       encoding: "utf8"
     });
   } else {
-    toolVersions = await fs.promises.readFile(".tool-versions", {
+    toolVersions = await fs2.promises.readFile(".tool-versions", {
       encoding: "utf8"
     });
   }

--- a/setup/main.js
+++ b/setup/main.js
@@ -126,7 +126,7 @@ var require_file_command = __commonJS((exports2) => {
     return result;
   };
   Object.defineProperty(exports2, "__esModule", {value: true});
-  var fs = __importStar(require("fs"));
+  var fs2 = __importStar(require("fs"));
   var os2 = __importStar(require("os"));
   var utils_1 = require_utils();
   function issueCommand(command, message) {
@@ -134,10 +134,10 @@ var require_file_command = __commonJS((exports2) => {
     if (!filePath) {
       throw new Error(`Unable to find environment variable for file command ${command}`);
     }
-    if (!fs.existsSync(filePath)) {
+    if (!fs2.existsSync(filePath)) {
       throw new Error(`Missing file at path: ${filePath}`);
     }
-    fs.appendFileSync(filePath, `${utils_1.toCommandValue(message)}${os2.EOL}`, {
+    fs2.appendFileSync(filePath, `${utils_1.toCommandValue(message)}${os2.EOL}`, {
       encoding: "utf8"
     });
   }
@@ -329,9 +329,9 @@ var require_io_util = __commonJS((exports2) => {
   var _a;
   Object.defineProperty(exports2, "__esModule", {value: true});
   var assert_1 = require("assert");
-  var fs = require("fs");
+  var fs2 = require("fs");
   var path2 = require("path");
-  _a = fs.promises, exports2.chmod = _a.chmod, exports2.copyFile = _a.copyFile, exports2.lstat = _a.lstat, exports2.mkdir = _a.mkdir, exports2.readdir = _a.readdir, exports2.readlink = _a.readlink, exports2.rename = _a.rename, exports2.rmdir = _a.rmdir, exports2.stat = _a.stat, exports2.symlink = _a.symlink, exports2.unlink = _a.unlink;
+  _a = fs2.promises, exports2.chmod = _a.chmod, exports2.copyFile = _a.copyFile, exports2.lstat = _a.lstat, exports2.mkdir = _a.mkdir, exports2.readdir = _a.readdir, exports2.readlink = _a.readlink, exports2.rename = _a.rename, exports2.rmdir = _a.rmdir, exports2.stat = _a.stat, exports2.symlink = _a.symlink, exports2.unlink = _a.unlink;
   exports2.IS_WINDOWS = process.platform === "win32";
   function exists(fsPath) {
     return __awaiter(this, void 0, void 0, function* () {
@@ -1218,6 +1218,7 @@ var core2 = __toModule(require_core());
 var core = __toModule(require_core());
 var exec = __toModule(require_exec());
 var io = __toModule(require_io());
+var fs = __toModule(require("fs"));
 var os = __toModule(require("os"));
 var path = __toModule(require("path"));
 async function setupAsdf() {
@@ -1230,17 +1231,25 @@ async function setupAsdf() {
   core.exportVariable("ASDF_DATA_DIR", asdfDir);
   core.addPath(`${asdfDir}/bin`);
   core.addPath(`${asdfDir}/shims`);
-  core.info(`Cloning asdf into ASDF_DIR: ${asdfDir}`);
   const branch = core.getInput("asdf_branch", {required: true});
-  await exec.exec("git", [
-    "clone",
-    "--depth",
-    "1",
-    "--branch",
-    branch,
-    "https://github.com/asdf-vm/asdf.git",
-    asdfDir
-  ]);
+  if (fs.existsSync(asdfDir)) {
+    core.info(`Updating asdf on ASDF_DIR: ${asdfDir}`);
+    await exec.exec("git", ["fetch", "--depth", "1"], {cwd: asdfDir});
+    await exec.exec("git", ["checkout", "-B", branch, "origin"], {
+      cwd: asdfDir
+    });
+  } else {
+    core.info(`Cloning asdf into ASDF_DIR: ${asdfDir}`);
+    await exec.exec("git", [
+      "clone",
+      "--depth",
+      "1",
+      "--branch",
+      branch,
+      "https://github.com/asdf-vm/asdf.git",
+      asdfDir
+    ]);
+  }
 }
 
 // lib/setup/main.ts


### PR DESCRIPTION
This PR allows `setup` action to update existing asdf with `git fetch` and `git switch`.
It is helpful on self-hosted runners because files generated by actions basically keep.

Close #356