### PR TITLE
fix: remove "origin" argument from git checkout command

### DIFF
--- a/install/main.js
+++ b/install/main.js
@@ -3296,7 +3296,7 @@ async function setupAsdf() {
     const options = { cwd: asdfDir };
     await exec.exec("git", ["remote", "set-branches", "origin", branch], options);
     await exec.exec("git", ["fetch", "--depth", "1", "origin", branch], options);
-    await exec.exec("git", ["checkout", "-B", branch, "origin"], options);
+    await exec.exec("git", ["checkout", "-B", branch], options);
   } else {
     core.info(`Cloning asdf into ASDF_DIR "${asdfDir}" on branch "${branch}"`);
     await exec.exec("git", [

--- a/plugin-test/main.js
+++ b/plugin-test/main.js
@@ -3292,7 +3292,7 @@ async function setupAsdf() {
     const options = { cwd: asdfDir };
     await exec.exec("git", ["remote", "set-branches", "origin", branch], options);
     await exec.exec("git", ["fetch", "--depth", "1", "origin", branch], options);
-    await exec.exec("git", ["checkout", "-B", branch, "origin"], options);
+    await exec.exec("git", ["checkout", "-B", branch], options);
   } else {
     core.info(`Cloning asdf into ASDF_DIR "${asdfDir}" on branch "${branch}"`);
     await exec.exec("git", [

--- a/plugins-add/main.js
+++ b/plugins-add/main.js
@@ -3292,7 +3292,7 @@ async function setupAsdf() {
     const options = { cwd: asdfDir };
     await exec.exec("git", ["remote", "set-branches", "origin", branch], options);
     await exec.exec("git", ["fetch", "--depth", "1", "origin", branch], options);
-    await exec.exec("git", ["checkout", "-B", branch, "origin"], options);
+    await exec.exec("git", ["checkout", "-B", branch], options);
   } else {
     core.info(`Cloning asdf into ASDF_DIR "${asdfDir}" on branch "${branch}"`);
     await exec.exec("git", [

--- a/setup/main.js
+++ b/setup/main.js
@@ -3287,7 +3287,7 @@ async function setupAsdf() {
     const options = { cwd: asdfDir };
     await exec.exec("git", ["remote", "set-branches", "origin", branch], options);
     await exec.exec("git", ["fetch", "--depth", "1", "origin", branch], options);
-    await exec.exec("git", ["checkout", "-B", branch, "origin"], options);
+    await exec.exec("git", ["checkout", "-B", branch], options);
   } else {
     core.info(`Cloning asdf into ASDF_DIR "${asdfDir}" on branch "${branch}"`);
     await exec.exec("git", [

--- a/src/setup/index.ts
+++ b/src/setup/index.ts
@@ -28,7 +28,7 @@ async function setupAsdf(): Promise<void> {
 		const options = {cwd: asdfDir};
 		await exec.exec('git', ['remote', 'set-branches', 'origin', branch], options);
 		await exec.exec('git', ['fetch', '--depth', '1', 'origin', branch], options);
-		await exec.exec('git', ['checkout', '-B', branch, 'origin'], options);
+		await exec.exec('git', ['checkout', '-B', branch], options);
 	} else {
 		core.info(`Cloning asdf into ASDF_DIR "${asdfDir}" on branch "${branch}"`);
 		await exec.exec('git', [


### PR DESCRIPTION
Hi,

We had a problem using the install action when the `~/.asdf` dir is restored from cache.

This is the error we got:

```
fatal: 'origin' is not a commit and a branch 'v0.15.0' cannot be created from it
```

From checking git's man page I cloud not understand why the "origin" argument was there to begin with.
I tested this branch in our repos and it's working now properly.

I'll appreciate your help in merging this 🙏 