### PR TITLE
ci: use asdf actions in workflows

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -11,9 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 16.x
+      - uses: asdf-vm/actions/install@v2.0.0
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "dir=$(yarn cache dir)" >> "$GITHUB_OUTPUT"
@@ -26,9 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 16.x
+      - uses: asdf-vm/actions/install@v2.0.0
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "dir=$(yarn cache dir)" >> "$GITHUB_OUTPUT"
@@ -41,9 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 16.x
+      - uses: asdf-vm/actions/install@v2.0.0
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "dir=$(yarn cache dir)" >> "$GITHUB_OUTPUT"
@@ -55,10 +49,8 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-
-      - name: Check workflow files
+      - uses: actions/checkout@v3
+      - name: Lint GitHub Actions Workflow files
         uses: docker://rhysd/actionlint:1.6.23
         with:
           args: -color


### PR DESCRIPTION
Use `asdf/actions/install` in CI to use the same `asdf` version from `.tool-versions` and to not fail the `yarn install` steps which require `lefthook` as we install it in `package.json:scripts.prepare`.