### PR TITLE
docs: fix example workflow running twice for PR commit pushes

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,15 @@ name: Main workflow
 
 on:
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
     paths-ignore:
       - "**.md"
   push:
+    branches:
+      - main
     paths-ignore:
       - "**.md"
   schedule:


### PR DESCRIPTION
I noticed this issue on a couple projects - the checks would run twice when a commit was pushed to an already opened PR.

With the changes here the workflow is triggered for PR updates (e.g. a PR opened or new commit pushed) OR when a new commit is pushed to the `main` branch. Restricting pushes to the main branch ensures checks only run once per PR commit.