### PR TITLE
fix: Add `--retry 5` to `asdf` download

### DIFF
--- a/install/main.js
+++ b/install/main.js
@@ -21233,6 +21233,8 @@ async function setupAsdf() {
     const downloadPath = path.join(os.tmpdir(), releaseToDownload.name);
     const extractPath = path.join(asdfDir, "bin");
     await exec.exec("curl", [
+      "--retry",
+      "5",
       "-sSL",
       "-o",
       downloadPath,

--- a/plugin-test/main.js
+++ b/plugin-test/main.js
@@ -21229,6 +21229,8 @@ async function setupAsdf() {
     const downloadPath = path.join(os.tmpdir(), releaseToDownload.name);
     const extractPath = path.join(asdfDir, "bin");
     await exec.exec("curl", [
+      "--retry",
+      "5",
       "-sSL",
       "-o",
       downloadPath,

--- a/plugins-add/main.js
+++ b/plugins-add/main.js
@@ -21229,6 +21229,8 @@ async function setupAsdf() {
     const downloadPath = path.join(os.tmpdir(), releaseToDownload.name);
     const extractPath = path.join(asdfDir, "bin");
     await exec.exec("curl", [
+      "--retry",
+      "5",
       "-sSL",
       "-o",
       downloadPath,

--- a/setup/main.js
+++ b/setup/main.js
@@ -21224,6 +21224,8 @@ async function setupAsdf() {
     const downloadPath = path.join(os.tmpdir(), releaseToDownload.name);
     const extractPath = path.join(asdfDir, "bin");
     await exec.exec("curl", [
+      "--retry",
+      "5",
       "-sSL",
       "-o",
       downloadPath,

--- a/src/setup/index.ts
+++ b/src/setup/index.ts
@@ -110,6 +110,8 @@ async function setupAsdf(): Promise<void> {
     const downloadPath = path.join(os.tmpdir(), releaseToDownload.name);
     const extractPath = path.join(asdfDir, "bin");
     await exec.exec("curl", [
+      "--retry",
+      "5",
       "-sSL",
       "-o",
       downloadPath,


### PR DESCRIPTION
Sometimes GitHub can be having a bad time. `curl` implements a default exponential backoff retry, which should help mitigate any partial failures that GitHub might experience and allow builds to continue.