### PR TITLE
docs: Encourage to use v3 by updating examples in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ workflows.
 
 | Action        | Use                              | Description                                                                                                                          |
 | :------------ | :------------------------------- | :----------------------------------------------------------------------------------------------------------------------------------- |
-| `install`     | `asdf-vm/actions/install@v2`     | Installs `asdf` & tools in `.tool-versions`.<br>Plugins fetched from [asdf-vm/asdf-plugins](https://github.com/asdf-vm/asdf-plugins) |
-| `setup`       | `asdf-vm/actions/setup@v2`       | Only install `asdf` CLI.                                                                                                             |
-| `plugins-add` | `asdf-vm/actions/plugins-add@v2` | Only install plugins, not tools.                                                                                                     |
-| `plugin-test` | `asdf-vm/actions/plugin-test@v2` | Plugin author test automation.                                                                                                       |
+| `install`     | `asdf-vm/actions/install@v3`     | Installs `asdf` & tools in `.tool-versions`.<br>Plugins fetched from [asdf-vm/asdf-plugins](https://github.com/asdf-vm/asdf-plugins) |
+| `setup`       | `asdf-vm/actions/setup@v3`       | Only install `asdf` CLI.                                                                                                             |
+| `plugins-add` | `asdf-vm/actions/plugins-add@v3` | Only install plugins, not tools.                                                                                                     |
+| `plugin-test` | `asdf-vm/actions/plugin-test@v3` | Plugin author test automation.                                                                                                       |
 
 <!-- TOC -->
 * [Usage](#usage)
@@ -34,7 +34,7 @@ workflows.
 ```yaml
 steps:
   - name: Install asdf & tools
-    uses: asdf-vm/actions/install@v2
+    uses: asdf-vm/actions/install@v3
 ```
 
 To avoid breaking changes, use the full [Semantic Version](https://semver.org/)
@@ -45,9 +45,9 @@ steps:
   # Reference a specific commit (most strict, for the supply-chain paranoid)
   - uses: asdf-vm/actions/install@2368b9d
   # Reference a semver major version only (GitHub recommended)
-  - uses: asdf-vm/actions/install@v2
+  - uses: asdf-vm/actions/install@v3
   # Reference a semver version of a release (recommended)
-  - uses: asdf-vm/actions/install@v2.2.0
+  - uses: asdf-vm/actions/install@v3.0.2
   # Reference a branch (most dangerous)
   - uses: asdf-vm/actions/install@master
 ```
@@ -76,7 +76,7 @@ Installs `asdf` & tools in `.tool-versions`. Plugins fetched from
 
 ```yaml
 steps:
-  - uses: asdf-vm/actions/install@v2
+  - uses: asdf-vm/actions/install@v3
 ```
 
 <!-- TODO(jthegedus): capture action.yml options in a markdown table here. Show usage examples for each option. -->
@@ -89,7 +89,7 @@ Plugin author test automation
 
 ```yaml
 steps:
-  - uses: asdf-vm/actions/plugin-test@v2
+  - uses: asdf-vm/actions/plugin-test@v3
     with:
       command: my_tool --version
 ```
@@ -107,7 +107,7 @@ Only install `asdf` CLI.
 
 ```yaml
 steps:
-  - uses: asdf-vm/actions/setup@v2
+  - uses: asdf-vm/actions/setup@v3
 ```
 
 <!-- TODO(jthegedus): capture action.yml options in a markdown table here. Show usage examples for each option. -->
@@ -123,7 +123,7 @@ Only install plugins, not tools.
 
 ```yaml
 steps:
-  - uses: asdf-vm/actions/plugins-add@v2
+  - uses: asdf-vm/actions/plugins-add@v3
 ```
 
 <!-- TODO(jthegedus): capture action.yml options in a markdown table here. Show usage examples for each option. -->
@@ -135,7 +135,7 @@ See [action.yml](plugins-add/action.yml) inputs.
 ### Full Example Workflow
 
 This example workflow demonstrates how to use the Install Action:
-`asdf-vm/actions/install@v2`. It is taken from the
+`asdf-vm/actions/install@v3`. It is taken from the
 [asdf-vm/asdf-plugin-template](https://github.com/asdf-vm/asdf-plugin-template)
 repository.
 
@@ -160,7 +160,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: asdf-vm/actions/install@v2
+      - uses: asdf-vm/actions/install@v3
       - run: scripts/lint.bash
       # script runs Shellcheck, Shfmt etc installed by previous action
 
@@ -197,7 +197,7 @@ jobs:
       image: ${{ matrix.container }}
 
     steps:
-      - uses: asdf-vm/actions/plugin-test@v2
+      - uses: asdf-vm/actions/plugin-test@v3
         with:
           command: my_tool --version
 ```


### PR DESCRIPTION
There is a discrepancy between the latest released version and the examples in readme. I bet it makes both users and maintainers feel comfortable if a newer version gets used more often and I thought the documentation is where we should encourage it at first. What do you think?