### PR TITLE
fix: exit non-zero when the asdf download fails

### DIFF
--- a/install/main.js
+++ b/install/main.js
@@ -21233,6 +21233,8 @@ async function setupAsdf() {
     const downloadPath = path.join(os.tmpdir(), releaseToDownload.name);
     const extractPath = path.join(asdfDir, "bin");
     await exec.exec("curl", [
+      "--retry",
+      "5",
       "-sSL",
       "-o",
       downloadPath,

--- a/install/main.js
+++ b/install/main.js
@@ -21235,7 +21235,8 @@ async function setupAsdf() {
     await exec.exec("curl", [
       "--retry",
       "5",
-      "-sSL",
+      "--retry-all-errors",
+      "-fsSL",
       "-o",
       downloadPath,
       releaseToDownload.browser_download_url

--- a/plugin-test/main.js
+++ b/plugin-test/main.js
@@ -21229,6 +21229,8 @@ async function setupAsdf() {
     const downloadPath = path.join(os.tmpdir(), releaseToDownload.name);
     const extractPath = path.join(asdfDir, "bin");
     await exec.exec("curl", [
+      "--retry",
+      "5",
       "-sSL",
       "-o",
       downloadPath,

--- a/plugin-test/main.js
+++ b/plugin-test/main.js
@@ -21231,7 +21231,8 @@ async function setupAsdf() {
     await exec.exec("curl", [
       "--retry",
       "5",
-      "-sSL",
+      "--retry-all-errors",
+      "-fsSL",
       "-o",
       downloadPath,
       releaseToDownload.browser_download_url

--- a/plugins-add/main.js
+++ b/plugins-add/main.js
@@ -21229,6 +21229,8 @@ async function setupAsdf() {
     const downloadPath = path.join(os.tmpdir(), releaseToDownload.name);
     const extractPath = path.join(asdfDir, "bin");
     await exec.exec("curl", [
+      "--retry",
+      "5",
       "-sSL",
       "-o",
       downloadPath,

--- a/plugins-add/main.js
+++ b/plugins-add/main.js
@@ -21231,7 +21231,8 @@ async function setupAsdf() {
     await exec.exec("curl", [
       "--retry",
       "5",
-      "-sSL",
+      "--retry-all-errors",
+      "-fsSL",
       "-o",
       downloadPath,
       releaseToDownload.browser_download_url

--- a/setup/main.js
+++ b/setup/main.js
@@ -21226,7 +21226,8 @@ async function setupAsdf() {
     await exec.exec("curl", [
       "--retry",
       "5",
-      "-sSL",
+      "--retry-all-errors",
+      "-fsSL",
       "-o",
       downloadPath,
       releaseToDownload.browser_download_url

--- a/setup/main.js
+++ b/setup/main.js
@@ -21224,6 +21224,8 @@ async function setupAsdf() {
     const downloadPath = path.join(os.tmpdir(), releaseToDownload.name);
     const extractPath = path.join(asdfDir, "bin");
     await exec.exec("curl", [
+      "--retry",
+      "5",
       "-sSL",
       "-o",
       downloadPath,

--- a/src/setup/index.ts
+++ b/src/setup/index.ts
@@ -112,7 +112,8 @@ async function setupAsdf(): Promise<void> {
     await exec.exec("curl", [
       "--retry",
       "5",
-      "-sSL",
+      "--retry-all-errors",
+      "-fsSL",
       "-o",
       downloadPath,
       releaseToDownload.browser_download_url,

--- a/src/setup/index.ts
+++ b/src/setup/index.ts
@@ -110,6 +110,8 @@ async function setupAsdf(): Promise<void> {
     const downloadPath = path.join(os.tmpdir(), releaseToDownload.name);
     const extractPath = path.join(asdfDir, "bin");
     await exec.exec("curl", [
+      "--retry",
+      "5",
       "-sSL",
       "-o",
       downloadPath,


### PR DESCRIPTION
Fixes #622.

`curl` ran without `--fail`, so an HTTP error exited 0 and the response body got written to `downloadPath`. `tar` then failed on it with `not in gzip format`, one step after the download had already reported success.

Reproduced against a missing release asset:

```
$ curl -sSL -o out.tar.gz <404 url>
exit=0, out.tar.gz contains "Not Found"

$ curl -fsSL --retry 5 --retry-all-errors -o out.tar.gz <404 url>
exit=56, no file written
```

The first commit here is @CGA1123's from #608, cherry-picked unchanged. `--retry 5` helps but doesn't close the hole on its own: a non-transient status isn't retried, and once retries run out curl still exits 0 and still writes the body. `--fail` is what turns the corrupt file into an error you can actually see.

On `--retry-all-errors`: a genuine 404 now takes ~30s to fail instead of failing immediately. That seemed like the right trade, since the download URL comes from release metadata fetched moments earlier, so an error on it is unexpected rather than a caller mistake. Happy to drop it if you'd rather fail fast.

Tagged this as `v4.0.1-curl-fail.1` on my fork if anyone needs it before this merges.
