### PR TITLE
chore: use lefthook to run pre-push & pre-commit hooks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,14 +18,8 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-
-      - name: Use Node.js 16.x
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16.x
-
+      - uses: actions/checkout@v3
+      - uses: asdf-vm/actions/install@v2.0.0
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "dir=$(yarn cache dir)" >> "$GITHUB_OUTPUT"
@@ -36,10 +30,8 @@ jobs:
           key: v1-${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
           restore-keys: |
             v1-${{ runner.os }}-yarn-
-
       - name: Install npm packages
         run: yarn --frozen-lockfile
-
       - name: Ensure out directories are up-to-date
         if: runner.os == 'Linux'
         shell: bash

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,3 @@
 nodejs 16.19.1
 yarn 1.22.19
+lefthook 1.3.4

--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -1,0 +1,15 @@
+pre-push:
+  commands:
+    lint:
+      run: yarn run lint
+    format:
+      run: yarn fmt:check
+
+pre-commit:
+  commands:
+    format:
+      run: yarn run fmt
+    build:
+      run: yarn run build
+    typecheck:
+      run: yarn run typecheck

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "author": "Victor Borja <vborja@apache.org>",
   "license": "Apache-2.0",
   "scripts": {
+    "prepare": "lefthook install",
     "fmt": "prettier --write .",
     "fmt:check": "prettier --check .",
     "typecheck": "tsc",


### PR DESCRIPTION
Introduce https://github.com/evilmartians/lefthook to run format, build, lint etc on pre-push and pre-commit git events.

Closes #526 