### PR TITLE
ci: group npm Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,7 @@ updates:
       interval: "monthly"
     reviewers:
       - "jthegedus"
+    groups:
+      npm:
+        patterns:
+          - "*"


### PR DESCRIPTION
Group Dependabot PRs together so that deps updates happen in a single PR.