### PR TITLE
feat: optionally skip install during setup

### DIFF
--- a/install/action.yml
+++ b/install/action.yml
@@ -18,3 +18,7 @@ inputs:
     description: asdf branch to clone
     required: false
     default: master
+  skip_install:
+    description: setup env without installing asdf
+    required: false
+    default: false

--- a/install/main.js
+++ b/install/main.js
@@ -31,6 +31,7 @@ var __toModule = (module2) => {
 var require_utils = __commonJS((exports2) => {
   "use strict";
   Object.defineProperty(exports2, "__esModule", {value: true});
+  exports2.toCommandValue = void 0;
   function toCommandValue(input) {
     if (input === null || input === void 0) {
       return "";
@@ -45,19 +46,36 @@ var require_utils = __commonJS((exports2) => {
 // node_modules/@actions/core/lib/command.js
 var require_command = __commonJS((exports2) => {
   "use strict";
+  var __createBinding = exports2 && exports2.__createBinding || (Object.create ? function(o, m, k, k2) {
+    if (k2 === void 0)
+      k2 = k;
+    Object.defineProperty(o, k2, {enumerable: true, get: function() {
+      return m[k];
+    }});
+  } : function(o, m, k, k2) {
+    if (k2 === void 0)
+      k2 = k;
+    o[k2] = m[k];
+  });
+  var __setModuleDefault = exports2 && exports2.__setModuleDefault || (Object.create ? function(o, v) {
+    Object.defineProperty(o, "default", {enumerable: true, value: v});
+  } : function(o, v) {
+    o["default"] = v;
+  });
   var __importStar = exports2 && exports2.__importStar || function(mod) {
     if (mod && mod.__esModule)
       return mod;
     var result = {};
     if (mod != null) {
       for (var k in mod)
-        if (Object.hasOwnProperty.call(mod, k))
-          result[k] = mod[k];
+        if (k !== "default" && Object.hasOwnProperty.call(mod, k))
+          __createBinding(result, mod, k);
     }
-    result["default"] = mod;
+    __setModuleDefault(result, mod);
     return result;
   };
   Object.defineProperty(exports2, "__esModule", {value: true});
+  exports2.issue = exports2.issueCommand = void 0;
   var os2 = __importStar(require("os"));
   var utils_1 = require_utils();
   function issueCommand(command, properties, message) {
@@ -113,19 +131,36 @@ var require_command = __commonJS((exports2) => {
 // node_modules/@actions/core/lib/file-command.js
 var require_file_command = __commonJS((exports2) => {
   "use strict";
+  var __createBinding = exports2 && exports2.__createBinding || (Object.create ? function(o, m, k, k2) {
+    if (k2 === void 0)
+      k2 = k;
+    Object.defineProperty(o, k2, {enumerable: true, get: function() {
+      return m[k];
+    }});
+  } : function(o, m, k, k2) {
+    if (k2 === void 0)
+      k2 = k;
+    o[k2] = m[k];
+  });
+  var __setModuleDefault = exports2 && exports2.__setModuleDefault || (Object.create ? function(o, v) {
+    Object.defineProperty(o, "default", {enumerable: true, value: v});
+  } : function(o, v) {
+    o["default"] = v;
+  });
   var __importStar = exports2 && exports2.__importStar || function(mod) {
     if (mod && mod.__esModule)
       return mod;
     var result = {};
     if (mod != null) {
       for (var k in mod)
-        if (Object.hasOwnProperty.call(mod, k))
-          result[k] = mod[k];
+        if (k !== "default" && Object.hasOwnProperty.call(mod, k))
+          __createBinding(result, mod, k);
     }
-    result["default"] = mod;
+    __setModuleDefault(result, mod);
     return result;
   };
   Object.defineProperty(exports2, "__esModule", {value: true});
+  exports2.issueCommand = void 0;
   var fs2 = __importStar(require("fs"));
   var os2 = __importStar(require("os"));
   var utils_1 = require_utils();
@@ -147,6 +182,34 @@ var require_file_command = __commonJS((exports2) => {
 // node_modules/@actions/core/lib/core.js
 var require_core = __commonJS((exports2) => {
   "use strict";
+  var __createBinding = exports2 && exports2.__createBinding || (Object.create ? function(o, m, k, k2) {
+    if (k2 === void 0)
+      k2 = k;
+    Object.defineProperty(o, k2, {enumerable: true, get: function() {
+      return m[k];
+    }});
+  } : function(o, m, k, k2) {
+    if (k2 === void 0)
+      k2 = k;
+    o[k2] = m[k];
+  });
+  var __setModuleDefault = exports2 && exports2.__setModuleDefault || (Object.create ? function(o, v) {
+    Object.defineProperty(o, "default", {enumerable: true, value: v});
+  } : function(o, v) {
+    o["default"] = v;
+  });
+  var __importStar = exports2 && exports2.__importStar || function(mod) {
+    if (mod && mod.__esModule)
+      return mod;
+    var result = {};
+    if (mod != null) {
+      for (var k in mod)
+        if (k !== "default" && Object.hasOwnProperty.call(mod, k))
+          __createBinding(result, mod, k);
+    }
+    __setModuleDefault(result, mod);
+    return result;
+  };
   var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
     function adopt(value) {
       return value instanceof P ? value : new P(function(resolve) {
@@ -174,19 +237,8 @@ var require_core = __commonJS((exports2) => {
       step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
   };
-  var __importStar = exports2 && exports2.__importStar || function(mod) {
-    if (mod && mod.__esModule)
-      return mod;
-    var result = {};
-    if (mod != null) {
-      for (var k in mod)
-        if (Object.hasOwnProperty.call(mod, k))
-          result[k] = mod[k];
-    }
-    result["default"] = mod;
-    return result;
-  };
   Object.defineProperty(exports2, "__esModule", {value: true});
+  exports2.getState = exports2.saveState = exports2.group = exports2.endGroup = exports2.startGroup = exports2.info = exports2.warning = exports2.error = exports2.debug = exports2.isDebug = exports2.setFailed = exports2.setCommandEcho = exports2.setOutput = exports2.getBooleanInput = exports2.getInput = exports2.addPath = exports2.setSecret = exports2.exportVariable = exports2.ExitCode = void 0;
   var command_1 = require_command();
   var file_command_1 = require_file_command();
   var utils_1 = require_utils();
@@ -229,10 +281,26 @@ var require_core = __commonJS((exports2) => {
     if (options && options.required && !val) {
       throw new Error(`Input required and not supplied: ${name}`);
     }
+    if (options && options.trimWhitespace === false) {
+      return val;
+    }
     return val.trim();
   }
   exports2.getInput = getInput4;
+  function getBooleanInput2(name, options) {
+    const trueValue = ["true", "True", "TRUE"];
+    const falseValue = ["false", "False", "FALSE"];
+    const val = getInput4(name, options);
+    if (trueValue.includes(val))
+      return true;
+    if (falseValue.includes(val))
+      return false;
+    throw new TypeError(`Input does not meet YAML 1.2 "Core Schema" specification: ${name}
+Support boolean input list: \`true | True | TRUE | false | False | FALSE\``);
+  }
+  exports2.getBooleanInput = getBooleanInput2;
   function setOutput(name, value) {
+    process.stdout.write(os2.EOL);
     command_1.issueCommand("set-output", {name}, value);
   }
   exports2.setOutput = setOutput;
@@ -1239,6 +1307,10 @@ async function setupAsdf() {
   core.exportVariable("ASDF_DATA_DIR", asdfDir);
   core.addPath(`${asdfDir}/bin`);
   core.addPath(`${asdfDir}/shims`);
+  const skip = core.getBooleanInput("skip_install", {required: true});
+  if (skip) {
+    return;
+  }
   core.info(`Cloning asdf into ASDF_DIR: ${asdfDir}`);
   const branch = core.getInput("asdf_branch", {required: true});
   await exec.exec("git", [

--- a/lib/setup/index.ts
+++ b/lib/setup/index.ts
@@ -14,6 +14,10 @@ export async function setupAsdf(): Promise<void> {
   core.exportVariable("ASDF_DATA_DIR", asdfDir);
   core.addPath(`${asdfDir}/bin`);
   core.addPath(`${asdfDir}/shims`);
+  const skip = core.getBooleanInput("skip_install", { required: true });
+  if (skip) {
+    return;
+  }
   core.info(`Cloning asdf into ASDF_DIR: ${asdfDir}`);
   const branch = core.getInput("asdf_branch", { required: true });
   await exec.exec("git", [

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "esbuild lib/install/main.ts lib/plugin-test/main.ts lib/plugins-add/main.ts lib/setup/main.ts --bundle --outdir=. --target=node12 --platform=node"
   },
   "dependencies": {
-    "@actions/core": "1.2.6",
+    "@actions/core": "1.3.0",
     "@actions/exec": "1.0.4",
     "@actions/github": "4.0.0",
     "@actions/io": "1.0.2"

--- a/plugin-test/action.yml
+++ b/plugin-test/action.yml
@@ -27,6 +27,10 @@ inputs:
     description: asdf branch to clone
     required: false
     default: master
+  skip_install:
+    description: setup env without installing asdf
+    required: false
+    default: false
   github_token:
     description: Token used to avoid rate limit when asdf calls the GitHub API
     required: false

--- a/plugin-test/main.js
+++ b/plugin-test/main.js
@@ -31,6 +31,7 @@ var __toModule = (module2) => {
 var require_utils = __commonJS((exports2) => {
   "use strict";
   Object.defineProperty(exports2, "__esModule", {value: true});
+  exports2.toCommandValue = void 0;
   function toCommandValue(input) {
     if (input === null || input === void 0) {
       return "";
@@ -45,19 +46,36 @@ var require_utils = __commonJS((exports2) => {
 // node_modules/@actions/core/lib/command.js
 var require_command = __commonJS((exports2) => {
   "use strict";
+  var __createBinding = exports2 && exports2.__createBinding || (Object.create ? function(o, m, k, k2) {
+    if (k2 === void 0)
+      k2 = k;
+    Object.defineProperty(o, k2, {enumerable: true, get: function() {
+      return m[k];
+    }});
+  } : function(o, m, k, k2) {
+    if (k2 === void 0)
+      k2 = k;
+    o[k2] = m[k];
+  });
+  var __setModuleDefault = exports2 && exports2.__setModuleDefault || (Object.create ? function(o, v) {
+    Object.defineProperty(o, "default", {enumerable: true, value: v});
+  } : function(o, v) {
+    o["default"] = v;
+  });
   var __importStar = exports2 && exports2.__importStar || function(mod) {
     if (mod && mod.__esModule)
       return mod;
     var result = {};
     if (mod != null) {
       for (var k in mod)
-        if (Object.hasOwnProperty.call(mod, k))
-          result[k] = mod[k];
+        if (k !== "default" && Object.hasOwnProperty.call(mod, k))
+          __createBinding(result, mod, k);
     }
-    result["default"] = mod;
+    __setModuleDefault(result, mod);
     return result;
   };
   Object.defineProperty(exports2, "__esModule", {value: true});
+  exports2.issue = exports2.issueCommand = void 0;
   var os2 = __importStar(require("os"));
   var utils_1 = require_utils();
   function issueCommand(command, properties, message) {
@@ -113,19 +131,36 @@ var require_command = __commonJS((exports2) => {
 // node_modules/@actions/core/lib/file-command.js
 var require_file_command = __commonJS((exports2) => {
   "use strict";
+  var __createBinding = exports2 && exports2.__createBinding || (Object.create ? function(o, m, k, k2) {
+    if (k2 === void 0)
+      k2 = k;
+    Object.defineProperty(o, k2, {enumerable: true, get: function() {
+      return m[k];
+    }});
+  } : function(o, m, k, k2) {
+    if (k2 === void 0)
+      k2 = k;
+    o[k2] = m[k];
+  });
+  var __setModuleDefault = exports2 && exports2.__setModuleDefault || (Object.create ? function(o, v) {
+    Object.defineProperty(o, "default", {enumerable: true, value: v});
+  } : function(o, v) {
+    o["default"] = v;
+  });
   var __importStar = exports2 && exports2.__importStar || function(mod) {
     if (mod && mod.__esModule)
       return mod;
     var result = {};
     if (mod != null) {
       for (var k in mod)
-        if (Object.hasOwnProperty.call(mod, k))
-          result[k] = mod[k];
+        if (k !== "default" && Object.hasOwnProperty.call(mod, k))
+          __createBinding(result, mod, k);
     }
-    result["default"] = mod;
+    __setModuleDefault(result, mod);
     return result;
   };
   Object.defineProperty(exports2, "__esModule", {value: true});
+  exports2.issueCommand = void 0;
   var fs = __importStar(require("fs"));
   var os2 = __importStar(require("os"));
   var utils_1 = require_utils();
@@ -147,6 +182,34 @@ var require_file_command = __commonJS((exports2) => {
 // node_modules/@actions/core/lib/core.js
 var require_core = __commonJS((exports2) => {
   "use strict";
+  var __createBinding = exports2 && exports2.__createBinding || (Object.create ? function(o, m, k, k2) {
+    if (k2 === void 0)
+      k2 = k;
+    Object.defineProperty(o, k2, {enumerable: true, get: function() {
+      return m[k];
+    }});
+  } : function(o, m, k, k2) {
+    if (k2 === void 0)
+      k2 = k;
+    o[k2] = m[k];
+  });
+  var __setModuleDefault = exports2 && exports2.__setModuleDefault || (Object.create ? function(o, v) {
+    Object.defineProperty(o, "default", {enumerable: true, value: v});
+  } : function(o, v) {
+    o["default"] = v;
+  });
+  var __importStar = exports2 && exports2.__importStar || function(mod) {
+    if (mod && mod.__esModule)
+      return mod;
+    var result = {};
+    if (mod != null) {
+      for (var k in mod)
+        if (k !== "default" && Object.hasOwnProperty.call(mod, k))
+          __createBinding(result, mod, k);
+    }
+    __setModuleDefault(result, mod);
+    return result;
+  };
   var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
     function adopt(value) {
       return value instanceof P ? value : new P(function(resolve) {
@@ -174,19 +237,8 @@ var require_core = __commonJS((exports2) => {
       step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
   };
-  var __importStar = exports2 && exports2.__importStar || function(mod) {
-    if (mod && mod.__esModule)
-      return mod;
-    var result = {};
-    if (mod != null) {
-      for (var k in mod)
-        if (Object.hasOwnProperty.call(mod, k))
-          result[k] = mod[k];
-    }
-    result["default"] = mod;
-    return result;
-  };
   Object.defineProperty(exports2, "__esModule", {value: true});
+  exports2.getState = exports2.saveState = exports2.group = exports2.endGroup = exports2.startGroup = exports2.info = exports2.warning = exports2.error = exports2.debug = exports2.isDebug = exports2.setFailed = exports2.setCommandEcho = exports2.setOutput = exports2.getBooleanInput = exports2.getInput = exports2.addPath = exports2.setSecret = exports2.exportVariable = exports2.ExitCode = void 0;
   var command_1 = require_command();
   var file_command_1 = require_file_command();
   var utils_1 = require_utils();
@@ -229,10 +281,26 @@ var require_core = __commonJS((exports2) => {
     if (options && options.required && !val) {
       throw new Error(`Input required and not supplied: ${name}`);
     }
+    if (options && options.trimWhitespace === false) {
+      return val;
+    }
     return val.trim();
   }
   exports2.getInput = getInput3;
+  function getBooleanInput2(name, options) {
+    const trueValue = ["true", "True", "TRUE"];
+    const falseValue = ["false", "False", "FALSE"];
+    const val = getInput3(name, options);
+    if (trueValue.includes(val))
+      return true;
+    if (falseValue.includes(val))
+      return false;
+    throw new TypeError(`Input does not meet YAML 1.2 "Core Schema" specification: ${name}
+Support boolean input list: \`true | True | TRUE | false | False | FALSE\``);
+  }
+  exports2.getBooleanInput = getBooleanInput2;
   function setOutput(name, value) {
+    process.stdout.write(os2.EOL);
     command_1.issueCommand("set-output", {name}, value);
   }
   exports2.setOutput = setOutput;
@@ -1234,6 +1302,10 @@ async function setupAsdf() {
   core.exportVariable("ASDF_DATA_DIR", asdfDir);
   core.addPath(`${asdfDir}/bin`);
   core.addPath(`${asdfDir}/shims`);
+  const skip = core.getBooleanInput("skip_install", {required: true});
+  if (skip) {
+    return;
+  }
   core.info(`Cloning asdf into ASDF_DIR: ${asdfDir}`);
   const branch = core.getInput("asdf_branch", {required: true});
   await exec.exec("git", [

--- a/plugins-add/action.yml
+++ b/plugins-add/action.yml
@@ -9,6 +9,10 @@ inputs:
     description: asdf branch to clone
     required: false
     default: master
+  skip_install:
+    description: setup env without installing asdf
+    required: false
+    default: false
   tool_versions:
     description:
       If present, this value will be written to the .tool-versions file.

--- a/plugins-add/main.js
+++ b/plugins-add/main.js
@@ -31,6 +31,7 @@ var __toModule = (module2) => {
 var require_utils = __commonJS((exports2) => {
   "use strict";
   Object.defineProperty(exports2, "__esModule", {value: true});
+  exports2.toCommandValue = void 0;
   function toCommandValue(input) {
     if (input === null || input === void 0) {
       return "";
@@ -45,19 +46,36 @@ var require_utils = __commonJS((exports2) => {
 // node_modules/@actions/core/lib/command.js
 var require_command = __commonJS((exports2) => {
   "use strict";
+  var __createBinding = exports2 && exports2.__createBinding || (Object.create ? function(o, m, k, k2) {
+    if (k2 === void 0)
+      k2 = k;
+    Object.defineProperty(o, k2, {enumerable: true, get: function() {
+      return m[k];
+    }});
+  } : function(o, m, k, k2) {
+    if (k2 === void 0)
+      k2 = k;
+    o[k2] = m[k];
+  });
+  var __setModuleDefault = exports2 && exports2.__setModuleDefault || (Object.create ? function(o, v) {
+    Object.defineProperty(o, "default", {enumerable: true, value: v});
+  } : function(o, v) {
+    o["default"] = v;
+  });
   var __importStar = exports2 && exports2.__importStar || function(mod) {
     if (mod && mod.__esModule)
       return mod;
     var result = {};
     if (mod != null) {
       for (var k in mod)
-        if (Object.hasOwnProperty.call(mod, k))
-          result[k] = mod[k];
+        if (k !== "default" && Object.hasOwnProperty.call(mod, k))
+          __createBinding(result, mod, k);
     }
-    result["default"] = mod;
+    __setModuleDefault(result, mod);
     return result;
   };
   Object.defineProperty(exports2, "__esModule", {value: true});
+  exports2.issue = exports2.issueCommand = void 0;
   var os2 = __importStar(require("os"));
   var utils_1 = require_utils();
   function issueCommand(command, properties, message) {
@@ -113,19 +131,36 @@ var require_command = __commonJS((exports2) => {
 // node_modules/@actions/core/lib/file-command.js
 var require_file_command = __commonJS((exports2) => {
   "use strict";
+  var __createBinding = exports2 && exports2.__createBinding || (Object.create ? function(o, m, k, k2) {
+    if (k2 === void 0)
+      k2 = k;
+    Object.defineProperty(o, k2, {enumerable: true, get: function() {
+      return m[k];
+    }});
+  } : function(o, m, k, k2) {
+    if (k2 === void 0)
+      k2 = k;
+    o[k2] = m[k];
+  });
+  var __setModuleDefault = exports2 && exports2.__setModuleDefault || (Object.create ? function(o, v) {
+    Object.defineProperty(o, "default", {enumerable: true, value: v});
+  } : function(o, v) {
+    o["default"] = v;
+  });
   var __importStar = exports2 && exports2.__importStar || function(mod) {
     if (mod && mod.__esModule)
       return mod;
     var result = {};
     if (mod != null) {
       for (var k in mod)
-        if (Object.hasOwnProperty.call(mod, k))
-          result[k] = mod[k];
+        if (k !== "default" && Object.hasOwnProperty.call(mod, k))
+          __createBinding(result, mod, k);
     }
-    result["default"] = mod;
+    __setModuleDefault(result, mod);
     return result;
   };
   Object.defineProperty(exports2, "__esModule", {value: true});
+  exports2.issueCommand = void 0;
   var fs2 = __importStar(require("fs"));
   var os2 = __importStar(require("os"));
   var utils_1 = require_utils();
@@ -147,6 +182,34 @@ var require_file_command = __commonJS((exports2) => {
 // node_modules/@actions/core/lib/core.js
 var require_core = __commonJS((exports2) => {
   "use strict";
+  var __createBinding = exports2 && exports2.__createBinding || (Object.create ? function(o, m, k, k2) {
+    if (k2 === void 0)
+      k2 = k;
+    Object.defineProperty(o, k2, {enumerable: true, get: function() {
+      return m[k];
+    }});
+  } : function(o, m, k, k2) {
+    if (k2 === void 0)
+      k2 = k;
+    o[k2] = m[k];
+  });
+  var __setModuleDefault = exports2 && exports2.__setModuleDefault || (Object.create ? function(o, v) {
+    Object.defineProperty(o, "default", {enumerable: true, value: v});
+  } : function(o, v) {
+    o["default"] = v;
+  });
+  var __importStar = exports2 && exports2.__importStar || function(mod) {
+    if (mod && mod.__esModule)
+      return mod;
+    var result = {};
+    if (mod != null) {
+      for (var k in mod)
+        if (k !== "default" && Object.hasOwnProperty.call(mod, k))
+          __createBinding(result, mod, k);
+    }
+    __setModuleDefault(result, mod);
+    return result;
+  };
   var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
     function adopt(value) {
       return value instanceof P ? value : new P(function(resolve) {
@@ -174,19 +237,8 @@ var require_core = __commonJS((exports2) => {
       step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
   };
-  var __importStar = exports2 && exports2.__importStar || function(mod) {
-    if (mod && mod.__esModule)
-      return mod;
-    var result = {};
-    if (mod != null) {
-      for (var k in mod)
-        if (Object.hasOwnProperty.call(mod, k))
-          result[k] = mod[k];
-    }
-    result["default"] = mod;
-    return result;
-  };
   Object.defineProperty(exports2, "__esModule", {value: true});
+  exports2.getState = exports2.saveState = exports2.group = exports2.endGroup = exports2.startGroup = exports2.info = exports2.warning = exports2.error = exports2.debug = exports2.isDebug = exports2.setFailed = exports2.setCommandEcho = exports2.setOutput = exports2.getBooleanInput = exports2.getInput = exports2.addPath = exports2.setSecret = exports2.exportVariable = exports2.ExitCode = void 0;
   var command_1 = require_command();
   var file_command_1 = require_file_command();
   var utils_1 = require_utils();
@@ -229,10 +281,26 @@ var require_core = __commonJS((exports2) => {
     if (options && options.required && !val) {
       throw new Error(`Input required and not supplied: ${name}`);
     }
+    if (options && options.trimWhitespace === false) {
+      return val;
+    }
     return val.trim();
   }
   exports2.getInput = getInput3;
+  function getBooleanInput2(name, options) {
+    const trueValue = ["true", "True", "TRUE"];
+    const falseValue = ["false", "False", "FALSE"];
+    const val = getInput3(name, options);
+    if (trueValue.includes(val))
+      return true;
+    if (falseValue.includes(val))
+      return false;
+    throw new TypeError(`Input does not meet YAML 1.2 "Core Schema" specification: ${name}
+Support boolean input list: \`true | True | TRUE | false | False | FALSE\``);
+  }
+  exports2.getBooleanInput = getBooleanInput2;
   function setOutput(name, value) {
+    process.stdout.write(os2.EOL);
     command_1.issueCommand("set-output", {name}, value);
   }
   exports2.setOutput = setOutput;
@@ -1235,6 +1303,10 @@ async function setupAsdf() {
   core.exportVariable("ASDF_DATA_DIR", asdfDir);
   core.addPath(`${asdfDir}/bin`);
   core.addPath(`${asdfDir}/shims`);
+  const skip = core.getBooleanInput("skip_install", {required: true});
+  if (skip) {
+    return;
+  }
   core.info(`Cloning asdf into ASDF_DIR: ${asdfDir}`);
   const branch = core.getInput("asdf_branch", {required: true});
   await exec.exec("git", [

--- a/setup/action.yml
+++ b/setup/action.yml
@@ -9,3 +9,7 @@ inputs:
     description: asdf branch to clone
     required: false
     default: master
+  skip_install:
+    description: setup env without installing asdf
+    required: false
+    default: false

--- a/setup/main.js
+++ b/setup/main.js
@@ -31,6 +31,7 @@ var __toModule = (module2) => {
 var require_utils = __commonJS((exports2) => {
   "use strict";
   Object.defineProperty(exports2, "__esModule", {value: true});
+  exports2.toCommandValue = void 0;
   function toCommandValue(input) {
     if (input === null || input === void 0) {
       return "";
@@ -45,19 +46,36 @@ var require_utils = __commonJS((exports2) => {
 // node_modules/@actions/core/lib/command.js
 var require_command = __commonJS((exports2) => {
   "use strict";
+  var __createBinding = exports2 && exports2.__createBinding || (Object.create ? function(o, m, k, k2) {
+    if (k2 === void 0)
+      k2 = k;
+    Object.defineProperty(o, k2, {enumerable: true, get: function() {
+      return m[k];
+    }});
+  } : function(o, m, k, k2) {
+    if (k2 === void 0)
+      k2 = k;
+    o[k2] = m[k];
+  });
+  var __setModuleDefault = exports2 && exports2.__setModuleDefault || (Object.create ? function(o, v) {
+    Object.defineProperty(o, "default", {enumerable: true, value: v});
+  } : function(o, v) {
+    o["default"] = v;
+  });
   var __importStar = exports2 && exports2.__importStar || function(mod) {
     if (mod && mod.__esModule)
       return mod;
     var result = {};
     if (mod != null) {
       for (var k in mod)
-        if (Object.hasOwnProperty.call(mod, k))
-          result[k] = mod[k];
+        if (k !== "default" && Object.hasOwnProperty.call(mod, k))
+          __createBinding(result, mod, k);
     }
-    result["default"] = mod;
+    __setModuleDefault(result, mod);
     return result;
   };
   Object.defineProperty(exports2, "__esModule", {value: true});
+  exports2.issue = exports2.issueCommand = void 0;
   var os2 = __importStar(require("os"));
   var utils_1 = require_utils();
   function issueCommand(command, properties, message) {
@@ -113,19 +131,36 @@ var require_command = __commonJS((exports2) => {
 // node_modules/@actions/core/lib/file-command.js
 var require_file_command = __commonJS((exports2) => {
   "use strict";
+  var __createBinding = exports2 && exports2.__createBinding || (Object.create ? function(o, m, k, k2) {
+    if (k2 === void 0)
+      k2 = k;
+    Object.defineProperty(o, k2, {enumerable: true, get: function() {
+      return m[k];
+    }});
+  } : function(o, m, k, k2) {
+    if (k2 === void 0)
+      k2 = k;
+    o[k2] = m[k];
+  });
+  var __setModuleDefault = exports2 && exports2.__setModuleDefault || (Object.create ? function(o, v) {
+    Object.defineProperty(o, "default", {enumerable: true, value: v});
+  } : function(o, v) {
+    o["default"] = v;
+  });
   var __importStar = exports2 && exports2.__importStar || function(mod) {
     if (mod && mod.__esModule)
       return mod;
     var result = {};
     if (mod != null) {
       for (var k in mod)
-        if (Object.hasOwnProperty.call(mod, k))
-          result[k] = mod[k];
+        if (k !== "default" && Object.hasOwnProperty.call(mod, k))
+          __createBinding(result, mod, k);
     }
-    result["default"] = mod;
+    __setModuleDefault(result, mod);
     return result;
   };
   Object.defineProperty(exports2, "__esModule", {value: true});
+  exports2.issueCommand = void 0;
   var fs = __importStar(require("fs"));
   var os2 = __importStar(require("os"));
   var utils_1 = require_utils();
@@ -147,6 +182,34 @@ var require_file_command = __commonJS((exports2) => {
 // node_modules/@actions/core/lib/core.js
 var require_core = __commonJS((exports2) => {
   "use strict";
+  var __createBinding = exports2 && exports2.__createBinding || (Object.create ? function(o, m, k, k2) {
+    if (k2 === void 0)
+      k2 = k;
+    Object.defineProperty(o, k2, {enumerable: true, get: function() {
+      return m[k];
+    }});
+  } : function(o, m, k, k2) {
+    if (k2 === void 0)
+      k2 = k;
+    o[k2] = m[k];
+  });
+  var __setModuleDefault = exports2 && exports2.__setModuleDefault || (Object.create ? function(o, v) {
+    Object.defineProperty(o, "default", {enumerable: true, value: v});
+  } : function(o, v) {
+    o["default"] = v;
+  });
+  var __importStar = exports2 && exports2.__importStar || function(mod) {
+    if (mod && mod.__esModule)
+      return mod;
+    var result = {};
+    if (mod != null) {
+      for (var k in mod)
+        if (k !== "default" && Object.hasOwnProperty.call(mod, k))
+          __createBinding(result, mod, k);
+    }
+    __setModuleDefault(result, mod);
+    return result;
+  };
   var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
     function adopt(value) {
       return value instanceof P ? value : new P(function(resolve) {
@@ -174,19 +237,8 @@ var require_core = __commonJS((exports2) => {
       step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
   };
-  var __importStar = exports2 && exports2.__importStar || function(mod) {
-    if (mod && mod.__esModule)
-      return mod;
-    var result = {};
-    if (mod != null) {
-      for (var k in mod)
-        if (Object.hasOwnProperty.call(mod, k))
-          result[k] = mod[k];
-    }
-    result["default"] = mod;
-    return result;
-  };
   Object.defineProperty(exports2, "__esModule", {value: true});
+  exports2.getState = exports2.saveState = exports2.group = exports2.endGroup = exports2.startGroup = exports2.info = exports2.warning = exports2.error = exports2.debug = exports2.isDebug = exports2.setFailed = exports2.setCommandEcho = exports2.setOutput = exports2.getBooleanInput = exports2.getInput = exports2.addPath = exports2.setSecret = exports2.exportVariable = exports2.ExitCode = void 0;
   var command_1 = require_command();
   var file_command_1 = require_file_command();
   var utils_1 = require_utils();
@@ -229,10 +281,26 @@ var require_core = __commonJS((exports2) => {
     if (options && options.required && !val) {
       throw new Error(`Input required and not supplied: ${name}`);
     }
+    if (options && options.trimWhitespace === false) {
+      return val;
+    }
     return val.trim();
   }
   exports2.getInput = getInput2;
+  function getBooleanInput2(name, options) {
+    const trueValue = ["true", "True", "TRUE"];
+    const falseValue = ["false", "False", "FALSE"];
+    const val = getInput2(name, options);
+    if (trueValue.includes(val))
+      return true;
+    if (falseValue.includes(val))
+      return false;
+    throw new TypeError(`Input does not meet YAML 1.2 "Core Schema" specification: ${name}
+Support boolean input list: \`true | True | TRUE | false | False | FALSE\``);
+  }
+  exports2.getBooleanInput = getBooleanInput2;
   function setOutput(name, value) {
+    process.stdout.write(os2.EOL);
     command_1.issueCommand("set-output", {name}, value);
   }
   exports2.setOutput = setOutput;
@@ -1230,6 +1298,10 @@ async function setupAsdf() {
   core.exportVariable("ASDF_DATA_DIR", asdfDir);
   core.addPath(`${asdfDir}/bin`);
   core.addPath(`${asdfDir}/shims`);
+  const skip = core.getBooleanInput("skip_install", {required: true});
+  if (skip) {
+    return;
+  }
   core.info(`Cloning asdf into ASDF_DIR: ${asdfDir}`);
   const branch = core.getInput("asdf_branch", {required: true});
   await exec.exec("git", [

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@actions/core@1.2.6":
-  version "1.2.6"
-  resolved "https://registry.yarnpkg.com/@actions/core/-/core-1.2.6.tgz#a78d49f41a4def18e88ce47c2cac615d5694bf09"
-  integrity sha512-ZQYitnqiyBc3D+k7LsgSBmMDVkOVidaagDG7j3fOym77jNunWRuYx7VSHa9GNfFZh+zh61xsCjRj4JxMZlDqTA==
+"@actions/core@1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@actions/core/-/core-1.3.0.tgz#f5e4b24c889e7f2e58b466cc8c7481292284eba0"
+  integrity sha512-xxtX0Cwdhb8LcgatfJkokqT8KzPvcIbwL9xpLU09nOwBzaStbfm0dNncsP0M4us+EpoPdWy7vbzU5vSOH7K6pg==
 
 "@actions/exec@1.0.4":
   version "1.0.4"


### PR DESCRIPTION
If we run this action on a self-hosted runner, It fails because asdf has already been installed on this machine.
﻿﻿It's git that can't clone the repository to be precise: `fatal: destination path '.asdf' already exists and is not an empty directory.`

This PR adds the possibility to skip the installation of asdf using the `skip_install` boolean input which allows to setup the env correctly (PATH, etc.) without failing at the time of the git clone.

Signed-off-by: aeddi <antoine.e.b@gmail.com>