### PR TITLE
Add `working_directory` input to install action

### DIFF
--- a/install/action.yml
+++ b/install/action.yml
@@ -18,3 +18,7 @@ inputs:
     description: asdf branch to clone
     required: false
     default: master
+  working_directory:
+    description:
+      The directory to run asdf install in, defaults to the workspace root.
+    required: false

--- a/install/main.js
+++ b/install/main.js
@@ -1301,6 +1301,10 @@ async function pluginsAdd() {
 
 // lib/install/index.ts
 async function toolsInstall() {
+  const workingDirectory = core3.getInput("working_directory", {
+    required: false
+  });
+  workingDirectory && process.chdir(workingDirectory);
   await pluginsAdd();
   const before = core3.getInput("before_install", {required: false});
   if (before) {

--- a/lib/install/index.ts
+++ b/lib/install/index.ts
@@ -3,6 +3,10 @@ import * as exec from "@actions/exec";
 import { pluginsAdd } from "../plugins-add";
 
 export async function toolsInstall(): Promise<void> {
+  const workingDirectory = core.getInput("working_directory", {
+    required: false,
+  });
+  workingDirectory && process.chdir(workingDirectory);
   await pluginsAdd();
 
   const before = core.getInput("before_install", { required: false });


### PR DESCRIPTION
Useful for monorepos to be able to install dependencies for a specific package.

```yaml
uses: asdf-vm/actions/install@v1
with:
  working_directory: ./foo
```