### PR TITLE
chore: list jthegedus as repo CODEOWNER

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owners for all the code in this repo
+* @jthegedus


### PR DESCRIPTION
We haven't really had any asdf core members actively contributing (updating, maintenance etc) to this repository. I have decided to be responsible for it and have added myself as CODEOWNER so PR creators will know who to tag as the GitHub UI will suggest myself.