### PR TITLE
ci: tag new `vX` major versions on semver releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,3 +19,15 @@ jobs:
           release-type: node
           extra-files: |
             README.md
+      - uses: actions/checkout@v2
+      # if there was a release, move the git tag for the major version to the same SHA as the new GitHub Release
+      - name: tag major version
+        if: ${{ steps.release.outputs.release_created }}
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git remote add gh-token "https://${{ secrets.GITHUB_TOKEN }}@github.com/google-github-actions/release-please-action.git"
+          git tag --delete v${{ steps.release.outputs.major }} || true
+          git push origin :v${{ steps.release.outputs.major }} || true
+          git tag --annotate v${{ steps.release.outputs.major }} --message "Release v${{ steps.release.outputs.major }}"
+          git push origin v${{ steps.release.outputs.major }}

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,4 @@ install/*.js
 plugin-test/*.js
 plugins-add/*.js
 setup/*.js
+CHANGELOG.md


### PR DESCRIPTION
- [x] tag new major versions `vX` on each semver release `vX.Y.Z`.
  - when version `v3.0.0` is released, tag the same SHA as `v3`
  - when version `v3.1.0` is released, delete the `v3` tag, and tag the `v3.1.0` SHA with `v3`, keeping `v3` synced to the latest semver for that major version
- [x] skip formatting `CHANGELOG.md` as it will be auto-generated