### PR TITLE
feat: allow to update existing asdf

### DIFF
--- a/install/main.js
+++ b/install/main.js
@@ -1243,10 +1243,12 @@ async function setupAsdf() {
   const branch = core.getInput("asdf_branch", {required: true});
   if (fs.existsSync(asdfDir)) {
     core.info(`Updating asdf on ASDF_DIR: ${asdfDir}`);
-    await exec.exec("git", ["fetch", "--depth", "1"], {cwd: asdfDir});
-    await exec.exec("git", ["checkout", "-B", branch, "origin"], {
+    const opts = {
       cwd: asdfDir
-    });
+    };
+    await exec.exec("git", ["remote", "set-branches", "origin", branch], opts);
+    await exec.exec("git", ["fetch", "--depth", "1", "origin", branch], opts);
+    await exec.exec("git", ["checkout", "-B", branch, "origin"], opts);
   } else {
     core.info(`Cloning asdf into ASDF_DIR: ${asdfDir}`);
     await exec.exec("git", [
@@ -1255,6 +1257,7 @@ async function setupAsdf() {
       "1",
       "--branch",
       branch,
+      "--single-branch",
       "https://github.com/asdf-vm/asdf.git",
       asdfDir
     ]);

--- a/install/main.js
+++ b/install/main.js
@@ -126,7 +126,7 @@ var require_file_command = __commonJS((exports2) => {
     return result;
   };
   Object.defineProperty(exports2, "__esModule", {value: true});
-  var fs2 = __importStar(require("fs"));
+  var fs3 = __importStar(require("fs"));
   var os2 = __importStar(require("os"));
   var utils_1 = require_utils();
   function issueCommand(command, message) {
@@ -134,10 +134,10 @@ var require_file_command = __commonJS((exports2) => {
     if (!filePath) {
       throw new Error(`Unable to find environment variable for file command ${command}`);
     }
-    if (!fs2.existsSync(filePath)) {
+    if (!fs3.existsSync(filePath)) {
       throw new Error(`Missing file at path: ${filePath}`);
     }
-    fs2.appendFileSync(filePath, `${utils_1.toCommandValue(message)}${os2.EOL}`, {
+    fs3.appendFileSync(filePath, `${utils_1.toCommandValue(message)}${os2.EOL}`, {
       encoding: "utf8"
     });
   }
@@ -329,9 +329,9 @@ var require_io_util = __commonJS((exports2) => {
   var _a;
   Object.defineProperty(exports2, "__esModule", {value: true});
   var assert_1 = require("assert");
-  var fs2 = require("fs");
+  var fs3 = require("fs");
   var path2 = require("path");
-  _a = fs2.promises, exports2.chmod = _a.chmod, exports2.copyFile = _a.copyFile, exports2.lstat = _a.lstat, exports2.mkdir = _a.mkdir, exports2.readdir = _a.readdir, exports2.readlink = _a.readlink, exports2.rename = _a.rename, exports2.rmdir = _a.rmdir, exports2.stat = _a.stat, exports2.symlink = _a.symlink, exports2.unlink = _a.unlink;
+  _a = fs3.promises, exports2.chmod = _a.chmod, exports2.copyFile = _a.copyFile, exports2.lstat = _a.lstat, exports2.mkdir = _a.mkdir, exports2.readdir = _a.readdir, exports2.readlink = _a.readlink, exports2.rename = _a.rename, exports2.rmdir = _a.rmdir, exports2.stat = _a.stat, exports2.symlink = _a.symlink, exports2.unlink = _a.unlink;
   exports2.IS_WINDOWS = process.platform === "win32";
   function exists(fsPath) {
     return __awaiter(this, void 0, void 0, function* () {
@@ -1221,12 +1221,13 @@ var exec5 = __toModule(require_exec());
 // lib/plugins-add/index.ts
 var core2 = __toModule(require_core());
 var exec3 = __toModule(require_exec());
-var fs = __toModule(require("fs"));
+var fs2 = __toModule(require("fs"));
 
 // lib/setup/index.ts
 var core = __toModule(require_core());
 var exec = __toModule(require_exec());
 var io = __toModule(require_io());
+var fs = __toModule(require("fs"));
 var os = __toModule(require("os"));
 var path = __toModule(require("path"));
 async function setupAsdf() {
@@ -1239,17 +1240,25 @@ async function setupAsdf() {
   core.exportVariable("ASDF_DATA_DIR", asdfDir);
   core.addPath(`${asdfDir}/bin`);
   core.addPath(`${asdfDir}/shims`);
-  core.info(`Cloning asdf into ASDF_DIR: ${asdfDir}`);
   const branch = core.getInput("asdf_branch", {required: true});
-  await exec.exec("git", [
-    "clone",
-    "--depth",
-    "1",
-    "--branch",
-    branch,
-    "https://github.com/asdf-vm/asdf.git",
-    asdfDir
-  ]);
+  if (fs.existsSync(asdfDir)) {
+    core.info(`Updating asdf on ASDF_DIR: ${asdfDir}`);
+    await exec.exec("git", ["fetch", "--depth", "1"], {cwd: asdfDir});
+    await exec.exec("git", ["checkout", "-B", branch, "origin"], {
+      cwd: asdfDir
+    });
+  } else {
+    core.info(`Cloning asdf into ASDF_DIR: ${asdfDir}`);
+    await exec.exec("git", [
+      "clone",
+      "--depth",
+      "1",
+      "--branch",
+      branch,
+      "https://github.com/asdf-vm/asdf.git",
+      asdfDir
+    ]);
+  }
 }
 
 // lib/plugins-add/index.ts
@@ -1279,11 +1288,11 @@ async function pluginsAdd() {
   await setupAsdf();
   let toolVersions = core2.getInput("tool_versions", {required: false});
   if (toolVersions) {
-    await fs.promises.writeFile(".tool-versions", toolVersions, {
+    await fs2.promises.writeFile(".tool-versions", toolVersions, {
       encoding: "utf8"
     });
   } else {
-    toolVersions = await fs.promises.readFile(".tool-versions", {
+    toolVersions = await fs2.promises.readFile(".tool-versions", {
       encoding: "utf8"
     });
   }

--- a/lib/setup/index.ts
+++ b/lib/setup/index.ts
@@ -18,10 +18,12 @@ export async function setupAsdf(): Promise<void> {
   const branch = core.getInput("asdf_branch", { required: true });
   if (fs.existsSync(asdfDir)) {
     core.info(`Updating asdf on ASDF_DIR: ${asdfDir}`);
-    await exec.exec("git", ["fetch", "--depth", "1"], { cwd: asdfDir });
-    await exec.exec("git", ["checkout", "-B", branch, "origin"], {
+    const opts = {
       cwd: asdfDir,
-    });
+    };
+    await exec.exec("git", ["remote", "set-branches", "origin", branch], opts);
+    await exec.exec("git", ["fetch", "--depth", "1", "origin", branch], opts);
+    await exec.exec("git", ["checkout", "-B", branch, "origin"], opts);
   } else {
     core.info(`Cloning asdf into ASDF_DIR: ${asdfDir}`);
     await exec.exec("git", [
@@ -30,6 +32,7 @@ export async function setupAsdf(): Promise<void> {
       "1",
       "--branch",
       branch,
+      "--single-branch",
       "https://github.com/asdf-vm/asdf.git",
       asdfDir,
     ]);

--- a/lib/setup/index.ts
+++ b/lib/setup/index.ts
@@ -1,6 +1,7 @@
 import * as core from "@actions/core";
 import * as exec from "@actions/exec";
 import * as io from "@actions/io";
+import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
 
@@ -14,15 +15,23 @@ export async function setupAsdf(): Promise<void> {
   core.exportVariable("ASDF_DATA_DIR", asdfDir);
   core.addPath(`${asdfDir}/bin`);
   core.addPath(`${asdfDir}/shims`);
-  core.info(`Cloning asdf into ASDF_DIR: ${asdfDir}`);
   const branch = core.getInput("asdf_branch", { required: true });
-  await exec.exec("git", [
-    "clone",
-    "--depth",
-    "1",
-    "--branch",
-    branch,
-    "https://github.com/asdf-vm/asdf.git",
-    asdfDir,
-  ]);
+  if (fs.existsSync(asdfDir)) {
+    core.info(`Updating asdf on ASDF_DIR: ${asdfDir}`);
+    await exec.exec("git", ["fetch", "--depth", "1"], { cwd: asdfDir });
+    await exec.exec("git", ["checkout", "-B", branch, "origin"], {
+      cwd: asdfDir,
+    });
+  } else {
+    core.info(`Cloning asdf into ASDF_DIR: ${asdfDir}`);
+    await exec.exec("git", [
+      "clone",
+      "--depth",
+      "1",
+      "--branch",
+      branch,
+      "https://github.com/asdf-vm/asdf.git",
+      asdfDir,
+    ]);
+  }
 }

--- a/plugin-test/main.js
+++ b/plugin-test/main.js
@@ -1238,10 +1238,12 @@ async function setupAsdf() {
   const branch = core.getInput("asdf_branch", {required: true});
   if (fs.existsSync(asdfDir)) {
     core.info(`Updating asdf on ASDF_DIR: ${asdfDir}`);
-    await exec.exec("git", ["fetch", "--depth", "1"], {cwd: asdfDir});
-    await exec.exec("git", ["checkout", "-B", branch, "origin"], {
+    const opts = {
       cwd: asdfDir
-    });
+    };
+    await exec.exec("git", ["remote", "set-branches", "origin", branch], opts);
+    await exec.exec("git", ["fetch", "--depth", "1", "origin", branch], opts);
+    await exec.exec("git", ["checkout", "-B", branch, "origin"], opts);
   } else {
     core.info(`Cloning asdf into ASDF_DIR: ${asdfDir}`);
     await exec.exec("git", [
@@ -1250,6 +1252,7 @@ async function setupAsdf() {
       "1",
       "--branch",
       branch,
+      "--single-branch",
       "https://github.com/asdf-vm/asdf.git",
       asdfDir
     ]);

--- a/plugin-test/main.js
+++ b/plugin-test/main.js
@@ -126,7 +126,7 @@ var require_file_command = __commonJS((exports2) => {
     return result;
   };
   Object.defineProperty(exports2, "__esModule", {value: true});
-  var fs = __importStar(require("fs"));
+  var fs2 = __importStar(require("fs"));
   var os2 = __importStar(require("os"));
   var utils_1 = require_utils();
   function issueCommand(command, message) {
@@ -134,10 +134,10 @@ var require_file_command = __commonJS((exports2) => {
     if (!filePath) {
       throw new Error(`Unable to find environment variable for file command ${command}`);
     }
-    if (!fs.existsSync(filePath)) {
+    if (!fs2.existsSync(filePath)) {
       throw new Error(`Missing file at path: ${filePath}`);
     }
-    fs.appendFileSync(filePath, `${utils_1.toCommandValue(message)}${os2.EOL}`, {
+    fs2.appendFileSync(filePath, `${utils_1.toCommandValue(message)}${os2.EOL}`, {
       encoding: "utf8"
     });
   }
@@ -329,9 +329,9 @@ var require_io_util = __commonJS((exports2) => {
   var _a;
   Object.defineProperty(exports2, "__esModule", {value: true});
   var assert_1 = require("assert");
-  var fs = require("fs");
+  var fs2 = require("fs");
   var path2 = require("path");
-  _a = fs.promises, exports2.chmod = _a.chmod, exports2.copyFile = _a.copyFile, exports2.lstat = _a.lstat, exports2.mkdir = _a.mkdir, exports2.readdir = _a.readdir, exports2.readlink = _a.readlink, exports2.rename = _a.rename, exports2.rmdir = _a.rmdir, exports2.stat = _a.stat, exports2.symlink = _a.symlink, exports2.unlink = _a.unlink;
+  _a = fs2.promises, exports2.chmod = _a.chmod, exports2.copyFile = _a.copyFile, exports2.lstat = _a.lstat, exports2.mkdir = _a.mkdir, exports2.readdir = _a.readdir, exports2.readlink = _a.readlink, exports2.rename = _a.rename, exports2.rmdir = _a.rmdir, exports2.stat = _a.stat, exports2.symlink = _a.symlink, exports2.unlink = _a.unlink;
   exports2.IS_WINDOWS = process.platform === "win32";
   function exists(fsPath) {
     return __awaiter(this, void 0, void 0, function* () {
@@ -1222,6 +1222,7 @@ var exec3 = __toModule(require_exec());
 var core = __toModule(require_core());
 var exec = __toModule(require_exec());
 var io = __toModule(require_io());
+var fs = __toModule(require("fs"));
 var os = __toModule(require("os"));
 var path = __toModule(require("path"));
 async function setupAsdf() {
@@ -1234,17 +1235,25 @@ async function setupAsdf() {
   core.exportVariable("ASDF_DATA_DIR", asdfDir);
   core.addPath(`${asdfDir}/bin`);
   core.addPath(`${asdfDir}/shims`);
-  core.info(`Cloning asdf into ASDF_DIR: ${asdfDir}`);
   const branch = core.getInput("asdf_branch", {required: true});
-  await exec.exec("git", [
-    "clone",
-    "--depth",
-    "1",
-    "--branch",
-    branch,
-    "https://github.com/asdf-vm/asdf.git",
-    asdfDir
-  ]);
+  if (fs.existsSync(asdfDir)) {
+    core.info(`Updating asdf on ASDF_DIR: ${asdfDir}`);
+    await exec.exec("git", ["fetch", "--depth", "1"], {cwd: asdfDir});
+    await exec.exec("git", ["checkout", "-B", branch, "origin"], {
+      cwd: asdfDir
+    });
+  } else {
+    core.info(`Cloning asdf into ASDF_DIR: ${asdfDir}`);
+    await exec.exec("git", [
+      "clone",
+      "--depth",
+      "1",
+      "--branch",
+      branch,
+      "https://github.com/asdf-vm/asdf.git",
+      asdfDir
+    ]);
+  }
 }
 
 // lib/plugin-test/index.ts

--- a/plugins-add/main.js
+++ b/plugins-add/main.js
@@ -1239,10 +1239,12 @@ async function setupAsdf() {
   const branch = core.getInput("asdf_branch", {required: true});
   if (fs.existsSync(asdfDir)) {
     core.info(`Updating asdf on ASDF_DIR: ${asdfDir}`);
-    await exec.exec("git", ["fetch", "--depth", "1"], {cwd: asdfDir});
-    await exec.exec("git", ["checkout", "-B", branch, "origin"], {
+    const opts = {
       cwd: asdfDir
-    });
+    };
+    await exec.exec("git", ["remote", "set-branches", "origin", branch], opts);
+    await exec.exec("git", ["fetch", "--depth", "1", "origin", branch], opts);
+    await exec.exec("git", ["checkout", "-B", branch, "origin"], opts);
   } else {
     core.info(`Cloning asdf into ASDF_DIR: ${asdfDir}`);
     await exec.exec("git", [
@@ -1251,6 +1253,7 @@ async function setupAsdf() {
       "1",
       "--branch",
       branch,
+      "--single-branch",
       "https://github.com/asdf-vm/asdf.git",
       asdfDir
     ]);

--- a/plugins-add/main.js
+++ b/plugins-add/main.js
@@ -126,7 +126,7 @@ var require_file_command = __commonJS((exports2) => {
     return result;
   };
   Object.defineProperty(exports2, "__esModule", {value: true});
-  var fs2 = __importStar(require("fs"));
+  var fs3 = __importStar(require("fs"));
   var os2 = __importStar(require("os"));
   var utils_1 = require_utils();
   function issueCommand(command, message) {
@@ -134,10 +134,10 @@ var require_file_command = __commonJS((exports2) => {
     if (!filePath) {
       throw new Error(`Unable to find environment variable for file command ${command}`);
     }
-    if (!fs2.existsSync(filePath)) {
+    if (!fs3.existsSync(filePath)) {
       throw new Error(`Missing file at path: ${filePath}`);
     }
-    fs2.appendFileSync(filePath, `${utils_1.toCommandValue(message)}${os2.EOL}`, {
+    fs3.appendFileSync(filePath, `${utils_1.toCommandValue(message)}${os2.EOL}`, {
       encoding: "utf8"
     });
   }
@@ -329,9 +329,9 @@ var require_io_util = __commonJS((exports2) => {
   var _a;
   Object.defineProperty(exports2, "__esModule", {value: true});
   var assert_1 = require("assert");
-  var fs2 = require("fs");
+  var fs3 = require("fs");
   var path2 = require("path");
-  _a = fs2.promises, exports2.chmod = _a.chmod, exports2.copyFile = _a.copyFile, exports2.lstat = _a.lstat, exports2.mkdir = _a.mkdir, exports2.readdir = _a.readdir, exports2.readlink = _a.readlink, exports2.rename = _a.rename, exports2.rmdir = _a.rmdir, exports2.stat = _a.stat, exports2.symlink = _a.symlink, exports2.unlink = _a.unlink;
+  _a = fs3.promises, exports2.chmod = _a.chmod, exports2.copyFile = _a.copyFile, exports2.lstat = _a.lstat, exports2.mkdir = _a.mkdir, exports2.readdir = _a.readdir, exports2.readlink = _a.readlink, exports2.rename = _a.rename, exports2.rmdir = _a.rmdir, exports2.stat = _a.stat, exports2.symlink = _a.symlink, exports2.unlink = _a.unlink;
   exports2.IS_WINDOWS = process.platform === "win32";
   function exists(fsPath) {
     return __awaiter(this, void 0, void 0, function* () {
@@ -1217,12 +1217,13 @@ var core3 = __toModule(require_core());
 // lib/plugins-add/index.ts
 var core2 = __toModule(require_core());
 var exec3 = __toModule(require_exec());
-var fs = __toModule(require("fs"));
+var fs2 = __toModule(require("fs"));
 
 // lib/setup/index.ts
 var core = __toModule(require_core());
 var exec = __toModule(require_exec());
 var io = __toModule(require_io());
+var fs = __toModule(require("fs"));
 var os = __toModule(require("os"));
 var path = __toModule(require("path"));
 async function setupAsdf() {
@@ -1235,17 +1236,25 @@ async function setupAsdf() {
   core.exportVariable("ASDF_DATA_DIR", asdfDir);
   core.addPath(`${asdfDir}/bin`);
   core.addPath(`${asdfDir}/shims`);
-  core.info(`Cloning asdf into ASDF_DIR: ${asdfDir}`);
   const branch = core.getInput("asdf_branch", {required: true});
-  await exec.exec("git", [
-    "clone",
-    "--depth",
-    "1",
-    "--branch",
-    branch,
-    "https://github.com/asdf-vm/asdf.git",
-    asdfDir
-  ]);
+  if (fs.existsSync(asdfDir)) {
+    core.info(`Updating asdf on ASDF_DIR: ${asdfDir}`);
+    await exec.exec("git", ["fetch", "--depth", "1"], {cwd: asdfDir});
+    await exec.exec("git", ["checkout", "-B", branch, "origin"], {
+      cwd: asdfDir
+    });
+  } else {
+    core.info(`Cloning asdf into ASDF_DIR: ${asdfDir}`);
+    await exec.exec("git", [
+      "clone",
+      "--depth",
+      "1",
+      "--branch",
+      branch,
+      "https://github.com/asdf-vm/asdf.git",
+      asdfDir
+    ]);
+  }
 }
 
 // lib/plugins-add/index.ts
@@ -1275,11 +1284,11 @@ async function pluginsAdd() {
   await setupAsdf();
   let toolVersions = core2.getInput("tool_versions", {required: false});
   if (toolVersions) {
-    await fs.promises.writeFile(".tool-versions", toolVersions, {
+    await fs2.promises.writeFile(".tool-versions", toolVersions, {
       encoding: "utf8"
     });
   } else {
-    toolVersions = await fs.promises.readFile(".tool-versions", {
+    toolVersions = await fs2.promises.readFile(".tool-versions", {
       encoding: "utf8"
     });
   }

--- a/setup/main.js
+++ b/setup/main.js
@@ -126,7 +126,7 @@ var require_file_command = __commonJS((exports2) => {
     return result;
   };
   Object.defineProperty(exports2, "__esModule", {value: true});
-  var fs = __importStar(require("fs"));
+  var fs2 = __importStar(require("fs"));
   var os2 = __importStar(require("os"));
   var utils_1 = require_utils();
   function issueCommand(command, message) {
@@ -134,10 +134,10 @@ var require_file_command = __commonJS((exports2) => {
     if (!filePath) {
       throw new Error(`Unable to find environment variable for file command ${command}`);
     }
-    if (!fs.existsSync(filePath)) {
+    if (!fs2.existsSync(filePath)) {
       throw new Error(`Missing file at path: ${filePath}`);
     }
-    fs.appendFileSync(filePath, `${utils_1.toCommandValue(message)}${os2.EOL}`, {
+    fs2.appendFileSync(filePath, `${utils_1.toCommandValue(message)}${os2.EOL}`, {
       encoding: "utf8"
     });
   }
@@ -329,9 +329,9 @@ var require_io_util = __commonJS((exports2) => {
   var _a;
   Object.defineProperty(exports2, "__esModule", {value: true});
   var assert_1 = require("assert");
-  var fs = require("fs");
+  var fs2 = require("fs");
   var path2 = require("path");
-  _a = fs.promises, exports2.chmod = _a.chmod, exports2.copyFile = _a.copyFile, exports2.lstat = _a.lstat, exports2.mkdir = _a.mkdir, exports2.readdir = _a.readdir, exports2.readlink = _a.readlink, exports2.rename = _a.rename, exports2.rmdir = _a.rmdir, exports2.stat = _a.stat, exports2.symlink = _a.symlink, exports2.unlink = _a.unlink;
+  _a = fs2.promises, exports2.chmod = _a.chmod, exports2.copyFile = _a.copyFile, exports2.lstat = _a.lstat, exports2.mkdir = _a.mkdir, exports2.readdir = _a.readdir, exports2.readlink = _a.readlink, exports2.rename = _a.rename, exports2.rmdir = _a.rmdir, exports2.stat = _a.stat, exports2.symlink = _a.symlink, exports2.unlink = _a.unlink;
   exports2.IS_WINDOWS = process.platform === "win32";
   function exists(fsPath) {
     return __awaiter(this, void 0, void 0, function* () {
@@ -1218,6 +1218,7 @@ var core2 = __toModule(require_core());
 var core = __toModule(require_core());
 var exec = __toModule(require_exec());
 var io = __toModule(require_io());
+var fs = __toModule(require("fs"));
 var os = __toModule(require("os"));
 var path = __toModule(require("path"));
 async function setupAsdf() {
@@ -1230,17 +1231,25 @@ async function setupAsdf() {
   core.exportVariable("ASDF_DATA_DIR", asdfDir);
   core.addPath(`${asdfDir}/bin`);
   core.addPath(`${asdfDir}/shims`);
-  core.info(`Cloning asdf into ASDF_DIR: ${asdfDir}`);
   const branch = core.getInput("asdf_branch", {required: true});
-  await exec.exec("git", [
-    "clone",
-    "--depth",
-    "1",
-    "--branch",
-    branch,
-    "https://github.com/asdf-vm/asdf.git",
-    asdfDir
-  ]);
+  if (fs.existsSync(asdfDir)) {
+    core.info(`Updating asdf on ASDF_DIR: ${asdfDir}`);
+    await exec.exec("git", ["fetch", "--depth", "1"], {cwd: asdfDir});
+    await exec.exec("git", ["checkout", "-B", branch, "origin"], {
+      cwd: asdfDir
+    });
+  } else {
+    core.info(`Cloning asdf into ASDF_DIR: ${asdfDir}`);
+    await exec.exec("git", [
+      "clone",
+      "--depth",
+      "1",
+      "--branch",
+      branch,
+      "https://github.com/asdf-vm/asdf.git",
+      asdfDir
+    ]);
+  }
 }
 
 // lib/setup/main.ts

--- a/setup/main.js
+++ b/setup/main.js
@@ -1234,10 +1234,12 @@ async function setupAsdf() {
   const branch = core.getInput("asdf_branch", {required: true});
   if (fs.existsSync(asdfDir)) {
     core.info(`Updating asdf on ASDF_DIR: ${asdfDir}`);
-    await exec.exec("git", ["fetch", "--depth", "1"], {cwd: asdfDir});
-    await exec.exec("git", ["checkout", "-B", branch, "origin"], {
+    const opts = {
       cwd: asdfDir
-    });
+    };
+    await exec.exec("git", ["remote", "set-branches", "origin", branch], opts);
+    await exec.exec("git", ["fetch", "--depth", "1", "origin", branch], opts);
+    await exec.exec("git", ["checkout", "-B", branch, "origin"], opts);
   } else {
     core.info(`Cloning asdf into ASDF_DIR: ${asdfDir}`);
     await exec.exec("git", [
@@ -1246,6 +1248,7 @@ async function setupAsdf() {
       "1",
       "--branch",
       branch,
+      "--single-branch",
       "https://github.com/asdf-vm/asdf.git",
       asdfDir
     ]);


### PR DESCRIPTION
I re-created the PR instead of #387 to switch the branch.

This PR allows `setup` action to update existing asdf with `git fetch` and `git switch`.
It is helpful on self-hosted runners because files generated by actions basically keep.

Close #356